### PR TITLE
feat: Robot exposed port (RET-428)

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_creator.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_creator.py
@@ -16,8 +16,12 @@ from emulation_system.compose_file_creator.input.configuration_file import (
 from emulation_system.compose_file_creator.input.hardware_models.modules.module_model import (  # noqa: E501
     ModuleInputModel,
 )
+from emulation_system.compose_file_creator.input.hardware_models.robots.robot_model import (  # noqa: E501
+    RobotModel,
+)
 from emulation_system.compose_file_creator.output.compose_file_model import (
     BuildItem,
+    Port,
     Service,
     Volume1,
 )
@@ -37,6 +41,43 @@ def _generate_container_name(
     )
 
 
+def _get_service_depends_on(
+    emulator_proxy_name: Optional[str], container: Containers
+) -> Optional[List[str]]:
+    """Get list of other services that service depends on.
+
+    If service is module, return [emulator_proxy_name]
+    """
+    return (
+        [emulator_proxy_name]
+        if emulator_proxy_name is not None
+        and issubclass(container.__class__, ModuleInputModel)
+        else None
+    )
+
+
+def _get_command(
+    emulator_proxy_name: Optional[str], container: Containers
+) -> Optional[str]:
+    """Get command for service to run.
+
+    If service is module, return emulator_proxy_name
+    """
+    depends_on = _get_service_depends_on(emulator_proxy_name, container)
+    return depends_on[0] if depends_on is not None else None
+
+
+def _get_port_bindings(
+    container: Containers,
+) -> Optional[List[Union[float, str, Port]]]:
+    port_string = (
+        [container.get_port_binding_string()]
+        if issubclass(container.__class__, RobotModel)
+        else None
+    )
+    return cast(Optional[List[Union[float, str, Port]]], port_string)
+
+
 def _configure_service(
     container: Containers,
     emulator_proxy_name: Optional[str],
@@ -49,18 +90,6 @@ def _configure_service(
         context=DOCKERFILE_DIR_LOCATION, target=container.get_image_name()
     )
     mount_strings = cast(List[Union[str, Volume1]], container.get_mount_strings())
-    service_depends_on = (
-        [emulator_proxy_name]
-        if emulator_proxy_name is not None
-        and issubclass(container.__class__, ModuleInputModel)
-        else None
-    )
-    service_command = (
-        emulator_proxy_name
-        if emulator_proxy_name is not None
-        and issubclass(container.__class__, ModuleInputModel)
-        else None
-    )
     service = Service(
         container_name=_generate_container_name(container.id, config_model),
         image=service_image,
@@ -68,8 +97,9 @@ def _configure_service(
         build=service_build,
         networks=required_networks.networks,
         volumes=mount_strings if len(mount_strings) > 0 else None,
-        depends_on=service_depends_on,
-        command=service_command,
+        depends_on=_get_service_depends_on(emulator_proxy_name, container),
+        ports=_get_port_bindings(container),
+        command=_get_command(emulator_proxy_name, container),
     )
     return service
 

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_creator.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_creator.py
@@ -17,7 +17,7 @@ from emulation_system.compose_file_creator.input.hardware_models.modules.module_
     ModuleInputModel,
 )
 from emulation_system.compose_file_creator.input.hardware_models.robots.robot_model import (  # noqa: E501
-    RobotModel,
+    RobotInputModel,
 )
 from emulation_system.compose_file_creator.output.compose_file_model import (
     BuildItem,
@@ -72,7 +72,7 @@ def _get_port_bindings(
 ) -> Optional[List[Union[float, str, Port]]]:
     port_string = (
         [container.get_port_binding_string()]
-        if issubclass(container.__class__, RobotModel)
+        if issubclass(container.__class__, RobotInputModel)
         else None
     )
     return cast(Optional[List[Union[float, str, Port]]], port_string)

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot2_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot2_model.py
@@ -6,7 +6,7 @@ from emulation_system.compose_file_creator.input.hardware_models.hardware_specif
     HardwareSpecificAttributes,
 )
 from emulation_system.compose_file_creator.input.hardware_models.robots.robot_model import (  # noqa: E501
-    RobotModel,
+    RobotInputModel,
 )
 from emulation_system.compose_file_creator.settings.config_file_settings import (
     EmulationLevels,
@@ -35,7 +35,7 @@ class OT2SourceRepositories(SourceRepositories):
     hardware_repo_name: Literal[None] = None
 
 
-class OT2InputModel(RobotModel):
+class OT2InputModel(RobotInputModel):
     """Model for OT2."""
 
     hardware: Literal[Hardware.OT2]

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot2_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot2_model.py
@@ -2,19 +2,18 @@
 from pydantic import Field
 from typing_extensions import Literal
 
+from emulation_system.compose_file_creator.input.hardware_models.hardware_specific_attributes import (  # noqa: E501
+    HardwareSpecificAttributes,
+)
+from emulation_system.compose_file_creator.input.hardware_models.robots.robot_model import (  # noqa: E501
+    RobotModel,
+)
 from emulation_system.compose_file_creator.settings.config_file_settings import (
     EmulationLevels,
     Hardware,
     OpentronsRepository,
     PipetteSettings,
     SourceRepositories,
-)
-
-from emulation_system.compose_file_creator.input.hardware_models.hardware_specific_attributes import (  # noqa: E501
-    HardwareSpecificAttributes,
-)
-from emulation_system.compose_file_creator.input.hardware_models.robots.robot_model import (  # noqa: E501
-    RobotModel,
 )
 
 
@@ -47,3 +46,4 @@ class OT2InputModel(RobotModel):
         alias="hardware-specific-attributes", default=OT2Attributes()
     )
     emulation_level: Literal[EmulationLevels.FIRMWARE] = Field(alias="emulation-level")
+    bound_port: int = Field(alias="bound-port", default=31950)

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/robot_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/robot_model.py
@@ -2,6 +2,8 @@
 
 Used to group all robots together and distinguish them from modules.
 """
+from pydantic import Field
+
 from emulation_system.compose_file_creator.input.hardware_models.hardware_model import (
     HardwareModel,
 )
@@ -13,4 +15,5 @@ class RobotModel(HardwareModel):
     Used to group all robots together and distinguish them from modules.
     """
 
-    pass
+    exposed_port: int = Field(..., alias="exposed-port")
+    bound_port: int

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/robot_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/robot_model.py
@@ -9,7 +9,7 @@ from emulation_system.compose_file_creator.input.hardware_models.hardware_model 
 )
 
 
-class RobotModel(HardwareModel):
+class RobotInputModel(HardwareModel):
     """Parent class of all Robots. Subclass of HardwareModel.
 
     Used to group all robots together and distinguish them from modules.

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/robot_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/robot_model.py
@@ -17,3 +17,7 @@ class RobotModel(HardwareModel):
 
     exposed_port: int = Field(..., alias="exposed-port")
     bound_port: int
+
+    def get_port_binding_string(self) -> str:
+        """Get port binding string for Docker Compose file."""
+        return f"{self.exposed_port}:{self.bound_port}"

--- a/emulation_system/tests/compose_file_creator/conftest.py
+++ b/emulation_system/tests/compose_file_creator/conftest.py
@@ -202,8 +202,16 @@ def ot2_default(opentrons_dir: str) -> Dict[str, Any]:
         "emulation-level": OT2_EMULATION_LEVEL,
         "source-type": OT2_SOURCE_TYPE,
         "source-location": opentrons_dir,
+        "exposed-port": 5000,
         "hardware-specific-attributes": {},
     }
+
+
+@pytest.fixture
+def ot2_with_overridden_bound_port(ot2_default: Dict[str, Any]) -> Dict[str, Any]:
+    """OT-2 with overridden bound-port."""
+    ot2_default["bound-port"] = 2500
+    return ot2_default
 
 
 @pytest.fixture

--- a/emulation_system/tests/compose_file_creator/input/hardware_models/robots/test_ot2.py
+++ b/emulation_system/tests/compose_file_creator/input/hardware_models/robots/test_ot2.py
@@ -29,6 +29,25 @@ def test_default_ot2(ot2_default: Dict[str, Any]) -> None:
     assert ot2.id == OT2_ID
     assert ot2.emulation_level == OT2_EMULATION_LEVEL
     assert ot2.source_type == OT2_SOURCE_TYPE
+    assert ot2.exposed_port == 5000
+    assert ot2.bound_port == 31950
+    assert ot2.hardware_specific_attributes.left_pipette.model == "p20_single_v2.0"
+    assert ot2.hardware_specific_attributes.left_pipette.id == "P20SV202020070101"
+    assert ot2.hardware_specific_attributes.right_pipette.model == "p20_single_v2.0"
+    assert ot2.hardware_specific_attributes.right_pipette.id == "P20SV202020070101"
+
+
+def test_ot2_with_overridden_bound_port(
+    ot2_with_overridden_bound_port: Dict[str, Any]
+) -> None:
+    """Confirm bound-port is overridden correctly."""
+    ot2 = parse_obj_as(OT2InputModel, ot2_with_overridden_bound_port)
+    assert ot2.hardware == Hardware.OT2.value
+    assert ot2.id == OT2_ID
+    assert ot2.emulation_level == OT2_EMULATION_LEVEL
+    assert ot2.source_type == OT2_SOURCE_TYPE
+    assert ot2.exposed_port == 5000
+    assert ot2.bound_port == 2500
     assert ot2.hardware_specific_attributes.left_pipette.model == "p20_single_v2.0"
     assert ot2.hardware_specific_attributes.left_pipette.id == "P20SV202020070101"
     assert ot2.hardware_specific_attributes.right_pipette.model == "p20_single_v2.0"
@@ -42,6 +61,8 @@ def test_ot2_with_custom_pipettes(ot2_with_pipettes: Dict[str, Any]) -> None:
     assert ot2.id == OT2_ID
     assert ot2.emulation_level == OT2_EMULATION_LEVEL
     assert ot2.source_type == OT2_SOURCE_TYPE
+    assert ot2.exposed_port == 5000
+    assert ot2.bound_port == 31950
     assert ot2.hardware_specific_attributes.left_pipette.model == "test_1"
     assert ot2.hardware_specific_attributes.left_pipette.id == "test_1_id"
     assert ot2.hardware_specific_attributes.right_pipette.model == "test_2"

--- a/emulation_system/tests/compose_file_creator/test_conversion_logic.py
+++ b/emulation_system/tests/compose_file_creator/test_conversion_logic.py
@@ -434,6 +434,11 @@ def test_robot_depends_on(
     assert robot_with_mount_and_modules_services[OT2_ID].depends_on is None
 
 
+def test_robot_port(robot_with_mount_and_modules_services: Dict[str, Any]) -> None:
+    """Confirm robot port string is created correctly."""
+    assert robot_with_mount_and_modules_services[OT2_ID].ports == ["5000:31950"]
+
+
 @pytest.mark.parametrize(
     "service_name",
     [


### PR DESCRIPTION
# Overview

Add logic for exposing robot port

# Changelog

- [robot_model.py](https://github.com/Opentrons/opentrons-emulation/pull/55/files#diff-435ac9a915b872f05ff4d9816cab0182f12aaa7396e247fa6d7a0245245c3a22)
  - Change `RobotModel` to `RobotInputModel` for consistency with other classes
  - Add `exposed_port` and `bound_port` properties to `RobotInputModel`
  - Add `get_port_binding_string` method
- [conftest.py](https://github.com/Opentrons/opentrons-emulation/pull/55/files#diff-01fc315b59882da252ab2cfe360f6ec8327ca1105b27688c32bc00982bec1fcf)
  - Add setup for setting `exposed_port` and overriding `bound_port`
- [ot2_model.py](https://github.com/Opentrons/opentrons-emulation/pull/55/files#diff-2a137b5dfd13bec19697db1ab918f1f0b587c5cecee313e889555e5c176d1960)
  - Define default for `bound_port` in `OT2InputModel`
- [test_ot2.py](https://github.com/Opentrons/opentrons-emulation/pull/55/files#diff-2bb16dd66f36b1e8ce0273d7d604a5de9dc7a2bbdcc275294cede9515574d5f3)
  - Add test for `exposed_port` property
  - Add test for overriding `bound_port` property
- [service_creator.py](https://github.com/Opentrons/opentrons-emulation/pull/55/files#diff-2c156182f7bf5f2c2c6e11912fa49a4d369e664279af1a5f56960da26e28048b)
  - Factor out logic inside of `_configure_service` to `_get_service_depends_on` and `_get_command`
  - Add `_get_port_bindings` function
- [test_conversion_logic.py](https://github.com/Opentrons/opentrons-emulation/pull/55/files#diff-749708e38c60613f39be1142cb867f721f9d31ad51840431e08edf52869f8ac7)
  - Add test for confirming port was converted correctly

# Review requests

None

# Risk assessment

Low