### PR TITLE
chore: Fix broken action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,6 +12,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - run: ./run_emulation.sh --headless --ot3-firmware-sha ${{ inputs.ot3-firmware-commit-id }} --modules-sha ${{ inputs.modules-commit-id }}
+    - run: ./run_emulation.sh --prod --headless --ot3-firmware-sha ${{ inputs.ot3-firmware-commit-id }} --modules-sha ${{ inputs.modules-commit-id }}
       shell: bash
       working-directory: ${{ github.action_path }}/scripts

--- a/scripts/run_emulation.sh
+++ b/scripts/run_emulation.sh
@@ -314,6 +314,8 @@ _main() {
     _print_help
   elif (( _PROD && _DEV )); then
     _exit_1 printf "Cannot specify --prod and --dev at the same time\\n"
+  elif [[ ${_PROD} == 0 && ${_DEV} == 0 ]]; then
+    _exit_1 printf "Must specify either --prod or --dev\\n"
   elif [[ ${_DEV} == 1 && ( -n "${_OT3_FIRMWARE}" || -n "${_MODULES}" ) ]]; then
     _exit_1 printf "Cannot specify --dev with either --ot3-firmware-sha or --modules-sha\\n"
   else

--- a/scripts/setup_can.sh
+++ b/scripts/setup_can.sh
@@ -14,7 +14,7 @@ fi
 sudo ip link add dev $NETWORK type vcan fd on
 if [ $? == 2 ]; then
   echo "CAN Virtual Network \"$NETWORK\" already exists"
-  exit 1
+  exit 0
 fi
 
 sudo ip link set up $NETWORK
@@ -23,5 +23,6 @@ if [ $? == 0 ]; then
   echo "CAN Virtual Network \"$NETWORK\" successfully created"
 else
   echo "Error creating CAN Virtual Network \"$NETWORK\""
+  exit 1
 fi
 

--- a/scripts/teardown_can.sh
+++ b/scripts/teardown_can.sh
@@ -13,7 +13,7 @@ fi
 sudo ip link delete $NETWORK 2> /dev/null
 if [ $? == 1 ]; then
   echo "CAN Virtual Network \"$NETWORK\" does not exist"
-  exit 1
+  exit 0
 fi
 
 echo "CAN Virtual Network \"$NETWORK\" successfully removed"


### PR DESCRIPTION
Specify --prod
Exit cleanly if CAN network does not exist when tearing down CAN network
Exit cleanly if CAN network exists when setting up CAN network
