### PR TITLE
chore: Allow for providing of default value

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,13 +1,21 @@
-name: 'OT-3 Emulator'
+name: 'Opentrons Emulation'
 description: 'Spin up emulator with specific version of firmware code'
 inputs:
   ot3-firmware-commit-id:
     description: 'Full commit id in ot3-firmware to pull.'
     required: false
-    default: ""
+    default: "latest"
+  modules-commit-id:
+    description: 'Full commit id in opentrons-modules to pull.'
+    required: false
+    default: "latest"
 runs:
   using: 'composite'
   steps:
-    - run: ./run_emulation.sh --headless --ot3-firmware-sha ${{ inputs.ot3-firmware-commit-id }}
+    - run: |
+      ./run_emulation.sh \
+        --headless \
+        --ot3-firmware-sha ${{ inputs.ot3-firmware-commit-id }} \
+        --modules-sha ${{ inputs.modules-commit-id }}
       shell: bash
       working-directory: ${{ github.action_path }}/scripts

--- a/scripts/run_emulation.sh
+++ b/scripts/run_emulation.sh
@@ -136,8 +136,8 @@ _DEV=0
 _PROD=0
 _SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 _COMPOSE_FILE_NAME=
-_OT3_FIRMWARE=
-_MODULES=
+_OT3_FIRMWARE="https://github.com/Opentrons/ot3-firmware/archive/refs/heads/main.zip"
+_MODULES="https://github.com/Opentrons/opentrons-modules/archive/refs/heads/edge.zip"
 
 # __get_option_value()
 #
@@ -183,11 +183,17 @@ do
       _COMPOSE_FILE_NAME="docker-compose.yaml"
       ;;
     --ot3-firmware-sha)
-      _OT3_FIRMWARE="https://github.com/Opentrons/ot3-firmware/archive/$(__get_option_value "${__arg}" "${__val:-}").zip"
+      _FIRMWARE_TEMP_VAL=$(__get_option_value "${__arg}" "${__val:-}")
+      if [[ $_FIRMWARE_TEMP_VAL != "latest" ]]; then
+        _OT3_FIRMWARE="https://github.com/Opentrons/ot3-firmware/archive/${_FIRMWARE_TEMP_VAL}.zip"
+      fi
       shift
       ;;
     --modules-sha)
-      _MODULES="https://github.com/Opentrons/opentrons-modules/archive/$(__get_option_value "${__arg}" "${__val:-}").zip"
+      _MODULES_TEMP_VAL=$(__get_option_value "${__arg}" "${__val:-}")
+      if [[ $_MODULES_TEMP_VAL != "latest" ]]; then
+        _MODULES="https://github.com/Opentrons/opentrons-modules/archive/${_MODULES_TEMP_VAL}.zip"
+      fi
       shift
       ;;
     --endopts)


### PR DESCRIPTION
Changing name of `ot3-emulator` repo to `opentrons-emulation`. This PR will also allow providing of `latest` to the commit id to pull the latest commit from the main branch. Added this because we always have to specify the commit id option in Github Actions but sometimes we just want to specify latest