### PR TITLE
feat: Add logic for loading files from multiple locations

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/conversion/conversion_functions.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/conversion_functions.py
@@ -31,7 +31,7 @@ from emulation_system.compose_file_creator.settings.config_file_settings import 
     DEFAULT_NETWORK_NAME,
 )
 from emulation_system.opentrons_emulation_configuration import (
-    load_opentrons_emulation_configuration,
+    OpentronsEmulationConfiguration,
 )
 
 
@@ -71,16 +71,17 @@ def _convert(config_model: SystemConfigurationModel) -> RuntimeComposeFileModel:
     )
 
 
-def convert_from_file(input_file_path: str) -> RuntimeComposeFileModel:
+def convert_from_file(
+    settings: OpentronsEmulationConfiguration, input_file_path: str
+) -> RuntimeComposeFileModel:
     """Parse from file.
 
     Will load either an absolute path, or a relative path against paths specified in
     emulation_configuration_file_locations setting.
     """
     if not os.path.isabs(input_file_path):
-        settings_file = load_opentrons_emulation_configuration()
         extra_locations = (
-            settings_file.global_settings.emulation_configuration_file_locations
+            settings.global_settings.emulation_configuration_file_locations
         )
         results = []
         for extra_location in extra_locations:
@@ -94,7 +95,6 @@ def convert_from_file(input_file_path: str) -> RuntimeComposeFileModel:
                 f" emulation_configuration_file_locations"
             )
         elif len(results) > 1:
-            print(extra_locations)
             paths = ", ".join(extra_locations)
             raise FileDisambiguationError(
                 f"Specified file found in multiple locations:" f" {paths}"
@@ -108,8 +108,3 @@ def convert_from_file(input_file_path: str) -> RuntimeComposeFileModel:
 def convert_from_obj(input_obj: Dict[str, Any]) -> RuntimeComposeFileModel:
     """Parse from obj."""
     return _convert(parse_obj_as(SystemConfigurationModel, input_obj))
-
-
-if __name__ == "__main__":
-    model = convert_from_file("/tests/test_resources/sample.json")
-    print(model.to_yaml())

--- a/emulation_system/emulation_system/opentrons_emulation_configuration.py
+++ b/emulation_system/emulation_system/opentrons_emulation_configuration.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 import json
+import os
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, parse_obj_as
+
+from emulation_system.consts import (
+    CONFIGURATION_FILE_LOCATION_VAR_NAME,
+    DEFAULT_CONFIGURATION_FILE_PATH,
+)
 
 
 class ConfigurationFileNotFoundError(FileNotFoundError):
@@ -102,3 +108,15 @@ class OpentronsEmulationConfiguration(BaseModel):
             )
 
         return parse_obj_as(cls, json.load(file))
+
+
+def load_opentrons_emulation_configuration(
+    file_path: str = None,
+) -> OpentronsEmulationConfiguration:
+    """Helper function for loading OpentronsEmulationConfiguration object."""
+    if file_path is None:
+        if CONFIGURATION_FILE_LOCATION_VAR_NAME in os.environ:
+            file_path = os.environ[CONFIGURATION_FILE_LOCATION_VAR_NAME]
+        else:
+            file_path = DEFAULT_CONFIGURATION_FILE_PATH
+    return OpentronsEmulationConfiguration.from_file_path(file_path)

--- a/emulation_system/emulation_system/opentrons_emulation_configuration.py
+++ b/emulation_system/emulation_system/opentrons_emulation_configuration.py
@@ -110,13 +110,10 @@ class OpentronsEmulationConfiguration(BaseModel):
         return parse_obj_as(cls, json.load(file))
 
 
-def load_opentrons_emulation_configuration(
-    file_path: str = None,
-) -> OpentronsEmulationConfiguration:
+def load_opentrons_emulation_configuration_from_env() -> OpentronsEmulationConfiguration:  # noqa: E501
     """Helper function for loading OpentronsEmulationConfiguration object."""
-    if file_path is None:
-        if CONFIGURATION_FILE_LOCATION_VAR_NAME in os.environ:
-            file_path = os.environ[CONFIGURATION_FILE_LOCATION_VAR_NAME]
-        else:
-            file_path = DEFAULT_CONFIGURATION_FILE_PATH
+    if CONFIGURATION_FILE_LOCATION_VAR_NAME in os.environ:
+        file_path = os.environ[CONFIGURATION_FILE_LOCATION_VAR_NAME]
+    else:
+        file_path = DEFAULT_CONFIGURATION_FILE_PATH
     return OpentronsEmulationConfiguration.from_file_path(file_path)

--- a/emulation_system/emulation_system/parsers/top_level_parser.py
+++ b/emulation_system/emulation_system/parsers/top_level_parser.py
@@ -1,6 +1,5 @@
 """Top-level parser for emulation cli."""
 import argparse
-import os
 import sys
 
 from emulation_system.commands.abstract_command_creator import (
@@ -10,12 +9,8 @@ from emulation_system.parser_utils import get_formatter
 from emulation_system.parsers.emulation_parser import EmulationParser
 from emulation_system.parsers.repo_parser import RepoParser
 from emulation_system.parsers.virtual_machine_parser import VirtualMachineParser
-from emulation_system.consts import (
-    CONFIGURATION_FILE_LOCATION_VAR_NAME,
-    DEFAULT_CONFIGURATION_FILE_PATH,
-)
 from emulation_system.opentrons_emulation_configuration import (
-    OpentronsEmulationConfiguration,
+    load_opentrons_emulation_configuration,
 )
 
 
@@ -35,7 +30,7 @@ class TopLevelParser:
         Pull settings from settings file
         Build parser
         """
-        self._settings = self._get_settings()
+        self._settings = load_opentrons_emulation_configuration()
         self._parser = argparse.ArgumentParser(
             description="Utility for managing Opentrons Emulation systems",
             formatter_class=get_formatter(),
@@ -54,16 +49,6 @@ class TopLevelParser:
 
         for subparser in self.SUBPARSERS:
             subparser.get_parser(subparsers, self._settings)  # type: ignore
-
-    @staticmethod
-    def _get_settings() -> OpentronsEmulationConfiguration:
-        """Load settings file."""
-        if CONFIGURATION_FILE_LOCATION_VAR_NAME in os.environ:
-            file_path = os.environ[CONFIGURATION_FILE_LOCATION_VAR_NAME]
-        else:
-            file_path = DEFAULT_CONFIGURATION_FILE_PATH
-
-        return OpentronsEmulationConfiguration.from_file_path(file_path)
 
     def parse(self, passed_args=[]) -> AbstractCommandCreator:  # noqa: ANN001
         """Parse args into CommandCreator."""

--- a/emulation_system/emulation_system/parsers/top_level_parser.py
+++ b/emulation_system/emulation_system/parsers/top_level_parser.py
@@ -10,7 +10,7 @@ from emulation_system.parsers.emulation_parser import EmulationParser
 from emulation_system.parsers.repo_parser import RepoParser
 from emulation_system.parsers.virtual_machine_parser import VirtualMachineParser
 from emulation_system.opentrons_emulation_configuration import (
-    load_opentrons_emulation_configuration,
+    OpentronsEmulationConfiguration,
 )
 
 
@@ -24,13 +24,13 @@ class TopLevelParser:
     # Parsers must inherit from emulation_system/src/parsers/abstract_parser.py
     SUBPARSERS = [EmulationParser, RepoParser, VirtualMachineParser]
 
-    def __init__(self) -> None:
+    def __init__(self, settings: OpentronsEmulationConfiguration) -> None:
         """Construct TopLevelParser object.
 
         Pull settings from settings file
         Build parser
         """
-        self._settings = load_opentrons_emulation_configuration()
+        self._settings = settings
         self._parser = argparse.ArgumentParser(
             description="Utility for managing Opentrons Emulation systems",
             formatter_class=get_formatter(),

--- a/emulation_system/main.py
+++ b/emulation_system/main.py
@@ -1,4 +1,6 @@
+from emulation_system.opentrons_emulation_configuration import load_opentrons_emulation_configuration_from_env
 from emulation_system.parsers.top_level_parser import TopLevelParser
 
 if __name__ == "__main__":
-    TopLevelParser().parse().get_commands().run_commands()
+    settings = load_opentrons_emulation_configuration_from_env()
+    TopLevelParser(settings).parse().get_commands().run_commands()

--- a/emulation_system/tests/command_creators/test_emulation.py
+++ b/emulation_system/tests/command_creators/test_emulation.py
@@ -1,8 +1,11 @@
 """Tests for emulation command."""
-from typing import List, Generator
+from typing import List
 
 import pytest
 
+from emulation_system.opentrons_emulation_configuration import (
+    OpentronsEmulationConfiguration,
+)
 from emulation_system.parsers.top_level_parser import TopLevelParser
 from tests.emulation_conftest import (
     BASIC_DEV_CMDS_TO_RUN,
@@ -53,32 +56,44 @@ def complex_prod_emulation_cmd() -> List[str]:
 
 
 def test_basic_dev_em_commands(
-    set_config_file_env_var: Generator, basic_emulation_dev_cmd: List[str]
+    testing_opentrons_emulation_configuration: OpentronsEmulationConfiguration,
+    basic_emulation_dev_cmd: List[str],
 ) -> None:
     """Confirm that basic dev emulation command is parsed correctly."""
-    dev_em_creator = TopLevelParser().parse(basic_emulation_dev_cmd)
+    dev_em_creator = TopLevelParser(testing_opentrons_emulation_configuration).parse(
+        basic_emulation_dev_cmd
+    )
     assert dev_em_creator.get_commands() == BASIC_DEV_CMDS_TO_RUN
 
 
 def test_complex_dev_em_commands(
-    set_config_file_env_var: Generator, complex_emulation_dev_cmd: List[str]
+    testing_opentrons_emulation_configuration: OpentronsEmulationConfiguration,
+    complex_emulation_dev_cmd: List[str],
 ) -> None:
     """Confirm that complex dev emulation command is parsed correctly."""
-    dev_em_creator = TopLevelParser().parse(complex_emulation_dev_cmd)
+    dev_em_creator = TopLevelParser(testing_opentrons_emulation_configuration).parse(
+        complex_emulation_dev_cmd
+    )
     assert dev_em_creator.get_commands() == COMPLEX_DEV_COMMANDS_TO_RUN
 
 
 def test_basic_prod_em_commands(
-    set_config_file_env_var: Generator, basic_prod_emulation_cmd: List[str]
+    testing_opentrons_emulation_configuration: OpentronsEmulationConfiguration,
+    basic_prod_emulation_cmd: List[str],
 ) -> None:
     """Confirm that basic prod emulation command is parsed correctly."""
-    prod_em_creator = TopLevelParser().parse(basic_prod_emulation_cmd)
+    prod_em_creator = TopLevelParser(testing_opentrons_emulation_configuration).parse(
+        basic_prod_emulation_cmd
+    )
     assert prod_em_creator.get_commands() == BASIC_PROD_COMMANDS_TO_RUN
 
 
 def test_complex_prod_em_commands(
-    set_config_file_env_var: Generator, complex_prod_emulation_cmd: List[str]
+    testing_opentrons_emulation_configuration: OpentronsEmulationConfiguration,
+    complex_prod_emulation_cmd: List[str],
 ) -> None:
     """Confirm that complex prod emulation command is parsed correctly."""
-    prod_em_creator = TopLevelParser().parse(complex_prod_emulation_cmd)
+    prod_em_creator = TopLevelParser(testing_opentrons_emulation_configuration).parse(
+        complex_prod_emulation_cmd
+    )
     assert prod_em_creator.get_commands() == COMPLEX_PROD_COMMANDS_TO_RUN

--- a/emulation_system/tests/command_creators/test_virtual_machine.py
+++ b/emulation_system/tests/command_creators/test_virtual_machine.py
@@ -1,10 +1,13 @@
 """Tests for virtual-machine sub-command."""
 import pytest
-from typing import List, Generator
+from typing import List
 from emulation_system.commands.virtual_machine_command_creator import (
     VirtualMachineCommandCreator,
 )
 from emulation_system.commands.command import CommandList, Command
+from emulation_system.opentrons_emulation_configuration import (
+    OpentronsEmulationConfiguration,
+)
 from emulation_system.parsers.top_level_parser import TopLevelParser
 
 EXPECTED_DEV_CREATE = CommandList(
@@ -102,48 +105,78 @@ def prod_shell_virtual_machine_cmd() -> List[str]:
 
 
 def test_dev_create(
-    set_config_file_env_var: Generator, dev_create_virtual_machine_cmd: List[str]
+    testing_opentrons_emulation_configuration: OpentronsEmulationConfiguration,
+    dev_create_virtual_machine_cmd: List[str],
 ) -> None:
     """Confirm that dev virtual-machine is created correctly."""
-    cmds = TopLevelParser().parse(dev_create_virtual_machine_cmd).get_commands()
+    cmds = (
+        TopLevelParser(testing_opentrons_emulation_configuration)
+        .parse(dev_create_virtual_machine_cmd)
+        .get_commands()
+    )
     assert cmds == EXPECTED_DEV_CREATE
 
 
 def test_dev_shell(
-    set_config_file_env_var: Generator, dev_shell_virtual_machine_cmd: List[str]
+    testing_opentrons_emulation_configuration: OpentronsEmulationConfiguration,
+    dev_shell_virtual_machine_cmd: List[str],
 ) -> None:
     """Confirm that shell to dev virtual-machine is opened correctly."""
-    cmds = TopLevelParser().parse(dev_shell_virtual_machine_cmd).get_commands()
+    cmds = (
+        TopLevelParser(testing_opentrons_emulation_configuration)
+        .parse(dev_shell_virtual_machine_cmd)
+        .get_commands()
+    )
     assert cmds == EXPECTED_DEV_SHELL
 
 
 def test_dev_remove(
-    set_config_file_env_var: Generator, dev_remove_virtual_machine_cmd: List[str]
+    testing_opentrons_emulation_configuration: OpentronsEmulationConfiguration,
+    dev_remove_virtual_machine_cmd: List[str],
 ) -> None:
     """Confirm that dev virtual-machine is removed correctly."""
-    cmds = TopLevelParser().parse(dev_remove_virtual_machine_cmd).get_commands()
+    cmds = (
+        TopLevelParser(testing_opentrons_emulation_configuration)
+        .parse(dev_remove_virtual_machine_cmd)
+        .get_commands()
+    )
     assert cmds == EXPECTED_DEV_REMOVE
 
 
 def test_prod_create(
-    set_config_file_env_var: Generator, prod_create_virtual_machine_cmd: List[str]
+    testing_opentrons_emulation_configuration: OpentronsEmulationConfiguration,
+    prod_create_virtual_machine_cmd: List[str],
 ) -> None:
     """Confirm that prod virtual-machine is created correctly."""
-    cmds = TopLevelParser().parse(prod_create_virtual_machine_cmd).get_commands()
+    cmds = (
+        TopLevelParser(testing_opentrons_emulation_configuration)
+        .parse(prod_create_virtual_machine_cmd)
+        .get_commands()
+    )
     assert cmds == EXPECTED_PROD_CREATE
 
 
 def test_prod_shell(
-    set_config_file_env_var: Generator, prod_shell_virtual_machine_cmd: List[str]
+    testing_opentrons_emulation_configuration: OpentronsEmulationConfiguration,
+    prod_shell_virtual_machine_cmd: List[str],
 ) -> None:
     """Confirm that shell to prod virtual-machine is opened correctly."""
-    cmds = TopLevelParser().parse(prod_shell_virtual_machine_cmd).get_commands()
+    cmds = (
+        TopLevelParser(testing_opentrons_emulation_configuration)
+        .parse(prod_shell_virtual_machine_cmd)
+        .get_commands()
+    )
     assert cmds == EXPECTED_PROD_SHELL
 
 
 def test_prod_remove(
-    set_config_file_env_var: Generator, prod_remove_virtual_machine_cmd: List[str]
+    testing_opentrons_emulation_configuration: OpentronsEmulationConfiguration,
+    prod_remove_virtual_machine_cmd: List[str],
 ) -> None:
     """Confirm that prod virtual-machine is removed correctly."""
-    cmds = TopLevelParser().parse(prod_remove_virtual_machine_cmd).get_commands()
+    cmds = (
+        TopLevelParser(testing_opentrons_emulation_configuration)
+        .parse(prod_remove_virtual_machine_cmd)
+        .get_commands()
+    )
     assert cmds == EXPECTED_PROD_REMOVE

--- a/emulation_system/tests/compose_file_creator/test_conversion_logic.py
+++ b/emulation_system/tests/compose_file_creator/test_conversion_logic.py
@@ -1,7 +1,9 @@
 """Tests for converting input file to DockerComposeFile."""
+import os
 from typing import (
     Any,
     Dict,
+    Generator,
     List,
     cast,
 )
@@ -10,7 +12,13 @@ import py
 import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 
+from emulation_system.opentrons_emulation_configuration import (
+    OpentronsEmulationConfiguration,
+    load_opentrons_emulation_configuration,
+)
 from emulation_system.compose_file_creator.conversion.conversion_functions import (
+    FileDisambiguationError,
+    convert_from_file,
     convert_from_obj,
 )
 from emulation_system.compose_file_creator.output.compose_file_model import (
@@ -32,15 +40,18 @@ from emulation_system.compose_file_creator.settings.images import (
     TemperatureModuleImages,
     ThermocyclerModuleImages,
 )
-from emulation_system.consts import DOCKERFILE_DIR_LOCATION
+from emulation_system.consts import (
+    CONFIGURATION_FILE_LOCATION_VAR_NAME,
+    DOCKERFILE_DIR_LOCATION,
+)
 from tests.compose_file_creator.conftest import (
     EMULATOR_PROXY_ID,
     HEATER_SHAKER_MODULE_ID,
     MAGNETIC_MODULE_ID,
     OT2_ID,
+    SYSTEM_UNIQUE_ID,
     TEMPERATURE_MODULE_ID,
     THERMOCYCLER_MODULE_ID,
-    SYSTEM_UNIQUE_ID,
 )
 
 CONTAINER_NAME_TO_IMAGE = {
@@ -60,6 +71,81 @@ SERVICE_NAMES = [
 ]
 
 EXTRA_MOUNT_PATH = "/var/log/log_files"
+EMULATION_CONFIGURATION_DIR_1 = "em-config-dir-1"
+EMULATION_CONFIGURATION_DIR_2 = "em-config-dir-2"
+EMULATION_CONFIGURATION_FILE_NAME = "test-config.json"
+TEMP_OPENTRONS_EMULATION_CONFIGURATION_FILE_NAME = "temp_test_configuration.json"
+
+
+@pytest.fixture
+def emulation_configuration_setup(
+    set_config_file_env_var: Generator, tmpdir: py.path.local
+) -> Generator[OpentronsEmulationConfiguration, None, None]:
+    """Creates temporary directories for loading configuration files from.
+
+    Stores these directories to OpentronsEmulationConfiguration.
+    """
+    root_dir = tmpdir.mkdir("emulation-configurations")
+    path_1 = root_dir.mkdir(EMULATION_CONFIGURATION_DIR_1)
+    path_2 = root_dir.mkdir(EMULATION_CONFIGURATION_DIR_2)
+    test_conf = load_opentrons_emulation_configuration()
+
+    test_conf.global_settings.emulation_configuration_file_locations.extend(
+        [str(path_1), str(path_2)]
+    )
+
+    # Going to create a new configuration file from test_conf since it has the 2 temp
+    # directories specified for emulation_configuration_file_locations
+    temp_path = os.path.join(
+        str(tmpdir), TEMP_OPENTRONS_EMULATION_CONFIGURATION_FILE_NAME
+    )
+    temp_config_file = open(temp_path, "w")
+    temp_config_file.write(test_conf.json(indent=4, by_alias=True))
+    temp_config_file.close()
+
+    # Changing the configuration file location env variable so that just for this test
+    # the system will be looking at the config file created above.
+    old_path = os.environ[CONFIGURATION_FILE_LOCATION_VAR_NAME]
+    os.environ[CONFIGURATION_FILE_LOCATION_VAR_NAME] = temp_path
+
+    yield test_conf
+
+    os.environ[CONFIGURATION_FILE_LOCATION_VAR_NAME] = old_path
+    test_conf.global_settings.emulation_configuration_file_locations = []
+
+
+@pytest.fixture
+def duplicate_emulation_files(
+    emulation_configuration_setup: OpentronsEmulationConfiguration,
+) -> OpentronsEmulationConfiguration:
+    """Create file with same name in the 2 emulation_configuration_file_locations directories."""  # noqa: E501
+    for (
+        file_loc
+    ) in (
+        emulation_configuration_setup.global_settings.emulation_configuration_file_locations  # noqa: E501
+    ):
+        file_path = os.path.join(file_loc, EMULATION_CONFIGURATION_FILE_NAME)
+        file = open(file_path, "w")
+        file.write("{}")
+        file.close()
+    return emulation_configuration_setup
+
+
+@pytest.fixture
+def valid_configuration_load(
+    emulation_configuration_setup: OpentronsEmulationConfiguration,
+) -> OpentronsEmulationConfiguration:
+    """Setup test to load a valid configuration."""
+    valid_dir = emulation_configuration_setup.global_settings.emulation_configuration_file_locations[  # noqa: E501
+        0
+    ]
+    file_path = os.path.join(valid_dir, EMULATION_CONFIGURATION_FILE_NAME)
+    file = open(file_path, "w")
+    # Technically an empty JSON is valid and we don't really care what is in the file
+    # for this test.
+    file.write("{}")
+    file.close()
+    return emulation_configuration_setup
 
 
 @pytest.fixture
@@ -383,6 +469,38 @@ def test_module_command(
 def test_robot_command(robot_with_mount_and_modules_services: Dict[str, Any]) -> None:
     """Confirm that modules depend on emulator proxy."""
     assert robot_with_mount_and_modules_services[OT2_ID].command is None
+
+
+def test_emulation_configuration_file_not_found(
+    emulation_configuration_setup: OpentronsEmulationConfiguration,
+) -> None:
+    """Test that correct error is thrown when configuration file cannot be found."""
+    with pytest.raises(FileNotFoundError) as err:
+        convert_from_file(EMULATION_CONFIGURATION_FILE_NAME)
+
+    err.match(
+        f"File {EMULATION_CONFIGURATION_FILE_NAME} not found in any specified "
+        f"emulation_configuration_file_locations"
+    )
+
+
+def test_duplicate_emulation_configuration_file(
+    duplicate_emulation_files: OpentronsEmulationConfiguration,
+) -> None:
+    """Test that correct error is thrown when configuration file cannot be found."""
+    with pytest.raises(FileDisambiguationError) as err:
+        convert_from_file(EMULATION_CONFIGURATION_FILE_NAME)
+    possible_locations = ", ".join(
+        duplicate_emulation_files.global_settings.emulation_configuration_file_locations
+    )
+    err.match(f"Specified file found in multiple locations:" f" {possible_locations}")
+
+
+def test_successful_conversion(
+    valid_configuration_load: OpentronsEmulationConfiguration,
+) -> None:
+    """Test convert_from_file loads a valid configuration correctly."""
+    convert_from_file(EMULATION_CONFIGURATION_FILE_NAME)
 
 
 # TODO: Add following tests:

--- a/emulation_system/tests/conftest.py
+++ b/emulation_system/tests/conftest.py
@@ -76,14 +76,6 @@ TEST_CONF_MODULES_EXPECTED_COMMIT = get_commit("modules")
 
 
 @pytest.fixture
-def default_folder_paths() -> DefaultFolderPaths:
-    """Returns default folder paths from test configuration file."""
-    return get_test_conf().global_settings.default_folder_paths
-
-
-@pytest.fixture
-def set_config_file_env_var(json_for_testing_path: str) -> Generator:
-    """Sets configuration file location env var then removes it after test."""
-    os.environ[CONFIGURATION_FILE_LOCATION_VAR_NAME] = json_for_testing_path
-    yield
-    del os.environ[CONFIGURATION_FILE_LOCATION_VAR_NAME]
+def testing_opentrons_emulation_configuration() -> OpentronsEmulationConfiguration:
+    """Get test configuration of OpentronsEmulationConfiguration."""
+    return get_test_conf()

--- a/emulation_system/tests/conftest.py
+++ b/emulation_system/tests/conftest.py
@@ -1,12 +1,10 @@
 """Utilities for emulation_system tests."""
 import os
-from typing import Generator
 
 import pytest
-from emulation_system.consts import CONFIGURATION_FILE_LOCATION_VAR_NAME
+
 from emulation_system.opentrons_emulation_configuration import (
     OpentronsEmulationConfiguration,
-    DefaultFolderPaths,
     SourceDownloadLocations,
 )
 
@@ -16,17 +14,6 @@ def get_test_configuration_file_path() -> str:
     return os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "test_configuration.json"
     )
-
-
-def get_test_resources_dir() -> str:
-    """Get path to test_resources directory."""
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_resources")
-
-
-@pytest.fixture
-def json_for_testing_path() -> str:
-    """Returns path to test file."""
-    return get_test_configuration_file_path()
 
 
 def get_test_conf() -> OpentronsEmulationConfiguration:


### PR DESCRIPTION
# Overview

Add logic for loading emulation configuration files from locations specified in emulation-configuration-file-locations

# Changelog

- Add `load_opentrons_emulation_configuration` to [opentrons_emulation_configuration.py](https://github.com/Opentrons/opentrons-emulation/pull/54/files#diff-18d96ae170acc31b8fe7ea29bcb16dec18438019e2887ebc683ab14d08da5461)
- Modify top_level_parser to use `load_opentrons_emulation_configuration`
- Add conversion logic in convert_from_file
- Add tests


# Review requests

Is there a better way to do this setup 
https://github.com/Opentrons/opentrons-emulation/pull/54/files#diff-749708e38c60613f39be1142cb867f721f9d31ad51840431e08edf52869f8ac7R80-R114

# Risk assessment

Low