### PR TITLE
feat: Compose version (RET-394)

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
@@ -33,6 +33,9 @@ class SystemConfigurationModel(BaseModel):
     Represents an entire system to be brought up.
     """
 
+    compose_file_version: Optional[str] = Field(
+        defaut="3.8", alias="compose-file-version"
+    )
     robot: Optional[Robots]
     modules: Optional[List[Modules]] = Field(default=[])
 

--- a/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
@@ -14,6 +14,7 @@ from pydantic import (
     parse_file_as,
     parse_obj_as,
     root_validator,
+    validator,
 )
 
 from emulation_system.compose_file_creator.settings.custom_types import (
@@ -87,6 +88,11 @@ class SystemConfigurationModel(BaseModel):
             )
 
         return values
+
+    @validator("compose_file_version", pre=True, always=True)
+    def set_default_version(cls, v: str) -> str:
+        """Sets default version if nothing is specified."""
+        return v or "3.8"
 
     @property
     def modules_exist(self) -> bool:

--- a/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
@@ -34,9 +34,7 @@ class SystemConfigurationModel(BaseModel):
     Represents an entire system to be brought up.
     """
 
-    compose_file_version: Optional[str] = Field(
-        defaut="3.8", alias="compose-file-version"
-    )
+    compose_file_version: Optional[str] = Field(alias="compose-file-version")
     robot: Optional[Robots]
     modules: Optional[List[Modules]] = Field(default=[])
 

--- a/emulation_system/tests/compose_file_creator/input/test_configuration_file.py
+++ b/emulation_system/tests/compose_file_creator/input/test_configuration_file.py
@@ -38,6 +38,8 @@ ROBOT_ONLY_PATH = os.path.join(VALID_CONFIG_DIR_PATH, "robot_only.json")
 ROBOT_AND_MODULES_PATH = os.path.join(VALID_CONFIG_DIR_PATH, "robot_and_modules.json")
 EMPTY_ROBOT_KEY_PATH = os.path.join(VALID_CONFIG_DIR_PATH, "empty_robot_key.json")
 EMPTY_MODULES_KEY_PATH = os.path.join(VALID_CONFIG_DIR_PATH, "empty_modules_key.json")
+VERSION_DEF_PATH = os.path.join(VALID_CONFIG_DIR_PATH, "version_def.json")
+NULL_VERSION_PATH = os.path.join(VALID_CONFIG_DIR_PATH, "null_version.json")
 
 
 @pytest.fixture
@@ -160,3 +162,16 @@ def test_get_by_id() -> None:
     assert isinstance(
         system_config.get_by_id("my-heater-shaker-2"), HeaterShakerModuleInputModel
     )
+
+
+@pytest.mark.parametrize("path", [ROBOT_AND_MODULES_PATH, NULL_VERSION_PATH])
+def test_default_version(path: str) -> None:
+    """Test that version is set to default when not specified."""
+    system_config = create_system_configuration_from_file(path)
+    assert system_config.compose_file_version == "3.8"
+
+
+def test_overriding_version() -> None:
+    """Test that version is overridden correctly."""
+    system_config = create_system_configuration_from_file(VERSION_DEF_PATH)
+    assert system_config.compose_file_version == "3.7"

--- a/emulation_system/tests/test_resources/valid_configurations/null_version.json
+++ b/emulation_system/tests/test_resources/valid_configurations/null_version.json
@@ -1,0 +1,5 @@
+{
+    "compose-file-version": null,
+    "robot": null,
+    "modules": null
+}

--- a/emulation_system/tests/test_resources/valid_configurations/version_def.json
+++ b/emulation_system/tests/test_resources/valid_configurations/version_def.json
@@ -1,0 +1,5 @@
+{
+    "compose-file-version": "3.7",
+    "robot": null,
+    "modules": null
+}


### PR DESCRIPTION
# Overview

Added ability to specify compose file version in input file

# Changelog

- Added string `compose_file_version` parameter to SystemConfigurationModel
- Added validator to set version if nothing is specified
- Added tests

# Review requests

None

# Risk assessment

Low