### PR TITLE
fix: Fix bug where prod builds with commit shas were not working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,8 @@ ENV OPENTRONS_HARDWARE "heater-shaker"
 # PROD FIRMWARE TARGETS #
 #########################
 # Targets for all prod builds of emulators
-
 FROM ot3-firmware-echo-dev as ot3-firmware-echo
-ARG FIRMWARE_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/ot3-firmware/archive/refs/heads/main.zip"
+ARG FIRMWARE_SOURCE_DOWNLOAD_LOCATION
 ADD $FIRMWARE_SOURCE_DOWNLOAD_LOCATION /ot3-firmware.zip
 RUN (cd / &&  \
     unzip -q ot3-firmware.zip && \
@@ -63,8 +62,9 @@ COPY entrypoint.sh /entrypoint.sh
 RUN /entrypoint.sh build
 ENTRYPOINT ["/entrypoint.sh", "run"]
 
+
 FROM heater-shaker-dev as heater-shaker
-ARG MODULE_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons-modules/archive/refs/heads/edge.zip"
+ARG MODULE_SOURCE_DOWNLOAD_LOCATION
 ADD $MODULE_SOURCE_DOWNLOAD_LOCATION /opentrons-modules.zip
 RUN (cd / &&  \
     unzip -q opentrons-modules.zip && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ case $FULL_COMMAND in
     ;;
   build-ot3-firmware-echo)
     (
-      cd ot3-firmware && \
+      cd /ot3-firmware && \
       cmake --preset host-gcc10 && \
       cmake --build ./build-host --target can-simulator
     )

--- a/scripts/run_emulation.sh
+++ b/scripts/run_emulation.sh
@@ -140,8 +140,8 @@ _SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd 
 _COMPOSE_FILE_NAME=
 _DEFAULT_OT3_FIRMWARE_DOWNLOAD_LOCATION="https://github.com/Opentrons/ot3-firmware/archive/refs/heads/main.zip"
 _DEFAULT_MODULES_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons-modules/archive/refs/heads/edge.zip"
-_OT3_FIRMWARE=
-_MODULES=
+_OT3_FIRMWARE=${_DEFAULT_OT3_FIRMWARE_DOWNLOAD_LOCATION}
+_MODULES=${_DEFAULT_MODULES_DOWNLOAD_LOCATION}
 
 # __get_option_value()
 #
@@ -188,18 +188,14 @@ do
       ;;
     --ot3-firmware-sha)
       _FIRMWARE_TEMP_VAL=$(__get_option_value "${__arg}" "${__val:-}")
-      if [[ $_FIRMWARE_TEMP_VAL = "latest" ]]; then
-         _OT3_FIRMWARE=${_DEFAULT_OT3_FIRMWARE_DOWNLOAD_LOCATION}
-      else
+      if ! [[ ${_FIRMWARE_TEMP_VAL} = "latest" ]]; then
         _OT3_FIRMWARE="https://github.com/Opentrons/ot3-firmware/archive/${_FIRMWARE_TEMP_VAL}.zip"
       fi
       shift
       ;;
     --modules-sha)
       _MODULES_TEMP_VAL=$(__get_option_value "${__arg}" "${__val:-}")
-      if [[ $_MODULES_TEMP_VAL = "latest" ]]; then
-        _MODULES=${_DEFAULT_MODULES_DOWNLOAD_LOCATION}
-      else
+      if ! [[ $_MODULES_TEMP_VAL = "latest" ]]; then
         _MODULES="https://github.com/Opentrons/opentrons-modules/archive/${_MODULES_TEMP_VAL}.zip"
       fi
       shift
@@ -313,6 +309,7 @@ _bring_up_docker_containers() {
 _build_system() {
   _COMPOSE_FILE_PATH="${_SCRIPT_DIR}/../${_COMPOSE_FILE_NAME}"
   _construct_build_command
+  _build_docker_images
   _teardown_can_network
   _setup_can_network
   _remove_existing_docker_containers


### PR DESCRIPTION
# Overview

Fixed bug where when you specified `--ot3-firmware-sha` or `modules-sha` with a commit id it would ignore the commit id and just pull main.

# Changelog

- Remove default values for `FIRMWARE_SOURCE_DOWNLOAD_LOCATION` and `MODULE_SOURCE_DOWNLOAD_LOCATION` from Dockerfile
- Add default values in `run_emulation.sh`
- Make `run_emulation.sh` actually build images
- Make `cd` in subshell an absolute path

# Review requests

Cross your fingers for me that it works in CI

# Risk assessment

Low risk, it's already broken