### PR TITLE
feat: add python to cpp-base

### DIFF
--- a/emulation_system/resources/docker/Dockerfile
+++ b/emulation_system/resources/docker/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get update \
 ############
 
 FROM ubuntu-base as cpp-base
-
+RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get update && \
     apt-get install \
     --no-install-recommends \
@@ -76,7 +76,9 @@ RUN apt-get update && \
     libboost-test-dev \
     gcc-10 \
     g++-10 \
-    lsb-release  > /dev/null
+    lsb-release \
+    python3.7 \
+    > /dev/null
 
 RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-linux-x86_64.tar.gz && \
     tar -zxf cmake-3.21.2-linux-x86_64.tar.gz && \

--- a/emulation_system/resources/docker/Dockerfile
+++ b/emulation_system/resources/docker/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update && \
     lsb-release \
     python3.7 \
     > /dev/null
-
+RUN (cd /usr/bin/ && ln -s /usr/bin/python3.7 python)
 RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-linux-x86_64.tar.gz && \
     tar -zxf cmake-3.21.2-linux-x86_64.tar.gz && \
     rm cmake-3.21.2-linux-x86_64.tar.gz && \


### PR DESCRIPTION
This is required by new codegen in ot3-firmware. The firmware repo will
set up everything but the interpreter itself.
