### PR TITLE
feat: Add Emulation Proxy Connection Environment Variables (RET-426)

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_creator.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_creator.py
@@ -16,9 +16,13 @@ from emulation_system.compose_file_creator.input.configuration_file import (
     SystemConfigurationModel,
 )
 from emulation_system.compose_file_creator.input.hardware_models import (
+    HeaterShakerModuleInputModel,
+    MagneticModuleInputModel,
     RobotInputModel,
     ModuleInputModel,
     OT3InputModel,
+    TemperatureModuleInputModel,
+    ThermocyclerModuleInputModel,
 )
 from emulation_system.compose_file_creator.output.compose_file_model import (
     BuildItem,
@@ -27,9 +31,18 @@ from emulation_system.compose_file_creator.output.compose_file_model import (
     Service,
     Volume1,
 )
-from emulation_system.compose_file_creator.settings.custom_types import Containers
+from emulation_system.compose_file_creator.settings.custom_types import (
+    Containers,
+)
 from emulation_system.compose_file_creator.settings.images import EmulatorProxyImages
 from emulation_system.consts import DOCKERFILE_DIR_LOCATION
+
+MODULE_TYPES = [
+    ThermocyclerModuleInputModel,
+    TemperatureModuleInputModel,
+    HeaterShakerModuleInputModel,
+    MagneticModuleInputModel,
+]
 
 
 def _generate_container_name(
@@ -132,6 +145,16 @@ def _configure_service(
     return service
 
 
+def _create_emulator_proxy_env_vars() -> ListOrDict:
+    return ListOrDict(
+        __root__={
+            env_var_name: env_var_value
+            for module in MODULE_TYPES
+            for env_var_name, env_var_value in module.get_proxy_info_env_var().items()  # type: ignore [attr-defined] # noqa: E501
+        }
+    )
+
+
 def create_services(
     config_model: SystemConfigurationModel, required_networks: RequiredNetworks
 ) -> DockerServices:
@@ -150,6 +173,7 @@ def create_services(
             build=BuildItem(context=DOCKERFILE_DIR_LOCATION, target=image),
             tty=True,
             networks=required_networks.networks,
+            environment=_create_emulator_proxy_env_vars(),
         )
 
     services.update(

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_creator.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_creator.py
@@ -75,8 +75,9 @@ def _get_env_vars(
 ) -> ListOrDict:
     temp_vars: Dict[str, Any] = {}
 
-    if emulator_proxy_name is not None and issubclass(
-        container.__class__, RobotInputModel
+    if (
+        issubclass(container.__class__, RobotInputModel)
+        and emulator_proxy_name is not None
     ):
         # TODO: If emulator proxy port is ever not hardcoded will have to update from
         #  11000 to a variable
@@ -86,6 +87,7 @@ def _get_env_vars(
         temp_vars["OT_API_FF_enableOT3HardwareController"] = True
     elif issubclass(container.__class__, ModuleInputModel):
         temp_vars.update(container.get_serial_number_env_var())
+        temp_vars.update(container.get_proxy_info_env_var())
     else:
         temp_vars = {}
 

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/heater_shaker_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/heater_shaker_module.py
@@ -41,7 +41,7 @@ class HeaterShakerModuleInputModel(ModuleInputModel):
     proxy_info: ClassVar[ProxyInfoModel] = ProxyInfoModel(
         env_var_name="OT_EMULATOR_heatershaker_proxy",
         emulator_port=10004,
-        driver_port=11004
+        driver_port=11004,
     )
 
     hardware: Literal[Hardware.HEATER_SHAKER_MODULE]

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/heater_shaker_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/heater_shaker_module.py
@@ -9,6 +9,7 @@ from emulation_system.compose_file_creator.input.hardware_models.hardware_specif
 )
 from emulation_system.compose_file_creator.input.hardware_models.modules.module_model import (  # noqa: E501
     ModuleInputModel,
+    ProxyInfoModel,
 )
 from emulation_system.compose_file_creator.settings.config_file_settings import (
     EmulationLevels,
@@ -37,6 +38,11 @@ class HeaterShakerModuleInputModel(ModuleInputModel):
 
     # Not defined because Heater Shaker does not have a firmware level implementation
     firmware_serial_number_info: ClassVar[Literal[None]] = None
+    proxy_info: ClassVar[ProxyInfoModel] = ProxyInfoModel(
+        env_var_name="OT_EMULATOR_heatershaker_proxy",
+        emulator_port=10004,
+        driver_port=11004
+    )
 
     hardware: Literal[Hardware.HEATER_SHAKER_MODULE]
     source_repos: HeaterShakerModuleSourceRepositories = Field(

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/magnetic_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/magnetic_module.py
@@ -10,6 +10,7 @@ from emulation_system.compose_file_creator.input.hardware_models.hardware_specif
 from emulation_system.compose_file_creator.input.hardware_models.modules.module_model import (  # noqa: E501
     FirmwareSerialNumberModel,
     ModuleInputModel,
+    ProxyInfoModel,
 )
 from emulation_system.compose_file_creator.settings.config_file_settings import (
     EmulationLevels,
@@ -39,6 +40,11 @@ class MagneticModuleInputModel(ModuleInputModel):
         FirmwareSerialNumberModel
     ] = FirmwareSerialNumberModel(
         model="mag_deck_v20", version="2.0.0", env_var_name="OT_EMULATOR_magdeck"
+    )
+    proxy_info: ClassVar[ProxyInfoModel] = ProxyInfoModel(
+        env_var_name="OT_EMULATOR_magnetic_proxy",
+        emulator_port=10002,
+        driver_port=11002
     )
 
     hardware: Literal[Hardware.MAGNETIC_MODULE]

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/magnetic_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/magnetic_module.py
@@ -44,7 +44,7 @@ class MagneticModuleInputModel(ModuleInputModel):
     proxy_info: ClassVar[ProxyInfoModel] = ProxyInfoModel(
         env_var_name="OT_EMULATOR_magnetic_proxy",
         emulator_port=10002,
-        driver_port=11002
+        driver_port=11002,
     )
 
     hardware: Literal[Hardware.MAGNETIC_MODULE]

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
@@ -33,6 +33,7 @@ class FirmwareSerialNumberModel(BaseModel):
 
 class ProxyInfoModel(BaseModel):
     """Model to provide information needed to connect module to proxy."""
+
     env_var_name: str
     emulator_port: int
     driver_port: int
@@ -47,7 +48,7 @@ class ModuleInputModel(HardwareModel):
     firmware_serial_number_info: ClassVar[Optional[FirmwareSerialNumberModel]] = Field(
         alias="firmware-serial-number-info", allow_mutation=False
     )
-    proxy_info: ClassVar[Optional[ProxyInfoModel]] = Field(
+    proxy_info: ClassVar[ProxyInfoModel] = Field(
         alias="proxy-info", allow_mutation=False
     )
 
@@ -81,6 +82,6 @@ class ModuleInputModel(HardwareModel):
         """Builds proxy info env var."""
         value = {
             "emulator_port": self.proxy_info.emulator_port,
-            "driver_port": self.proxy_info.driver_port
+            "driver_port": self.proxy_info.driver_port,
         }
         return {self.proxy_info.env_var_name: json.dumps(value)}

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
@@ -78,10 +78,11 @@ class ModuleInputModel(HardwareModel):
             else self._get_hardware_serial_number_env_var()
         )
 
-    def get_proxy_info_env_var(self) -> Dict[str, str]:
+    @classmethod
+    def get_proxy_info_env_var(cls) -> Dict[str, str]:
         """Builds proxy info env var."""
         value = {
-            "emulator_port": self.proxy_info.emulator_port,
-            "driver_port": self.proxy_info.driver_port,
+            "emulator_port": cls.proxy_info.emulator_port,
+            "driver_port": cls.proxy_info.driver_port,
         }
-        return {self.proxy_info.env_var_name: json.dumps(value)}
+        return {cls.proxy_info.env_var_name: json.dumps(value)}

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
@@ -26,9 +26,16 @@ from emulation_system.compose_file_creator.settings.config_file_settings import 
 class FirmwareSerialNumberModel(BaseModel):
     """Model for information needed to set a firmware emulator's serial number."""
 
+    env_var_name: str
     model: str
     version: str
+
+
+class ProxyInfoModel(BaseModel):
+    """Model to provide information needed to connect module to proxy."""
     env_var_name: str
+    emulator_port: int
+    driver_port: int
 
 
 class ModuleInputModel(HardwareModel):
@@ -39,6 +46,9 @@ class ModuleInputModel(HardwareModel):
 
     firmware_serial_number_info: ClassVar[Optional[FirmwareSerialNumberModel]] = Field(
         alias="firmware-serial-number-info", allow_mutation=False
+    )
+    proxy_info: ClassVar[Optional[ProxyInfoModel]] = Field(
+        alias="proxy-info", allow_mutation=False
     )
 
     def _get_firmware_serial_number_env_var(self) -> Dict[str, str]:
@@ -66,3 +76,11 @@ class ModuleInputModel(HardwareModel):
             if self.emulation_level == EmulationLevels.FIRMWARE
             else self._get_hardware_serial_number_env_var()
         )
+
+    def get_proxy_info_env_var(self) -> Dict[str, str]:
+        """Builds proxy info env var."""
+        value = {
+            "emulator_port": self.proxy_info.emulator_port,
+            "driver_port": self.proxy_info.driver_port
+        }
+        return {self.proxy_info.env_var_name: json.dumps(value)}

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/temperature_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/temperature_module.py
@@ -45,7 +45,7 @@ class TemperatureModuleInputModel(ModuleInputModel):
     proxy_info: ClassVar[ProxyInfoModel] = ProxyInfoModel(
         env_var_name="OT_EMULATOR_temperature_proxy",
         emulator_port=10001,
-        driver_port=11001
+        driver_port=11001,
     )
 
     hardware: Literal[Hardware.TEMPERATURE_MODULE]

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/temperature_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/temperature_module.py
@@ -10,6 +10,7 @@ from emulation_system.compose_file_creator.input.hardware_models.hardware_specif
 from emulation_system.compose_file_creator.input.hardware_models.modules.module_model import (  # noqa: E501
     FirmwareSerialNumberModel,
     ModuleInputModel,
+    ProxyInfoModel,
 )
 from emulation_system.compose_file_creator.settings.config_file_settings import (
     EmulationLevels,
@@ -40,6 +41,11 @@ class TemperatureModuleInputModel(ModuleInputModel):
         FirmwareSerialNumberModel
     ] = FirmwareSerialNumberModel(
         model="temp_deck_v20", version="v2.0.1", env_var_name="OT_EMULATOR_tempdeck"
+    )
+    proxy_info: ClassVar[ProxyInfoModel] = ProxyInfoModel(
+        env_var_name="OT_EMULATOR_temperature_proxy",
+        emulator_port=10001,
+        driver_port=11001
     )
 
     hardware: Literal[Hardware.TEMPERATURE_MODULE]

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/thermocycler_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/thermocycler_module.py
@@ -10,6 +10,7 @@ from emulation_system.compose_file_creator.input.hardware_models.hardware_specif
 from emulation_system.compose_file_creator.input.hardware_models.modules.module_model import (  # noqa: E501
     FirmwareSerialNumberModel,
     ModuleInputModel,
+    ProxyInfoModel,
 )
 from emulation_system.compose_file_creator.settings.config_file_settings import (
     EmulationLevels,
@@ -45,6 +46,11 @@ class ThermocyclerModuleInputModel(ModuleInputModel):
         FirmwareSerialNumberModel
     ] = FirmwareSerialNumberModel(
         model="v02", version="v1.1.0", env_var_name="OT_EMULATOR_thermocycler"
+    )
+    proxy_info: ClassVar[ProxyInfoModel] = ProxyInfoModel(
+        env_var_name="OT_EMULATOR_thermocycler_proxy",
+        emulator_port=10003,
+        driver_port=11003
     )
 
     hardware: Literal[Hardware.THERMOCYCLER_MODULE]

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/thermocycler_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/thermocycler_module.py
@@ -50,7 +50,7 @@ class ThermocyclerModuleInputModel(ModuleInputModel):
     proxy_info: ClassVar[ProxyInfoModel] = ProxyInfoModel(
         env_var_name="OT_EMULATOR_thermocycler_proxy",
         emulator_port=10003,
-        driver_port=11003
+        driver_port=11003,
     )
 
     hardware: Literal[Hardware.THERMOCYCLER_MODULE]

--- a/emulation_system/tests/compose_file_creator/test_conversion_logic.py
+++ b/emulation_system/tests/compose_file_creator/test_conversion_logic.py
@@ -1,13 +1,7 @@
 """Tests for converting input file to DockerComposeFile."""
 import json
 import os
-from typing import (
-    Any,
-    Dict,
-    List,
-    cast,
-    Type
-)
+from typing import Any, Dict, List, cast, Type
 from unittest.mock import (
     MagicMock,
     patch,
@@ -494,7 +488,7 @@ def test_ot3_feature_flag_added(ot3_only: Dict[str, Any]) -> None:
 def test_firmware_serial_number_env_vars(
     service_name: str,
     input_class: Type[ModuleInputModel],
-    robot_with_mount_and_modules_services: Dict[str, Service]
+    robot_with_mount_and_modules_services: Dict[str, Service],
 ) -> None:
     """Confirm that serial number env vars are created correctly on firmware modules."""
     services = robot_with_mount_and_modules_services
@@ -502,10 +496,8 @@ def test_firmware_serial_number_env_vars(
 
     module_env = services[service_name].environment
     assert module_env is not None
-    assert (
-        input_class.firmware_serial_number_info.env_var_name
-        in module_env.__root__
-    )
+    assert input_class.firmware_serial_number_info is not None
+    assert input_class.firmware_serial_number_info.env_var_name in module_env.__root__
 
     module_root = cast(Dict[str, str], module_env.__root__)
     assert module_root[
@@ -527,8 +519,7 @@ def test_firmware_serial_number_env_vars(
     ],
 )
 def test_hardware_serial_number_env_vars(
-    service_name: str,
-    robot_with_mount_and_modules_services: Dict[str, Service]
+    service_name: str, robot_with_mount_and_modules_services: Dict[str, Service]
 ) -> None:
     """Confirm that serial number env vars are created correctly on hardware modules."""
     services = robot_with_mount_and_modules_services

--- a/emulation_system/tests/compose_file_creator/test_conversion_logic.py
+++ b/emulation_system/tests/compose_file_creator/test_conversion_logic.py
@@ -6,6 +6,7 @@ from typing import (
     Dict,
     List,
     cast,
+    Type
 )
 from unittest.mock import (
     MagicMock,
@@ -23,6 +24,7 @@ from emulation_system.compose_file_creator.conversion.conversion_functions impor
 )
 from emulation_system.compose_file_creator.input.hardware_models import (
     MagneticModuleInputModel,
+    ModuleInputModel,
     TemperatureModuleInputModel,
 )
 from emulation_system.compose_file_creator.output.compose_file_model import (
@@ -482,58 +484,62 @@ def test_ot3_feature_flag_added(ot3_only: Dict[str, Any]) -> None:
     assert root["OT_API_FF_enableOT3HardwareController"] == "True"
 
 
-def test_serial_number_env_vars(
+@pytest.mark.parametrize(
+    "service_name,input_class",
+    [
+        [TEMPERATURE_MODULE_ID, TemperatureModuleInputModel],
+        [MAGNETIC_MODULE_ID, MagneticModuleInputModel],
+    ],
+)
+def test_firmware_serial_number_env_vars(
+    service_name: str,
+    input_class: Type[ModuleInputModel],
     robot_with_mount_and_modules_services: Dict[str, Service]
 ) -> None:
-    """Confirm that serial number env vars are created correctly on modules."""
+    """Confirm that serial number env vars are created correctly on firmware modules."""
     services = robot_with_mount_and_modules_services
     assert services is not None
 
-    heater_shaker_env = services[HEATER_SHAKER_MODULE_ID].environment
-    assert heater_shaker_env is not None
-    assert "SERIAL_NUMBER" in heater_shaker_env.__root__
-    heater_shaker_root = cast(Dict[str, str], heater_shaker_env.__root__)
-    assert heater_shaker_root["SERIAL_NUMBER"] == HEATER_SHAKER_MODULE_ID
-
-    magdeck_env = services[MAGNETIC_MODULE_ID].environment
-    assert magdeck_env is not None
+    module_env = services[service_name].environment
+    assert module_env is not None
     assert (
-        MagneticModuleInputModel.firmware_serial_number_info.env_var_name
-        in magdeck_env.__root__
+        input_class.firmware_serial_number_info.env_var_name
+        in module_env.__root__
     )
-    magdeck_root = cast(Dict[str, str], magdeck_env.__root__)
-    assert magdeck_root[
-        MagneticModuleInputModel.firmware_serial_number_info.env_var_name
+
+    module_root = cast(Dict[str, str], module_env.__root__)
+    assert module_root[
+        input_class.firmware_serial_number_info.env_var_name
     ] == json.dumps(
         {
-            "serial_number": MAGNETIC_MODULE_ID,
-            "model": MagneticModuleInputModel.firmware_serial_number_info.model,
-            "version": MagneticModuleInputModel.firmware_serial_number_info.version,
+            "serial_number": service_name,
+            "model": input_class.firmware_serial_number_info.model,
+            "version": input_class.firmware_serial_number_info.version,
         }
     )
 
-    tempdeck_env = services[TEMPERATURE_MODULE_ID].environment
-    assert tempdeck_env is not None
-    assert (
-        TemperatureModuleInputModel.firmware_serial_number_info.env_var_name
-        in tempdeck_env.__root__
-    )
-    tempdeck_root = cast(Dict[str, str], tempdeck_env.__root__)
-    assert tempdeck_root[
-        TemperatureModuleInputModel.firmware_serial_number_info.env_var_name
-    ] == json.dumps(
-        {
-            "serial_number": TEMPERATURE_MODULE_ID,
-            "model": TemperatureModuleInputModel.firmware_serial_number_info.model,
-            "version": TemperatureModuleInputModel.firmware_serial_number_info.version,
-        }
-    )
 
-    thermocycler_env = services[THERMOCYCLER_MODULE_ID].environment
-    assert thermocycler_env is not None
-    assert "SERIAL_NUMBER" in thermocycler_env.__root__
-    thermocycler_root = cast(Dict[str, str], thermocycler_env.__root__)
-    assert thermocycler_root["SERIAL_NUMBER"] == THERMOCYCLER_MODULE_ID
+@pytest.mark.parametrize(
+    "service_name",
+    [
+        THERMOCYCLER_MODULE_ID,
+        HEATER_SHAKER_MODULE_ID,
+    ],
+)
+def test_hardware_serial_number_env_vars(
+    service_name: str,
+    robot_with_mount_and_modules_services: Dict[str, Service]
+) -> None:
+    """Confirm that serial number env vars are created correctly on hardware modules."""
+    services = robot_with_mount_and_modules_services
+    assert services is not None
+
+    module_env = services[service_name].environment
+    assert module_env is not None
+    assert "SERIAL_NUMBER" in module_env.__root__
+
+    module_root = cast(Dict[str, str], module_env.__root__)
+    assert module_root["SERIAL_NUMBER"] == service_name
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Overview

Add Emulator Proxy connection environment variables to modules and Emulator Proxy itself.
Parameterize serial number tests

# Changelog

- [service_creator.py](https://github.com/Opentrons/opentrons-emulation/pull/59/files#diff-2c156182f7bf5f2c2c6e11912fa49a4d369e664279af1a5f56960da26e28048b)
  - Add `_create_emulator_proxy_env_vars` method to add all connection env vars to emulator proxy
  - Add `container.get_proxy_info_env_var` call inside all Module containers
- [module_model.py](https://github.com/Opentrons/opentrons-emulation/pull/59/files#diff-0f98439172f71cadc1b2b4af1a21b0637c96fcafab77045e9b4be78a121a7851)
  - Add `ProxyInfoModel` class to describe proxy connection
  - Define proxy_info class variable, provide instantiation on all modules
- TESTING!!!

# Review requests

None

# Risk assessment

None