### PR TITLE
refactor: Only support one robot

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
@@ -75,11 +75,14 @@ class SystemConfigurationModel(BaseModel):
     @property
     def containers(self) -> Mapping[str, Containers]:
         """Return all robots and modules in a single dictionary."""
+        # mypy type ignores are added in this method because mypy is not detecting that
+        # robot_exists and modules_exists is checking if self.robot or self.modules
+        # can be None. So it is throwing linting errors about them being None.
         new_dict: Dict[str, Containers] = {}
         if self.robot_exists:
-            new_dict[self.robot.id] = self.robot
+            new_dict[self.robot.id] = self.robot  # type: ignore[union-attr, assignment]
         if self.modules_exist:
-            for module in self.modules:
+            for module in self.modules:  # type: ignore[union-attr]
                 new_dict[module.id] = module
         return new_dict
 

--- a/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
@@ -50,14 +50,16 @@ class SystemConfigurationModel(BaseModel):
         name_list = []
 
         if (
-                # Shouldn't really hit this one, as you would be specifying a
-                # system with no modules or robots and that is kinda pointless.
-                # But it is still an edge case.
-                not robot_key_exists and not modules_key_exists
+            # Shouldn't really hit this one, as you would be specifying a
+            # system with no modules or robots and that is kinda pointless.
+            # But it is still an edge case.
+            not robot_key_exists
+            and not modules_key_exists
         ) or (
-                # Only going to have a single piece of hardware so of course there
-                # will not be any duplicates.
-                robot_key_exists and not modules_key_exists
+            # Only going to have a single piece of hardware so of course there
+            # will not be any duplicates.
+            robot_key_exists
+            and not modules_key_exists
         ):
             return values
 

--- a/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
@@ -47,7 +47,7 @@ class SystemConfigurationModel(BaseModel):
         robot_key_exists = "robot" in values and values["robot"] is not None
         modules_key_exists = "modules" in values and values["modules"] is not None
 
-        name_list = []
+        name_list: List[str] = []
 
         if (
             # Shouldn't really hit this one, as you would be specifying a
@@ -66,7 +66,7 @@ class SystemConfigurationModel(BaseModel):
         if modules_key_exists:
             # Don't want to use a set comprehension here because I want to maintain
             # duplicates.
-            name_list.extend([module["id"] for module in values["modules"]])
+            name_list.extend(module["id"] for module in values["modules"])
 
         if robot_key_exists:
             name_list.append(values["robot"]["id"])

--- a/emulation_system/tests/compose_file_creator/input/test_configuration_file.py
+++ b/emulation_system/tests/compose_file_creator/input/test_configuration_file.py
@@ -82,12 +82,6 @@ def create_system_configuration_from_file(path: str) -> SystemConfigurationModel
     return SystemConfigurationModel.from_file(path)
 
 
-def test_new_config_format() -> None:
-    """Test converting new format."""
-    path = os.path.join(get_test_resources_dir(), "sample.json")
-    print(SystemConfigurationModel.from_file(path))
-
-
 def test_duplicate_names() -> None:
     """Confirm that ValidationError is thrown when a robot and module have the same name."""  # noqa: E501
     with pytest.raises(DuplicateHardwareNameError) as err:

--- a/emulation_system/tests/compose_file_creator/input/test_configuration_file.py
+++ b/emulation_system/tests/compose_file_creator/input/test_configuration_file.py
@@ -86,7 +86,7 @@ def create_system_configuration_from_file(path: str) -> SystemConfigurationModel
 
 
 @pytest.mark.parametrize(
-    'path', [MATCHING_MODULE_NAMES_PATH, MATCHING_ROBOT_AND_MODULE_NAMES_PATH]
+    "path", [MATCHING_MODULE_NAMES_PATH, MATCHING_ROBOT_AND_MODULE_NAMES_PATH]
 )
 def test_duplicate_names(path: str) -> None:
     """Confirm that ValidationError is thrown when a robot and module have the same name."""  # noqa: E501

--- a/emulation_system/tests/compose_file_creator/input/test_configuration_file.py
+++ b/emulation_system/tests/compose_file_creator/input/test_configuration_file.py
@@ -27,6 +27,9 @@ VALID_CONFIG_DIR_PATH = os.path.join(get_test_resources_dir(), "valid_configurat
 MATCHING_ROBOT_AND_MODULE_NAMES_PATH = os.path.join(
     INVALID_CONFIG_DIR_PATH, "matching_robot_and_module_names.json"
 )
+MATCHING_MODULE_NAMES_PATH = os.path.join(
+    INVALID_CONFIG_DIR_PATH, "matching_module_names.json"
+)
 INVALID_NAME_FORMAT_PATH = os.path.join(
     INVALID_CONFIG_DIR_PATH, "invalid_name_format.json"
 )
@@ -82,10 +85,13 @@ def create_system_configuration_from_file(path: str) -> SystemConfigurationModel
     return SystemConfigurationModel.from_file(path)
 
 
-def test_duplicate_names() -> None:
+@pytest.mark.parametrize(
+    'path', [MATCHING_MODULE_NAMES_PATH, MATCHING_ROBOT_AND_MODULE_NAMES_PATH]
+)
+def test_duplicate_names(path: str) -> None:
     """Confirm that ValidationError is thrown when a robot and module have the same name."""  # noqa: E501
     with pytest.raises(DuplicateHardwareNameError) as err:
-        create_system_configuration_from_file(MATCHING_ROBOT_AND_MODULE_NAMES_PATH)
+        create_system_configuration_from_file(path)
     expected_error_text = (
         "The following container names are duplicated in the "
         "configuration file: common-name"

--- a/emulation_system/tests/compose_file_creator/input/test_configuration_file.py
+++ b/emulation_system/tests/compose_file_creator/input/test_configuration_file.py
@@ -3,158 +3,38 @@
 Note: Do not need to test matching module names because module names cannot be the same
 by definition of dict.
 """
-import json
+import os
 import pathlib
 from typing import Dict
 
 import pytest
 from pydantic import ValidationError
-from pytest_lazyfixture import lazy_fixture  # type: ignore
 
 from emulation_system.compose_file_creator.input.configuration_file import (
+    DuplicateHardwareNameError,
     SystemConfigurationModel,
 )
 from emulation_system.compose_file_creator.input.hardware_models import (
     HeaterShakerModuleInputModel,
     OT2InputModel,
 )
-from emulation_system.compose_file_creator.input.hardware_models.hardware_model import (
-    NoMountsDefinedError,
+from tests.conftest import get_test_resources_dir
+
+INVALID_CONFIG_DIR_PATH = os.path.join(
+    get_test_resources_dir(), "invalid_configurations"
 )
-from emulation_system.compose_file_creator.settings.config_file_settings import (
-    DirectoryMount,
-    FileMount,
+VALID_CONFIG_DIR_PATH = os.path.join(get_test_resources_dir(), "valid_configurations")
+MATCHING_ROBOT_AND_MODULE_NAMES_PATH = os.path.join(
+    INVALID_CONFIG_DIR_PATH, "matching_robot_and_module_names.json"
 )
-
-
-@pytest.fixture
-def matching_robot_and_module_names() -> Dict:
-    """Configuration file with matching robot and module name."""
-    return {
-        "robot": {
-            "common-name": {
-                "hardware": "ot2",
-                "emulation-level": "firmware",
-                "source-type": "remote",
-                "source-location": "latest",
-            }
-        },
-        "modules": {
-            "common-name": {
-                "hardware": "heater-shaker-module",
-                "emulation-level": "hardware",
-                "source-type": "remote",
-                "source-location": "latest",
-                "hardware-specific-attributes": {"mode": "stdin"},
-            }
-        },
-    }
-
-
-@pytest.fixture
-def invalid_name_format() -> Dict:
-    """Configuration file with matching robot and module name."""
-    return {
-        "modules": {
-            "invalid name with spaces": {
-                "hardware": "heater-shaker-module",
-                "emulation-level": "hardware",
-                "source-type": "remote",
-                "source-location": "latest",
-                "hardware-specific-attributes": {"mode": "stdin"},
-            }
-        }
-    }
-
-
-@pytest.fixture
-def multiple_robots() -> Dict:
-    """Configuration file with matching robot and module name."""
-    return {
-        "robot": {
-            "robot-1": {
-                "hardware": "ot2",
-                "emulation-level": "firmware",
-                "source-type": "remote",
-                "source-location": "latest",
-            },
-            "robot-2": {
-                "hardware": "ot2",
-                "emulation-level": "firmware",
-                "source-type": "remote",
-                "source-location": "latest",
-            },
-        }
-    }
-
-
-@pytest.fixture
-def modules_only() -> Dict:
-    """Configuration with only modules."""
-    return {
-        "modules": {
-            "my-heater-shaker": {
-                "hardware": "heater-shaker-module",
-                "emulation-level": "hardware",
-                "source-type": "remote",
-                "source-location": "latest",
-                "hardware-specific-attributes": {"mode": "stdin"},
-            },
-            "my-heater-shaker-2": {
-                "hardware": "heater-shaker-module",
-                "emulation-level": "hardware",
-                "source-type": "remote",
-                "source-location": "latest",
-                "hardware-specific-attributes": {"mode": "stdin"},
-            },
-        }
-    }
-
-
-@pytest.fixture
-def robot_only() -> Dict:
-    """Configuration with only modules."""
-    return {
-        "robot": {
-            "my-robot": {
-                "hardware": "ot2",
-                "emulation-level": "firmware",
-                "source-type": "remote",
-                "source-location": "latest",
-            }
-        }
-    }
-
-
-@pytest.fixture
-def robot_and_modules() -> Dict:
-    """Configuration with robot and modules."""
-    return {
-        "robot": {
-            "my-robot": {
-                "hardware": "ot2",
-                "emulation-level": "firmware",
-                "source-type": "remote",
-                "source-location": "latest",
-            }
-        },
-        "modules": {
-            "my-heater-shaker": {
-                "hardware": "heater-shaker-module",
-                "emulation-level": "hardware",
-                "source-type": "remote",
-                "source-location": "latest",
-                "hardware-specific-attributes": {"mode": "stdin"},
-            },
-            "my-heater-shaker-2": {
-                "hardware": "heater-shaker-module",
-                "emulation-level": "hardware",
-                "source-type": "remote",
-                "source-location": "latest",
-                "hardware-specific-attributes": {"mode": "stdin"},
-            },
-        },
-    }
+INVALID_NAME_FORMAT_PATH = os.path.join(
+    INVALID_CONFIG_DIR_PATH, "invalid_name_format.json"
+)
+MODULES_ONLY_PATH = os.path.join(VALID_CONFIG_DIR_PATH, "modules_only.json")
+ROBOT_ONLY_PATH = os.path.join(VALID_CONFIG_DIR_PATH, "robot_only.json")
+ROBOT_AND_MODULES_PATH = os.path.join(VALID_CONFIG_DIR_PATH, "robot_and_modules.json")
+EMPTY_ROBOT_KEY_PATH = os.path.join(VALID_CONFIG_DIR_PATH, "empty_robot_key.json")
+EMPTY_MODULES_KEY_PATH = os.path.join(VALID_CONFIG_DIR_PATH, "empty_modules_key.json")
 
 
 @pytest.fixture
@@ -192,27 +72,26 @@ def invalid_mount_name(extra_mounts: Dict) -> Dict:
     return extra_mounts
 
 
-@pytest.fixture
-def config_from_json(
-    tmp_path: pathlib.Path, robot_and_modules: Dict
-) -> SystemConfigurationModel:
-    """Create SystemConfigurationModel from a JSON file."""
-    p = tmp_path / "temp.json"
-    file = open(p, "w")
-    json.dump(robot_and_modules, file, indent=4)
-    file.close()
-    return SystemConfigurationModel.from_file(str(p))
-
-
 def create_system_configuration(obj: Dict) -> SystemConfigurationModel:
     """Creates SystemConfigurationModel object."""
     return SystemConfigurationModel.from_dict(obj)
 
 
-def test_invalid_name_format(matching_robot_and_module_names: Dict) -> None:
+def create_system_configuration_from_file(path: str) -> SystemConfigurationModel:
+    """Creates SystemConfigurationModel object from config file."""
+    return SystemConfigurationModel.from_file(path)
+
+
+def test_new_config_format() -> None:
+    """Test converting new format."""
+    path = os.path.join(get_test_resources_dir(), "sample.json")
+    print(SystemConfigurationModel.from_file(path))
+
+
+def test_duplicate_names() -> None:
     """Confirm that ValidationError is thrown when a robot and module have the same name."""  # noqa: E501
-    with pytest.raises(ValidationError) as err:
-        create_system_configuration(matching_robot_and_module_names)
+    with pytest.raises(DuplicateHardwareNameError) as err:
+        create_system_configuration_from_file(MATCHING_ROBOT_AND_MODULE_NAMES_PATH)
     expected_error_text = (
         "The following container names are duplicated in the "
         "configuration file: common-name"
@@ -220,59 +99,47 @@ def test_invalid_name_format(matching_robot_and_module_names: Dict) -> None:
     assert err.match(expected_error_text)
 
 
-def test_module_and_robot_name_the_same(invalid_name_format: Dict) -> None:
+def test_module_and_robot_name_the_same() -> None:
     """Confirm that ValidationError is thrown when a robot and module have the same name."""  # noqa: E501
     with pytest.raises(ValidationError) as err:
-        create_system_configuration(invalid_name_format)
-    expected_error_text = ".*invalid name with spaces.*"
-    assert err.match(expected_error_text)
-
-
-def test_multiple_robots(multiple_robots: Dict) -> None:
-    """Confirm that ValidationError is thrown when a robot and module have the same name."""  # noqa: E501
-    with pytest.raises(ValidationError) as err:
-        create_system_configuration(multiple_robots)
-    expected_error_text = "You can only define 1 robot"
+        create_system_configuration_from_file(INVALID_NAME_FORMAT_PATH)
+    expected_error_text = ".*string does not match regex.*"
     assert err.match(expected_error_text)
 
 
 @pytest.mark.parametrize(
-    "config_dict",
-    [
-        lazy_fixture("modules_only"),
-        lazy_fixture("robot_and_modules"),
-    ],
+    "path", [MODULES_ONLY_PATH, ROBOT_AND_MODULES_PATH, EMPTY_ROBOT_KEY_PATH]
 )
-def test_modules_exist_is_true(config_dict: Dict) -> None:
+def test_modules_exist_is_true(path: str) -> None:
     """Test that modules_exist property is true when it is supposed to be."""
-    assert create_system_configuration(config_dict).modules_exist
+    assert create_system_configuration_from_file(path).modules_exist
 
 
-def test_modules_exist_is_false(robot_only: Dict) -> None:
+@pytest.mark.parametrize("path", [ROBOT_ONLY_PATH, EMPTY_MODULES_KEY_PATH])
+def test_modules_exist_is_false(path: str) -> None:
     """Test that modules_exist property is false when it is supposed to be."""
-    assert not create_system_configuration(robot_only).modules_exist
+    assert not create_system_configuration_from_file(path).modules_exist
 
 
 @pytest.mark.parametrize(
-    "config_dict",
-    [
-        lazy_fixture("robot_only"),
-        lazy_fixture("robot_and_modules"),
-    ],
+    "path", [ROBOT_ONLY_PATH, ROBOT_AND_MODULES_PATH, EMPTY_MODULES_KEY_PATH]
 )
-def test_robot_exists_is_true(config_dict: Dict) -> None:
+def test_robot_exists_is_true(path: str) -> None:
     """Test that robot_exists property is true when it is supposed to be."""
-    assert create_system_configuration(config_dict).robot_exists
+    assert create_system_configuration_from_file(path).robot_exists
 
 
-def test_robot_exists_is_false(modules_only: Dict) -> None:
+@pytest.mark.parametrize("path", [MODULES_ONLY_PATH, EMPTY_ROBOT_KEY_PATH])
+def test_robot_exists_is_false(path: str) -> None:
     """Test that robot_exists property is false when it is supposed to be."""
-    assert not create_system_configuration(modules_only).robot_exists
+    assert not create_system_configuration_from_file(path).robot_exists
 
 
-def test_containers_property(robot_and_modules: Dict) -> None:
+def test_containers_property() -> None:
     """Test the containers property is constructed correctly."""
-    containers = create_system_configuration(robot_and_modules).containers
+    containers = create_system_configuration_from_file(
+        ROBOT_AND_MODULES_PATH
+    ).containers
     assert set(containers.keys()) == {
         "my-robot",
         "my-heater-shaker",
@@ -283,9 +150,9 @@ def test_containers_property(robot_and_modules: Dict) -> None:
     assert isinstance(containers["my-heater-shaker-2"], HeaterShakerModuleInputModel)
 
 
-def test_get_by_id(robot_and_modules: Dict) -> None:
+def test_get_by_id() -> None:
     """Test that loading containers by id works correctly."""
-    system_config = create_system_configuration(robot_and_modules)
+    system_config = create_system_configuration_from_file(ROBOT_AND_MODULES_PATH)
     assert isinstance(system_config.get_by_id("my-robot"), OT2InputModel)
     assert isinstance(
         system_config.get_by_id("my-heater-shaker"), HeaterShakerModuleInputModel
@@ -293,43 +160,3 @@ def test_get_by_id(robot_and_modules: Dict) -> None:
     assert isinstance(
         system_config.get_by_id("my-heater-shaker-2"), HeaterShakerModuleInputModel
     )
-
-
-def test_from_file(config_from_json: SystemConfigurationModel) -> None:
-    """Test that parsing a config from a JSON file works correctly."""
-    assert isinstance(config_from_json.get_by_id("my-robot"), OT2InputModel)
-    assert isinstance(
-        config_from_json.get_by_id("my-heater-shaker"), HeaterShakerModuleInputModel
-    )
-    assert isinstance(
-        config_from_json.get_by_id("my-heater-shaker-2"), HeaterShakerModuleInputModel
-    )
-
-
-def test_extra_mounts(extra_mounts: Dict) -> None:
-    """Test that extra mounts are created correctly."""
-    robot = create_system_configuration(extra_mounts).get_robot()
-    datadog_mount = robot.get_mount_by_name("DATADOG")
-    assert isinstance(datadog_mount, FileMount)
-    assert datadog_mount.name == "DATADOG"
-    assert datadog_mount.mount_path == "/datadog/log.txt"
-
-    log_mount = robot.get_mount_by_name("LOG_FILES")
-    assert isinstance(log_mount, DirectoryMount)
-    assert log_mount.name == "LOG_FILES"
-    assert log_mount.mount_path == "/var/log/opentrons/"
-
-
-def test_loading_mount_when_none_exist(robot_only: Dict) -> None:
-    """Test NoMountsDefinedError is thrown when you load a nonexistent mount."""
-    robot = create_system_configuration(robot_only).get_robot()
-    with pytest.raises(NoMountsDefinedError) as err:
-        robot.get_mount_by_name("ugh")
-    expected_error_text = "You have no mounts defined."
-    assert err.match(expected_error_text)
-
-
-def test_invalid_mount_name(invalid_mount_name: Dict) -> None:
-    """Test that ValidationError is thrown when you have an invalid mount name."""
-    with pytest.raises(ValidationError):
-        create_system_configuration(invalid_mount_name)

--- a/emulation_system/tests/conftest.py
+++ b/emulation_system/tests/conftest.py
@@ -18,6 +18,13 @@ def get_test_configuration_file_path() -> str:
     )
 
 
+def get_test_resources_dir() -> str:
+    """Get path to test_resources directory."""
+    return os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "test_resources"
+    )
+
+
 @pytest.fixture
 def json_for_testing_path() -> str:
     """Returns path to test file."""

--- a/emulation_system/tests/conftest.py
+++ b/emulation_system/tests/conftest.py
@@ -20,9 +20,7 @@ def get_test_configuration_file_path() -> str:
 
 def get_test_resources_dir() -> str:
     """Get path to test_resources directory."""
-    return os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "test_resources"
-    )
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_resources")
 
 
 @pytest.fixture

--- a/emulation_system/tests/test_resources/invalid_configurations/invalid_name_format.json
+++ b/emulation_system/tests/test_resources/invalid_configurations/invalid_name_format.json
@@ -1,0 +1,14 @@
+{
+    "modules": [
+        {
+            "id": "invalid name with spaces",
+            "hardware": "heater-shaker-module",
+            "emulation-level": "hardware",
+            "source-type": "remote",
+            "source-location": "latest",
+            "hardware-specific-attributes": {
+                "mode": "stdin"
+            }
+        }
+    ]
+}

--- a/emulation_system/tests/test_resources/invalid_configurations/matching_module_names.json
+++ b/emulation_system/tests/test_resources/invalid_configurations/matching_module_names.json
@@ -1,0 +1,31 @@
+{
+    "robot": {
+        "id": "robot-name",
+        "hardware": "ot2",
+        "emulation-level": "firmware",
+        "source-type": "remote",
+        "source-location": "latest"
+    },
+    "modules": [
+        {
+            "id": "common-name",
+            "hardware": "heater-shaker-module",
+            "emulation-level": "hardware",
+            "source-type": "remote",
+            "source-location": "latest",
+            "hardware-specific-attributes": {
+                "mode": "stdin"
+            }
+        },
+        {
+            "id": "common-name",
+            "hardware": "heater-shaker-module",
+            "emulation-level": "hardware",
+            "source-type": "remote",
+            "source-location": "latest",
+            "hardware-specific-attributes": {
+                "mode": "stdin"
+            }
+        }
+    ]
+}

--- a/emulation_system/tests/test_resources/invalid_configurations/matching_robot_and_module_names.json
+++ b/emulation_system/tests/test_resources/invalid_configurations/matching_robot_and_module_names.json
@@ -1,0 +1,21 @@
+{
+    "robot": {
+        "id": "common-name",
+        "hardware": "ot2",
+        "emulation-level": "firmware",
+        "source-type": "remote",
+        "source-location": "latest"
+    },
+    "modules": [
+        {
+            "id": "common-name",
+            "hardware": "heater-shaker-module",
+            "emulation-level": "hardware",
+            "source-type": "remote",
+            "source-location": "latest",
+            "hardware-specific-attributes": {
+                "mode": "stdin"
+            }
+        }
+    ]
+}

--- a/emulation_system/tests/test_resources/sample.json
+++ b/emulation_system/tests/test_resources/sample.json
@@ -1,0 +1,55 @@
+{
+    "robot": {
+        "id": "ot-2",
+        "hardware": "ot2",
+        "emulation-level": "firmware",
+        "source-type": "local",
+        "source-location": "/home/derek-maggio/Documents/repos/opentrons",
+        "hardware-specific-attributes": {},
+        "extra-mounts": []
+    },
+    "modules": [
+        {
+            "id": "heater-shaker-1",
+            "hardware": "heater-shaker-module",
+            "emulation-level": "hardware",
+            "source-type": "remote",
+            "source-location": "latest",
+            "hardware-specific-attributes": {
+                "mode": "stdin"
+            }
+        },
+        {
+            "id": "thermocycler-1",
+            "hardware": "thermocycler-module",
+            "emulation-level": "hardware",
+            "source-type": "remote",
+            "source-location": "latest",
+            "hardware-specific-attributes": {
+                "lid-temperature": {
+                    "degrees-per-tick": 3.0
+                }
+            }
+        },
+        {
+            "id": "temp-1",
+            "hardware": "temperature-module",
+            "emulation-level": "firmware",
+            "source-type": "local",
+            "source-location": "/home/derek-maggio/Documents/repos/opentrons",
+            "hardware-specific-attributes": {
+                "temperature": {
+                    "degrees-per-tick": 5.0
+                }
+            }
+        },
+        {
+            "id": "mag-1",
+            "hardware": "magnetic-module",
+            "emulation-level": "firmware",
+            "source-type": "local",
+            "source-location": "/home/derek-maggio/Documents/repos/opentrons",
+            "hardware-specific-attributes": {}
+        }
+    ]
+}

--- a/emulation_system/tests/test_resources/valid_configurations/empty_modules_key.json
+++ b/emulation_system/tests/test_resources/valid_configurations/empty_modules_key.json
@@ -1,0 +1,10 @@
+{
+    "robot": {
+        "id": "my-robot",
+        "hardware": "ot2",
+        "emulation-level": "firmware",
+        "source-type": "remote",
+        "source-location": "latest"
+    },
+    "modules": null
+}

--- a/emulation_system/tests/test_resources/valid_configurations/empty_robot_key.json
+++ b/emulation_system/tests/test_resources/valid_configurations/empty_robot_key.json
@@ -1,0 +1,25 @@
+{
+    "robot": null,
+    "modules": [
+        {
+            "id": "my-heater-shaker",
+            "hardware": "heater-shaker-module",
+            "emulation-level": "hardware",
+            "source-type": "remote",
+            "source-location": "latest",
+            "hardware-specific-attributes": {
+                "mode": "stdin"
+            }
+        },
+        {
+            "id": "my-heater-shaker-2",
+            "hardware": "heater-shaker-module",
+            "emulation-level": "hardware",
+            "source-type": "remote",
+            "source-location": "latest",
+            "hardware-specific-attributes": {
+                "mode": "stdin"
+            }
+        }
+    ]
+}

--- a/emulation_system/tests/test_resources/valid_configurations/modules_only.json
+++ b/emulation_system/tests/test_resources/valid_configurations/modules_only.json
@@ -1,0 +1,24 @@
+{
+    "modules": [
+        {
+            "id": "my-heater-shaker",
+            "hardware": "heater-shaker-module",
+            "emulation-level": "hardware",
+            "source-type": "remote",
+            "source-location": "latest",
+            "hardware-specific-attributes": {
+                "mode": "stdin"
+            }
+        },
+        {
+            "id": "my-heater-shaker-2",
+            "hardware": "heater-shaker-module",
+            "emulation-level": "hardware",
+            "source-type": "remote",
+            "source-location": "latest",
+            "hardware-specific-attributes": {
+                "mode": "stdin"
+            }
+        }
+    ]
+}

--- a/emulation_system/tests/test_resources/valid_configurations/robot_and_modules.json
+++ b/emulation_system/tests/test_resources/valid_configurations/robot_and_modules.json
@@ -1,0 +1,31 @@
+{
+    "robot": {
+        "id": "my-robot",
+        "hardware": "ot2",
+        "emulation-level": "firmware",
+        "source-type": "remote",
+        "source-location": "latest"
+    },
+    "modules": [
+        {
+            "id": "my-heater-shaker",
+            "hardware": "heater-shaker-module",
+            "emulation-level": "hardware",
+            "source-type": "remote",
+            "source-location": "latest",
+            "hardware-specific-attributes": {
+                "mode": "stdin"
+            }
+        },
+        {
+            "id": "my-heater-shaker-2",
+            "hardware": "heater-shaker-module",
+            "emulation-level": "hardware",
+            "source-type": "remote",
+            "source-location": "latest",
+            "hardware-specific-attributes": {
+                "mode": "stdin"
+            }
+        }
+    ]
+}

--- a/emulation_system/tests/test_resources/valid_configurations/robot_only.json
+++ b/emulation_system/tests/test_resources/valid_configurations/robot_only.json
@@ -1,0 +1,9 @@
+{
+    "robot": {
+        "id": "my-robot",
+        "hardware": "ot2",
+        "emulation-level": "firmware",
+        "source-type": "remote",
+        "source-location": "latest"
+    }
+}


### PR DESCRIPTION
# Overview

Change input file format to only support a single robot

# Changelog

Changed format of configuration file. 
- The `robot` entry is now a dictionary containing all the information about a single robot.
- The `modules` entry is now a list of `Modules` objects
- The `id` key will now how to specified for all hardware
- Modified `validate_names` `root_validator` to account for changes to format
- Added `DuplicateHardwareNameErro`r that is thrown instead of just a normal `ValidationError`
- Removed `there_can_only_be_one`, `add_robot_ids`, and `add_module_ids` validators as they are no longer necessary
- Modified `modules_exist`, `robot_exists`, and containers methods to account for change to format
- Removed `get_robot` method as it is now just a singular value

Tests
- Pulled verbose fixtures from test_configuration_file and made defined them as JSON files in emulation_system/tests/test_resources. This will more closely match the parsing done by the user
- Renamed `test_conversion_functions` to `test_hardware_model`
- Moved mount tests from `test_configuration_file` to `test_hardware_model`

# Review requests

None

# Risk assessment

Low