### PR TITLE
feat: Add driver level emulator images

### DIFF
--- a/emulation_system/emulation_system/settings_models.py
+++ b/emulation_system/emulation_system/settings_models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, parse_obj_as
+from pydantic import BaseModel, Field, parse_obj_as, validator
 
 class ConfigurationFileNotFoundError(FileNotFoundError):
     pass

--- a/emulation_system/emulation_system/settings_models.py
+++ b/emulation_system/emulation_system/settings_models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, parse_obj_as, validator
+from pydantic import BaseModel, Field, parse_obj_as
 
 class ConfigurationFileNotFoundError(FileNotFoundError):
     pass

--- a/emulation_system/resources/docker/Dockerfile
+++ b/emulation_system/resources/docker/Dockerfile
@@ -242,6 +242,9 @@ ENV OPENTRONS_HARDWARE "thermocycler-driver"
 FROM python-base as emulator-proxy-dev
 ENV OPENTRONS_HARDWARE "emulator-proxy"
 
+FROM python-base as robot-server-dev
+ENV OPENTRONS_HARDWARE "robot-server"
+
 ##############################################################
 #                     PRODUCTION TARGETS                     #
 ##############################################################
@@ -299,6 +302,11 @@ ENTRYPOINT ["/entrypoint.sh", "run"]
 
 FROM driver-common as tempdeck-driver-prod
 ENV OPENTRONS_HARDWARE "tempdeck-driver"
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh", "run"]
+
+FROM driver-common as robot-server-prod
+ENV OPENTRONS_HARDWARE "robot-server"
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
 

--- a/emulation_system/resources/docker/Dockerfile
+++ b/emulation_system/resources/docker/Dockerfile
@@ -157,6 +157,20 @@ RUN (cd / &&  \
     mv opentrons-modules* opentrons-modules)
 COPY entrypoint.sh /entrypoint.sh
 
+####################
+# opentrons-source #
+####################
+
+FROM python-base as opentrons-source
+ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION
+ADD $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons.zip
+RUN (cd / &&  \
+    unzip -q opentrons.zip && \
+    rm -f opentrons.zip && \
+    mv opentrons* opentrons)
+COPY entrypoint.sh /entrypoint.sh
+
+
 #############################################################
 #                    EXECUTABLE BUILDERS                    #
 #############################################################
@@ -178,6 +192,26 @@ FROM opentrons-modules-source as thermocycler-builder
 ENV OPENTRONS_HARDWARE "thermocycler"
 RUN /entrypoint.sh build
 
+FROM opentrons-source as driver-builder
+RUN \
+	(cd /opentrons/shared-data/python && python3 setup.py bdist_wheel -d /dist/) && \
+    (cd /opentrons/api && python3 setup.py bdist_wheel -d /dist/) && \
+    (cd /opentrons/notify-server && python3 setup.py bdist_wheel -d /dist/) && \
+    (cd /opentrons/robot-server && python3 setup.py bdist_wheel -d /dist/)
+
+
+#################
+# Driver Common #
+#################
+
+# Added this driver-common image because all driver level emulator images are based off of
+# the same source code build, it's just a different command that is ran for each.
+
+FROM python-base as driver-common
+RUN mkdir /dist
+COPY --from=driver-builder /dist/* /dist/
+RUN pip install /dist/*
+
 #############################################################
 #                    DEVELOPMENT TARGETS                    #
 #############################################################
@@ -196,33 +230,75 @@ ENV OPENTRONS_HARDWARE "heater-shaker"
 FROM cpp-base as thermocycler-dev
 ENV OPENTRONS_HARDWARE "thermocycler"
 
+FROM python-base as tempdeck-driver-dev
+ENV OPENTRONS_HARDWARE "tempdeck-driver"
+
+FROM python-base as magdeck-driver-dev
+ENV OPENTRONS_HARDWARE "magdeck-driver"
+
+FROM python-base as thermocycler-driver-dev
+ENV OPENTRONS_HARDWARE "thermocycler-driver"
+
+FROM python-base as emulator-proxy-dev
+ENV OPENTRONS_HARDWARE "emulator-proxy"
+
 ##############################################################
 #                     PRODUCTION TARGETS                     #
 ##############################################################
 
 # Targets for all production builds of emulators
-# Each Production Target should have a corresponding Executable Builder target
-# Each Production Target should copy the executable from the Executable Builder target
-# Each Production Target should copy in entrypoint.sh
 # Make sure to include the OPENTRONS_HARDWARE env variable
+# Each Production Target should copy in entrypoint.sh
 
+#################################
+# Firmware Production Emulators #
+#################################
+
+# Each Firmware Production Target should copy the executable from the Executable Builder target
+# Each Firmware Production Target should have a corresponding Executable Builder target
 
 FROM ubuntu-base as ot3-firmware-echo-prod
 ENV OPENTRONS_HARDWARE "ot3-firmware-echo"
-COPY entrypoint.sh /entrypoint.sh
 COPY --from=ot3-echo-builder /ot3-firmware/build-host/can/simulator/can-simulator /ot3-firmware/build-host/can/simulator/can-simulator
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
 
 FROM ubuntu-base as heater-shaker-prod
 ENV OPENTRONS_HARDWARE "heater-shaker"
-COPY entrypoint.sh /entrypoint.sh
 COPY --from=heater-shaker-builder /opentrons-modules/build-stm32-host/stm32-modules/heater-shaker/simulator/heater-shaker-simulator /opentrons-modules/build-stm32-host/stm32-modules/heater-shaker/simulator/heater-shaker-simulator
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
-
 
 FROM ubuntu-base as thermocycler-prod
 ENV OPENTRONS_HARDWARE "thermocycler"
-COPY entrypoint.sh /entrypoint.sh
 COPY --from=thermocycler-builder /opentrons-modules/build-stm32-host/stm32-modules/thermocycler-refresh/simulator/thermocycler-refresh-simulator /opentrons-modules/build-stm32-host/stm32-modules/thermocycler-refresh/simulator/thermocycler-refresh-simulator
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh", "run"]
+
+
+###############################
+# Driver Production Emulators #
+###############################
+
+# All driver level emulators should be based off of driver-common
+
+FROM driver-common as emulator-proxy
+ENV OPENTRONS_HARDWARE "emulator-proxy"
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh", "run"]
+
+FROM driver-common as thermocycler-driver-prod
+ENV OPENTRONS_HARDWARE "thermocycler-driver"
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh", "run"]
+
+FROM driver-common as magdeck-driver-prod
+ENV OPENTRONS_HARDWARE "magdeck-driver"
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh", "run"]
+
+FROM driver-common as tempdeck-driver-prod
+ENV OPENTRONS_HARDWARE "tempdeck-driver"
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
 

--- a/emulation_system/resources/docker/Dockerfile
+++ b/emulation_system/resources/docker/Dockerfile
@@ -282,7 +282,7 @@ ENTRYPOINT ["/entrypoint.sh", "run"]
 
 # All driver level emulators should be based off of driver-common
 
-FROM driver-common as emulator-proxy
+FROM driver-common as emulator-proxy-prod
 ENV OPENTRONS_HARDWARE "emulator-proxy"
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]

--- a/emulation_system/resources/docker/Dockerfile
+++ b/emulation_system/resources/docker/Dockerfile
@@ -50,32 +50,65 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN rm -rf /var/lib/apt/lists/*
 RUN echo "Updating apt" && apt-get update > /dev/null
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y wget unzip
+    && apt-get install \
+       --no-install-recommends \
+       -y \
+      wget \
+      unzip \
+      software-properties-common \
+      build-essential \
+      curl \
+      git \
+      libssl-dev \
+      && rm -rf /var/lib/apt/lists/*
 
-#############
+############
 # cpp-base #
-#############
+############
 
 FROM ubuntu-base as cpp-base
 
-RUN apt-get install \
+RUN apt-get update && \
+    apt-get install \
     --no-install-recommends \
     -y \
     libgtest-dev \
     libboost-test-dev \
-    build-essential \
     gcc-10 \
     g++-10 \
-    libssl-dev \
-    git \
-    lsb-release \
-    software-properties-common > /dev/null
+    lsb-release  > /dev/null
 
 RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-linux-x86_64.tar.gz && \
     tar -zxf cmake-3.21.2-linux-x86_64.tar.gz && \
     rm cmake-3.21.2-linux-x86_64.tar.gz && \
     mv cmake-3.21.2-linux-x86_64 cmake && \
     (cd /usr/bin/ && ln -s /cmake/bin/cmake cmake)
+
+###############
+# python-base #
+###############
+
+FROM ubuntu-base as python-base
+
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get update && \
+    apt-get install -y \
+    pipenv \
+    python3.7 \
+    libudev-dev \
+    libsystemd-dev \
+    python3-dev \
+    pkgconf \
+    libpython3.7-dev \
+    pip
+
+RUN (cd /usr/bin/ && ln -s /usr/bin/python3.7 python)
+
+ENV NODE_VERSION 14
+ENV OT_PYTHON "/usr/bin/python3.7"
+
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -
+RUN apt-get install -y nodejs && npm install --global yarn
 
 #############################################################
 #                        REPO SOURCE                        #

--- a/emulation_system/resources/docker/docker-compose-dev.yaml
+++ b/emulation_system/resources/docker/docker-compose-dev.yaml
@@ -1,25 +1,71 @@
 version: '3.8'
 services:
-  ot3-echo-dev:
-    image: ot3-echo-dev:latest
+  emulator-proxy-dev:
+    image: emulator-proxy-dev:latest
     build:
       context: .
-      target: ot3-firmware-echo-dev
-    container_name: ot3-echo-dev
-    network_mode: host
-    tty: true
+      target: emulator-proxy-dev
+    container_name: emulator-proxy-dev
+    ports:
+      - '8000-8005:8000-8005'
+      - '9000-9005:9000-9005'
+    environment:
+      OT_EMULATOR_magdeck_proxy: '{"emulator_port": 8000, "driver_port": 9000}'
+      OT_EMULATOR_temperature_proxy: '{"emulator_port": 8001, "driver_port": 9001}'
+      OT_EMULATOR_thermocycler_proxy: '{"emulator_port": 8002, "driver_port": 9002}'
     volumes:
-      - ${OT3_FIRMWARE_DIRECTORY}:/ot3-firmware
-      - ./entrypoint.sh:/entrypoint.sh
+      - "./entrypoint.sh:/entrypoint.sh"
+      - ${OPENTRONS_DIRECTORY}:/opentrons
 
-  heater-shaker-dev:
-    image: heater-shaker-dev:latest
+    tty: true
+
+  magdeck-driver-dev:
+    image: magdeck-driver-dev:latest
     build:
       context: .
-      target: heater-shaker-dev
-    container_name: heater-shaker-dev
-    network_mode: host
-    tty: true
+      target: magdeck-driver-dev
+    container_name: magdeck-driver-dev
+    environment:
+      OT_EMULATOR_magdeck_proxy: '{"emulator_port": 8000, "driver_port": 9000}'
+    links:
+      - 'emulator-proxy-dev'
+    depends_on:
+      - 'emulator-proxy-dev'
     volumes:
-      - ${OPENTRONS_MODULES_DIRECTORY}:/opentrons-modules
-      - ./entrypoint.sh:/entrypoint.sh
+      - "./entrypoint.sh:/entrypoint.sh"
+      - ${OPENTRONS_DIRECTORY}:/opentrons
+    tty: true
+
+  tempdeck-driver-dev:
+    image: tempdeck-driver-dev:latest
+    build:
+      context: .
+      target: tempdeck-driver-dev
+    container_name: tempdeck-driver-dev
+    environment:
+      OT_EMULATOR_temperature_proxy: '{"emulator_port": 8001, "driver_port": 9001}'
+    links:
+      - 'emulator-proxy-dev'
+    depends_on:
+      - 'emulator-proxy-dev'
+    volumes:
+      - "./entrypoint.sh:/entrypoint.sh"
+      - ${OPENTRONS_DIRECTORY}:/opentrons
+    tty: true
+
+  thermocycler-driver-dev:
+    image: thermocycler-driver-dev:latest
+    build:
+      context: .
+      target: thermocycler-driver-dev
+    container_name: thermocycler-driver-dev
+    environment:
+      OT_EMULATOR_thermocycler_proxy: '{"emulator_port": 8002, "driver_port": 9002}'
+    links:
+      - 'emulator-proxy-dev'
+    depends_on:
+      - 'emulator-proxy-dev'
+    volumes:
+      - "./entrypoint.sh:/entrypoint.sh"
+      - ${OPENTRONS_DIRECTORY}:/opentrons
+    tty: true

--- a/emulation_system/resources/docker/docker-compose.yaml
+++ b/emulation_system/resources/docker/docker-compose.yaml
@@ -1,10 +1,10 @@
 version: '3.8'
 services:
   emulator-proxy:
-    image: emulator-proxy:latest
+    image: emulator-proxy-prod:latest
     build:
       context: .
-      target: emulator-proxy
+      target: emulator-proxy-prod
     container_name: emulator-proxy-prod
     ports:
       - '10000-10005:10000-10005'

--- a/emulation_system/resources/docker/docker-compose.yaml
+++ b/emulation_system/resources/docker/docker-compose.yaml
@@ -1,20 +1,62 @@
 version: '3.8'
 services:
-  ot3-echo-prod:
-    image: ot3-echo-prod:latest
+  emulator-proxy:
+    image: emulator-proxy:latest
     build:
       context: .
-      target: ot3-firmware-echo-prod
-    container_name: ot3-echo-prod
-    network_mode: host
+      target: emulator-proxy
+    container_name: emulator-proxy-prod
+    ports:
+      - '10000-10005:10000-10005'
+      - '11000-11005:11000-11005'
+    environment:
+      OT_EMULATOR_magdeck_proxy: '{"emulator_port": 10000, "driver_port": 11000}'
+      OT_EMULATOR_temperature_proxy: '{"emulator_port": 10001, "driver_port": 11001}'
+      OT_EMULATOR_thermocycler_proxy: '{"emulator_port": 10002, "driver_port": 11002}'
+
     tty: true
 
-  heater-shaker-prod:
-    image: heater-shaker-prod:latest
+  magdeck-driver-prod:
+    image: magdeck-driver-prod:latest
     build:
       context: .
-      target: heater-shaker-prod
-    container_name: heater-shaker-prod
-    network_mode: host
-    command: ["--socket", "http://${HEATER_SHAKER_SOCKET_HOST}:${HEATER_SHAKER_SOCKET_PORT}"]
+      target: magdeck-driver-prod
+    container_name: magdeck-driver-prod
+    environment:
+      OT_EMULATOR_magdeck_proxy: '{"emulator_port": 10000, "driver_port": 11000}'
+    command: ["emulator-proxy-prod"]
+    links:
+      - 'emulator-proxy'
+    depends_on:
+      - 'emulator-proxy'
+    tty: true
+
+  tempdeck-driver-prod:
+    image: tempdeck-driver-prod:latest
+    build:
+      context: .
+      target: tempdeck-driver-prod
+    container_name: tempdeck-driver-prod
+    environment:
+      OT_EMULATOR_temperature_proxy: '{"emulator_port": 10001, "driver_port": 11001}'
+    command: ["emulator-proxy-prod"]
+    links:
+      - 'emulator-proxy'
+    depends_on:
+      - 'emulator-proxy'
+    tty: true
+
+  thermocycler-driver-prod:
+    image: thermocycler-driver-prod:latest
+    build:
+      context: .
+      target: thermocycler-driver-prod
+    container_name: thermocycler-driver-prod
+    environment:
+      OT_EMULATOR_thermocycler_proxy: '{"emulator_port": 10002, "driver_port": 11002}'
+    command: ["emulator-proxy-prod"]
+    links:
+      - 'emulator-proxy'
+    depends_on:
+      - 'emulator-proxy'
     tty: true

--- a/emulation_system/resources/docker/docker-compose.yaml
+++ b/emulation_system/resources/docker/docker-compose.yaml
@@ -16,14 +16,31 @@ services:
 
     tty: true
 
-  magdeck-driver-prod:
+  magdeck-driver-1:
     image: magdeck-driver-prod:latest
     build:
       context: .
       target: magdeck-driver-prod
-    container_name: magdeck-driver-prod
+    container_name: magdeck-driver-1
     environment:
       OT_EMULATOR_magdeck_proxy: '{"emulator_port": 10000, "driver_port": 11000}'
+      OT_EMULATOR_magdeck: '{"serial_number": "magdeck-1", "model":"mag_deck_v20", "version":"2.0.0"}'
+    command: ["emulator-proxy-prod"]
+    links:
+      - 'emulator-proxy'
+    depends_on:
+      - 'emulator-proxy'
+    tty: true
+
+  magdeck-driver-2:
+    image: magdeck-driver-prod:latest
+    build:
+      context: .
+      target: magdeck-driver-prod
+    container_name: magdeck-driver-2
+    environment:
+      OT_EMULATOR_magdeck_proxy: '{"emulator_port": 10000, "driver_port": 11000}'
+      OT_EMULATOR_magdeck: '{"serial_number": "magdeck-2", "model":"mag_deck_v20", "version":"2.0.0"}'
     command: ["emulator-proxy-prod"]
     links:
       - 'emulator-proxy'

--- a/emulation_system/resources/docker/docker-compose.yaml
+++ b/emulation_system/resources/docker/docker-compose.yaml
@@ -1,20 +1,37 @@
 version: '3.8'
 services:
-  emulator-proxy:
+  emulator-proxy-prod:
     image: emulator-proxy-prod:latest
     build:
       context: .
       target: emulator-proxy-prod
     container_name: emulator-proxy-prod
     ports:
-      - '10000-10005:10000-10005'
-      - '11000-11005:11000-11005'
+      - '10000-10004:10000-10004'
+      - '11000-11004:11000-11004'
     environment:
-      OT_EMULATOR_magdeck_proxy: '{"emulator_port": 10000, "driver_port": 11000}'
-      OT_EMULATOR_temperature_proxy: '{"emulator_port": 10001, "driver_port": 11001}'
-      OT_EMULATOR_thermocycler_proxy: '{"emulator_port": 10002, "driver_port": 11002}'
-
+      OT_EMULATOR_smoothie: '{"port": 11000}'
+      OT_EMULATOR_magdeck_proxy: '{"emulator_port": 10001, "driver_port": 11001}'
+      OT_EMULATOR_temperature_proxy: '{"emulator_port": 10002, "driver_port": 11002}'
+      OT_EMULATOR_thermocycler_proxy: '{"emulator_port": 10003, "driver_port": 11003}'
+      OT_EMULATOR_heatershaker_proxy_proxy: '{"emulator_port": 10004, "driver_port": 11004}'
     tty: true
+
+  robot-server:
+    image: robot-server-prod:lastest
+    build:
+      context: .
+      target: robot-server-prod
+    container_name: robot-server-prod
+    ports:
+      - '31950:31950'
+    environment:
+      OT_SMOOTHIE_EMULATOR_URI: socket://emulator-proxy-prod:11000
+      OT_EMULATOR_module_server: '{"host": "emulator-proxy-prod"}'
+    links:
+      - 'emulator-proxy-prod'
+    depends_on:
+      - 'emulator-proxy-prod'
 
   magdeck-driver-1:
     image: magdeck-driver-prod:latest
@@ -23,13 +40,13 @@ services:
       target: magdeck-driver-prod
     container_name: magdeck-driver-1
     environment:
-      OT_EMULATOR_magdeck_proxy: '{"emulator_port": 10000, "driver_port": 11000}'
+      OT_EMULATOR_magdeck_proxy: '{"emulator_port": 10001, "driver_port": 11001}'
       OT_EMULATOR_magdeck: '{"serial_number": "magdeck-1", "model":"mag_deck_v20", "version":"2.0.0"}'
     command: ["emulator-proxy-prod"]
     links:
-      - 'emulator-proxy'
+      - 'emulator-proxy-prod'
     depends_on:
-      - 'emulator-proxy'
+      - 'emulator-proxy-prod'
     tty: true
 
   magdeck-driver-2:
@@ -39,13 +56,13 @@ services:
       target: magdeck-driver-prod
     container_name: magdeck-driver-2
     environment:
-      OT_EMULATOR_magdeck_proxy: '{"emulator_port": 10000, "driver_port": 11000}'
+      OT_EMULATOR_magdeck_proxy: '{"emulator_port": 10001, "driver_port": 11001}'
       OT_EMULATOR_magdeck: '{"serial_number": "magdeck-2", "model":"mag_deck_v20", "version":"2.0.0"}'
     command: ["emulator-proxy-prod"]
     links:
-      - 'emulator-proxy'
+      - 'emulator-proxy-prod'
     depends_on:
-      - 'emulator-proxy'
+      - 'emulator-proxy-prod'
     tty: true
 
   tempdeck-driver-prod:
@@ -55,12 +72,12 @@ services:
       target: tempdeck-driver-prod
     container_name: tempdeck-driver-prod
     environment:
-      OT_EMULATOR_temperature_proxy: '{"emulator_port": 10001, "driver_port": 11001}'
+      OT_EMULATOR_temperature_proxy: '{"emulator_port": 10002, "driver_port": 11002}'
     command: ["emulator-proxy-prod"]
     links:
-      - 'emulator-proxy'
+      - 'emulator-proxy-prod'
     depends_on:
-      - 'emulator-proxy'
+      - 'emulator-proxy-prod'
     tty: true
 
   thermocycler-driver-prod:
@@ -70,10 +87,25 @@ services:
       target: thermocycler-driver-prod
     container_name: thermocycler-driver-prod
     environment:
-      OT_EMULATOR_thermocycler_proxy: '{"emulator_port": 10002, "driver_port": 11002}'
+      OT_EMULATOR_thermocycler_proxy: '{"emulator_port": 10003, "driver_port": 11003}'
     command: ["emulator-proxy-prod"]
     links:
-      - 'emulator-proxy'
+      - 'emulator-proxy-prod'
     depends_on:
-      - 'emulator-proxy'
+      - 'emulator-proxy-prod'
     tty: true
+#
+#  heatershaker-prod:
+#    image: heatershaker-prod:latest
+#    build:
+#      context: .
+#      target: heatershaker-prod
+#    container_name: heatershaker-prod
+#    environment:
+#      OT_EMULATOR_heatershaker_proxy: '{"emulator_port": 10004, "driver_port": 11004}'
+#    command: ["emulator-proxy-prod"]
+#    links:
+#      - 'emulator-proxy-prod'
+#    depends_on:
+#      - 'emulator-proxy-prod'
+#    tty: true

--- a/emulation_system/resources/docker/entrypoint.sh
+++ b/emulation_system/resources/docker/entrypoint.sh
@@ -41,6 +41,24 @@ case $FULL_COMMAND in
   run-thermocycler)
     bash -c "/opentrons-modules/build-stm32-host/stm32-modules/thermocycler-refresh/simulator/thermocycler-refresh-simulator $OTHER_ARGS"
     ;;
+  build-driver)
+    (cd /opentrons/shared-data/python && python3 setup.py bdist_wheel -d /dist/)
+    (cd /opentrons/api && python3 setup.py bdist_wheel -d /dist/)
+    (cd /opentrons/notify-server && python3 setup.py bdist_wheel -d /dist/)
+    (cd /opentrons/robot-server && python3 setup.py bdist_wheel -d /dist/)
+    ;;
+  run-emulator-proxy)
+    python3 -m opentrons.hardware_control.emulation.app
+    ;;
+  run-thermocycler-driver)
+    bash -c "python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator thermocycler $OTHER_ARGS"
+    ;;
+  run-tempdeck-driver)
+    bash -c "python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator tempdeck $OTHER_ARGS"
+    ;;
+  run-magdeck-driver)
+    bash -c "python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator magdeck $OTHER_ARGS"
+    ;;
   build-ot3-firmware-echo)
     (
       cd /ot3-firmware && \

--- a/emulation_system/resources/docker/entrypoint.sh
+++ b/emulation_system/resources/docker/entrypoint.sh
@@ -41,12 +41,6 @@ case $FULL_COMMAND in
   run-thermocycler)
     bash -c "/opentrons-modules/build-stm32-host/stm32-modules/thermocycler-refresh/simulator/thermocycler-refresh-simulator $OTHER_ARGS"
     ;;
-  build-driver)
-    (cd /opentrons/shared-data/python && python3 setup.py bdist_wheel -d /dist/)
-    (cd /opentrons/api && python3 setup.py bdist_wheel -d /dist/)
-    (cd /opentrons/notify-server && python3 setup.py bdist_wheel -d /dist/)
-    (cd /opentrons/robot-server && python3 setup.py bdist_wheel -d /dist/)
-    ;;
   run-emulator-proxy)
     python3 -m opentrons.hardware_control.emulation.app
     ;;
@@ -58,6 +52,9 @@ case $FULL_COMMAND in
     ;;
   run-magdeck-driver)
     bash -c "python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator magdeck $OTHER_ARGS"
+    ;;
+  run-robot-server)
+    bash -c "uvicorn "robot_server:app" --host 0.0.0.0 --port 31950 --ws wsproto --reload"
     ;;
   build-ot3-firmware-echo)
     (

--- a/emulation_system/resources/vagrant/Vagrantfile
+++ b/emulation_system/resources/vagrant/Vagrantfile
@@ -10,6 +10,10 @@ Vagrant.configure("2") do |config|
   	config.vm.synced_folder conf['host_path'], conf['vm_path']
   end
 
+  settings['SHARED_FOLDERS'].each do |conf|
+  	config.vm.synced_folder conf['host_path'], conf['vm_path']
+  end
+
   config.vm.provider "virtualbox" do |vb|
     vb.gui = false
     vb.memory = settings['VM_MEMORY']


### PR DESCRIPTION
# Overview

Added the following stages: 
- python-base
- opentrons-source
- driver-builder
- driver-common

Added the following images
- emulator-proxy-prod
- emulator-proxy-dev
- thermocycler-driver-prod
- thermocycler-driver-dev
- magdeck-driver-prod
- magdeck-driver-dev
- tempdeck-driver-prod
- tempdeck-driver-dev

# Changelog

- Added python-base target. This is the base for all driver-level emulators and the emulator-proxy
  - Installs all python and node stuff required for building and running our projects
- Refactored cpp-base and ubuntu-base. Pulled any dependencies that are in both cpp-base and python-base and added them to ubuntu-base
- Added opentrons-source target. This pulls code from [opentrons repo](https://github.com/Opentrons/opentrons) 
- Added driver-builder target. This builds the code that we will use to run the driver level emulators and emulator proxy
- Add driver-common target. This pulls all build files from driver-builder target and installs them
- Added tempdeck-driver-dev, magdeck-driver-dev, thermocycler-driver-dev, and emulator-proxy-dev images. These require that you bind in entrypoint.sh, the opentrons repo, and build and run the code yourself
- Added emulator-proxy-prod, thermocycler-driver-prod, magdeck-driver-prod, and tempdeck-driver-prod. These images build and run the code for you
- Added build script for all driver level emulators to entrypoint.sh
- Added run script for tempdeck-driver, magdeck-driver, thermocycler-driver, and emulator-proxy to entrypoint.sh
- Built working dev and prod compose files for bringing up emulated driver level system

# Review requests

None

# Risk assessment

Low, just adding new features