### PR TITLE
fix: Fix poetry not installing correctly

### DIFF
--- a/emulation_system/resources/docker/Dockerfile
+++ b/emulation_system/resources/docker/Dockerfile
@@ -78,6 +78,7 @@ RUN apt-get update && \
     g++-10 \
     lsb-release \
     python3.7 \
+    python3.7-venv \
     > /dev/null
 RUN (cd /usr/bin/ && ln -s /usr/bin/python3.7 python)
 RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-linux-x86_64.tar.gz && \


### PR DESCRIPTION
# Overview

Fix error happening when trying to install poetry. [Error](https://github.com/Opentrons/ot3-firmware/runs/4410588901?check_suite_focus=true)

During investigation I tried running `/bin/sh -c "python install-poetry.py`. This the command `cmake` is running to install poetry, I received an error saying I needed to install python virtual environments. So I added the command to do that to the Dockerfile

# Changelog

- Add python3.7-venv to list of packages to install

# Review requests

None. This should work just fine. 
I tested manually by building firmware container with custom compose file and then running the build inside the container
But I will test further when I have the fixes in to allow ot3-firmware to build the emulator again

# Risk assessment

None, it's already broken in ot3-firmware.