### PR TITLE
feat: Serial Number Environment Variable Creation (RET-427)

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_creator.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_creator.py
@@ -84,6 +84,8 @@ def _get_env_vars(
         temp_vars["OT_EMULATOR_module_server"] = f'{{"host": "{emulator_proxy_name}"}}'
     elif issubclass(container.__class__, OT3InputModel):
         temp_vars["OT_API_FF_enableOT3HardwareController"] = True
+    elif issubclass(container.__class__, ModuleInputModel):
+        temp_vars.update(container.get_serial_number_env_var())
     else:
         temp_vars = {}
 

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/heater_shaker_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/heater_shaker_module.py
@@ -1,20 +1,21 @@
 """Model and attributes for heater-shaker Module."""
+from typing import ClassVar
 
 from pydantic import Field
 from typing_extensions import Literal
 
+from emulation_system.compose_file_creator.input.hardware_models.hardware_specific_attributes import (  # noqa: E501
+    HardwareSpecificAttributes,
+)
+from emulation_system.compose_file_creator.input.hardware_models.modules.module_model import (  # noqa: E501
+    ModuleInputModel,
+)
 from emulation_system.compose_file_creator.settings.config_file_settings import (
     EmulationLevels,
     Hardware,
     HeaterShakerModes,
     OpentronsRepository,
     SourceRepositories,
-)
-from emulation_system.compose_file_creator.input.hardware_models.hardware_specific_attributes import (  # noqa: E501
-    HardwareSpecificAttributes,
-)
-from emulation_system.compose_file_creator.input.hardware_models.modules.module_model import (  # noqa: E501
-    ModuleInputModel,
 )
 
 
@@ -33,6 +34,9 @@ class HeaterShakerModuleSourceRepositories(SourceRepositories):
 
 class HeaterShakerModuleInputModel(ModuleInputModel):
     """Model for Heater Shaker Module."""
+
+    # Not defined because Heater Shaker does not have a firmware level implementation
+    firmware_serial_number_info: ClassVar[Literal[None]] = None
 
     hardware: Literal[Hardware.HEATER_SHAKER_MODULE]
     source_repos: HeaterShakerModuleSourceRepositories = Field(

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/magnetic_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/magnetic_module.py
@@ -1,18 +1,21 @@
 """Model and attributes for Magnetic Module."""
+from typing import ClassVar
+
 from pydantic import Field
 from typing_extensions import Literal
 
+from emulation_system.compose_file_creator.input.hardware_models.hardware_specific_attributes import (  # noqa: E501
+    HardwareSpecificAttributes,
+)
+from emulation_system.compose_file_creator.input.hardware_models.modules.module_model import (  # noqa: E501
+    FirmwareSerialNumberModel,
+    ModuleInputModel,
+)
 from emulation_system.compose_file_creator.settings.config_file_settings import (
     EmulationLevels,
     Hardware,
     OpentronsRepository,
     SourceRepositories,
-)
-from emulation_system.compose_file_creator.input.hardware_models.hardware_specific_attributes import (  # noqa: E501
-    HardwareSpecificAttributes,
-)
-from emulation_system.compose_file_creator.input.hardware_models.modules.module_model import (  # noqa: E501
-    ModuleInputModel,
 )
 
 
@@ -31,6 +34,12 @@ class MagneticModuleSourceRepositories(SourceRepositories):
 
 class MagneticModuleInputModel(ModuleInputModel):
     """Model for Magnetic Module."""
+
+    firmware_serial_number_info: ClassVar[
+        FirmwareSerialNumberModel
+    ] = FirmwareSerialNumberModel(
+        model="mag_deck_v20", version="2.0.0", env_var_name="OT_EMULATOR_magdeck"
+    )
 
     hardware: Literal[Hardware.MAGNETIC_MODULE]
     source_repos: MagneticModuleSourceRepositories = Field(

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
@@ -2,9 +2,33 @@
 
 Used to group all modules together and distinguish them from robots.
 """
+import json
+from typing import (
+    ClassVar,
+    Dict,
+    Optional,
+)
+
+from pydantic import (
+    BaseModel,
+    Field,
+)
+
 from emulation_system.compose_file_creator.input.hardware_models.hardware_model import (
     HardwareModel,
+    EmulationLevelNotSupportedError,
 )
+from emulation_system.compose_file_creator.settings.config_file_settings import (
+    EmulationLevels,
+)
+
+
+class FirmwareSerialNumberModel(BaseModel):
+    """Model for information needed to set a firmware emulator's serial number."""
+
+    model: str
+    version: str
+    env_var_name: str
 
 
 class ModuleInputModel(HardwareModel):
@@ -13,4 +37,32 @@ class ModuleInputModel(HardwareModel):
     Used to group all modules together and distinguish them from robots.
     """
 
-    ...
+    firmware_serial_number_info: ClassVar[Optional[FirmwareSerialNumberModel]] = Field(
+        alias="firmware-serial-number-info", allow_mutation=False
+    )
+
+    def _get_firmware_serial_number_env_var(self) -> Dict[str, str]:
+        """Builds firmware level serial number environment variable."""
+        if self.firmware_serial_number_info is None:
+            raise EmulationLevelNotSupportedError(
+                f'Emulation level, "{self.emulation_level}" not supported for '
+                f"{self.hardware}"
+            )
+        value = {
+            "serial_number": self.id,
+            "model": self.firmware_serial_number_info.model,
+            "version": self.firmware_serial_number_info.version,
+        }
+        return {self.firmware_serial_number_info.env_var_name: json.dumps(value)}
+
+    def _get_hardware_serial_number_env_var(self) -> Dict[str, str]:
+        """Builds hardware level serial number environment variable."""
+        return {"SERIAL_NUMBER": self.id}
+
+    def get_serial_number_env_var(self) -> Dict[str, str]:
+        """Builds serial number env var based off of emulation level."""
+        return (
+            self._get_firmware_serial_number_env_var()
+            if self.emulation_level == EmulationLevels.FIRMWARE
+            else self._get_hardware_serial_number_env_var()
+        )

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/temperature_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/temperature_module.py
@@ -1,19 +1,22 @@
 """Model and attributes for Temperature Module."""
+from typing import ClassVar
+
 from pydantic import Field
 from typing_extensions import Literal
 
+from emulation_system.compose_file_creator.input.hardware_models.hardware_specific_attributes import (  # noqa: E501
+    HardwareSpecificAttributes,
+)
+from emulation_system.compose_file_creator.input.hardware_models.modules.module_model import (  # noqa: E501
+    FirmwareSerialNumberModel,
+    ModuleInputModel,
+)
 from emulation_system.compose_file_creator.settings.config_file_settings import (
     EmulationLevels,
     Hardware,
     OpentronsRepository,
     SourceRepositories,
     TemperatureModelSettings,
-)
-from emulation_system.compose_file_creator.input.hardware_models.hardware_specific_attributes import (  # noqa: E501
-    HardwareSpecificAttributes,
-)
-from emulation_system.compose_file_creator.input.hardware_models.modules.module_model import (  # noqa: E501
-    ModuleInputModel,
 )
 
 
@@ -32,6 +35,12 @@ class TemperatureModuleSourceRepositories(SourceRepositories):
 
 class TemperatureModuleInputModel(ModuleInputModel):
     """Model for Temperature Module."""
+
+    firmware_serial_number_info: ClassVar[
+        FirmwareSerialNumberModel
+    ] = FirmwareSerialNumberModel(
+        model="temp_deck_v20", version="v2.0.1", env_var_name="OT_EMULATOR_tempdeck"
+    )
 
     hardware: Literal[Hardware.TEMPERATURE_MODULE]
     source_repos: TemperatureModuleSourceRepositories = Field(

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/thermocycler_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/thermocycler_module.py
@@ -1,20 +1,22 @@
 """Model and attributes for Thermocycler Module."""
+from typing import ClassVar
+
 from pydantic import Field
 from typing_extensions import Literal
 
+from emulation_system.compose_file_creator.input.hardware_models.hardware_specific_attributes import (  # noqa: E501
+    HardwareSpecificAttributes,
+)
+from emulation_system.compose_file_creator.input.hardware_models.modules.module_model import (  # noqa: E501
+    FirmwareSerialNumberModel,
+    ModuleInputModel,
+)
 from emulation_system.compose_file_creator.settings.config_file_settings import (
     EmulationLevels,
     Hardware,
     OpentronsRepository,
     SourceRepositories,
     TemperatureModelSettings,
-)
-
-from emulation_system.compose_file_creator.input.hardware_models.hardware_specific_attributes import (  # noqa: E501
-    HardwareSpecificAttributes,
-)
-from emulation_system.compose_file_creator.input.hardware_models.modules.module_model import (  # noqa: E501
-    ModuleInputModel,
 )
 
 
@@ -38,6 +40,12 @@ class ThermocyclerModuleSourceRepositories(SourceRepositories):
 
 class ThermocyclerModuleInputModel(ModuleInputModel):
     """Model for Thermocycler Module."""
+
+    firmware_serial_number_info: ClassVar[
+        FirmwareSerialNumberModel
+    ] = FirmwareSerialNumberModel(
+        model="v02", version="v1.1.0", env_var_name="OT_EMULATOR_thermocycler"
+    )
 
     hardware: Literal[Hardware.THERMOCYCLER_MODULE]
     source_repos: ThermocyclerModuleSourceRepositories = Field(


### PR DESCRIPTION
# Overview

Add functionality to populate environment variable for serial number.

# Changelog

- [module_model.py](https://github.com/Opentrons/opentrons-emulation/pull/58/files#diff-0f98439172f71cadc1b2b4af1a21b0637c96fcafab77045e9b4be78a121a7851)
  - Created FirmwareSerialNumberModel
  - Add logic for generating either firmware level or hardware level serial number env var
- ModuleInputModule classes
  - Define firmware_serial_number_info
  - Note for Heater Shaker that it is defaulted to `None` because there is no firmware level emulation implementation 
- Add test

# Review requests

Does the ClassVar stuff for firmware_serial_number_info need some comments to talk about what it is doing?

# Risk assessment

None