### PR TITLE
fix: Add logic to allow setting command based on em level and hardware

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_creation/input_service_creation.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_creation/input_service_creation.py
@@ -11,16 +11,6 @@ from typing import (
 from emulation_system.compose_file_creator.conversion.intermediate_types import (
     RequiredNetworks,
 )
-from emulation_system.opentrons_emulation_configuration import (
-    OpentronsEmulationConfiguration,
-)
-from .shared_functions import (
-    generate_container_name,
-    get_mount_strings,
-    get_service_build,
-    get_service_image,
-    get_build_args,
-)
 from emulation_system.compose_file_creator.input.configuration_file import (
     SystemConfigurationModel,
 )
@@ -36,7 +26,20 @@ from emulation_system.compose_file_creator.output.compose_file_model import (
     Service,
 )
 from emulation_system.compose_file_creator.settings.custom_types import Containers
-from ...settings.config_file_settings import SourceType
+from emulation_system.opentrons_emulation_configuration import (
+    OpentronsEmulationConfiguration,
+)
+from .shared_functions import (
+    generate_container_name,
+    get_build_args,
+    get_mount_strings,
+    get_service_build,
+    get_service_image,
+)
+from ...settings.config_file_settings import (
+    EmulationLevels,
+    SourceType,
+)
 
 
 def _get_service_depends_on(
@@ -56,15 +59,17 @@ def _get_service_depends_on(
 
 def _get_command(
     container: Containers, emulator_proxy_name: Optional[str]
-) -> Optional[str]:
+) -> Optional[List[str]]:
     # If emulator proxy exists and container is module then the emulator proxy name
     # should be the command.
-    return (
-        emulator_proxy_name
-        if emulator_proxy_name is not None
-        and issubclass(container.__class__, ModuleInputModel)
-        else None
-    )
+    command: Optional[List[str]] = None
+    if emulator_proxy_name is not None:
+        if container.emulation_level == EmulationLevels.HARDWARE:
+            command = container.get_hardware_level_command(emulator_proxy_name)
+        else:
+            command = container.get_firmware_level_command(emulator_proxy_name)
+
+    return command
 
 
 def _get_port_bindings(

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/hardware_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/hardware_model.py
@@ -8,6 +8,7 @@ from typing import (
     Any,
     Dict,
     List,
+    Optional,
     Union,
 )
 
@@ -169,3 +170,15 @@ class HardwareModel(BaseModel):
             volumes=self.get_mount_strings(),  # type: ignore[arg-type]
             tty=True,
         )
+
+    def get_hardware_level_command(
+        self, emulator_proxy_name: str
+    ) -> Optional[List[str]]:
+        """Get command for module when it is being emulated at hardware level."""
+        return None
+
+    def get_firmware_level_command(
+        self, emulator_proxy_name: str
+    ) -> Optional[List[str]]:
+        """Get command for module when it is being emulated at hardware level."""
+        return None

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/heater_shaker_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/heater_shaker_module.py
@@ -1,5 +1,9 @@
 """Model and attributes for heater-shaker Module."""
-from typing import ClassVar
+from typing import (
+    ClassVar,
+    List,
+    Optional,
+)
 
 from pydantic import Field
 from typing_extensions import Literal
@@ -52,3 +56,12 @@ class HeaterShakerModuleInputModel(ModuleInputModel):
         alias="hardware-specific-attributes", default=HeaterShakerModuleAttributes()
     )
     emulation_level: Literal[EmulationLevels.HARDWARE] = Field(alias="emulation-level")
+
+    def get_hardware_level_command(
+        self, emulator_proxy_name: str
+    ) -> Optional[List[str]]:
+        """Get command for heater shaker when it is being emulated at hardware level."""
+        return [
+            "--socket",
+            f"http://{emulator_proxy_name}:{self.proxy_info.emulator_port}",
+        ]

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/magnetic_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/magnetic_module.py
@@ -1,5 +1,9 @@
 """Model and attributes for Magnetic Module."""
-from typing import ClassVar
+from typing import (
+    ClassVar,
+    List,
+    Optional,
+)
 
 from pydantic import Field
 from typing_extensions import Literal
@@ -55,3 +59,9 @@ class MagneticModuleInputModel(ModuleInputModel):
         alias="hardware-specific-attributes", default=MagneticModuleAttributes()
     )
     emulation_level: Literal[EmulationLevels.FIRMWARE] = Field(alias="emulation-level")
+
+    def get_firmware_level_command(
+        self, emulator_proxy_name: str
+    ) -> Optional[List[str]]:
+        """Get command for module when it is being emulated at hardware level."""
+        return [emulator_proxy_name]

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
@@ -2,21 +2,21 @@
 
 Used to group all modules together and distinguish them from robots.
 """
-import json
 from typing import (
     ClassVar,
     Dict,
     Optional,
 )
 
+import json
 from pydantic import (
     BaseModel,
     Field,
 )
 
 from emulation_system.compose_file_creator.input.hardware_models.hardware_model import (
-    HardwareModel,
     EmulationLevelNotSupportedError,
+    HardwareModel,
 )
 from emulation_system.compose_file_creator.settings.config_file_settings import (
     EmulationLevels,

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/temperature_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/temperature_module.py
@@ -1,5 +1,9 @@
 """Model and attributes for Temperature Module."""
-from typing import ClassVar
+from typing import (
+    ClassVar,
+    List,
+    Optional,
+)
 
 from pydantic import Field
 from typing_extensions import Literal
@@ -57,3 +61,9 @@ class TemperatureModuleInputModel(ModuleInputModel):
     )
 
     emulation_level: Literal[EmulationLevels.FIRMWARE] = Field(alias="emulation-level")
+
+    def get_firmware_level_command(
+        self, emulator_proxy_name: str
+    ) -> Optional[List[str]]:
+        """Get command for module when it is being emulated at hardware level."""
+        return [emulator_proxy_name]

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/thermocycler_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/thermocycler_module.py
@@ -1,5 +1,9 @@
 """Model and attributes for Thermocycler Module."""
-from typing import ClassVar
+from typing import (
+    ClassVar,
+    List,
+    Optional,
+)
 
 from pydantic import Field
 from typing_extensions import Literal
@@ -63,3 +67,18 @@ class ThermocyclerModuleInputModel(ModuleInputModel):
     emulation_level: Literal[
         EmulationLevels.FIRMWARE, EmulationLevels.HARDWARE
     ] = Field(alias="emulation-level")
+
+    def get_hardware_level_command(
+        self, emulator_proxy_name: str
+    ) -> Optional[List[str]]:
+        """Get command for heater shaker when it is being emulated at hardware level."""
+        return [
+            "--socket",
+            f"http://{emulator_proxy_name}:{self.proxy_info.emulator_port}",
+        ]
+
+    def get_firmware_level_command(
+        self, emulator_proxy_name: str
+    ) -> Optional[List[str]]:
+        """Get command for module when it is being emulated at hardware level."""
+        return [emulator_proxy_name]

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_conversion_logic.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_conversion_logic.py
@@ -2,6 +2,7 @@
 from typing import (
     Any,
     Dict,
+    List,
     cast,
 )
 
@@ -132,21 +133,21 @@ def test_robot_port(robot_with_mount_and_modules_services: Dict[str, Any]) -> No
 
 
 @pytest.mark.parametrize(
-    "service_name",
+    "service_name, expected_value",
     [
-        THERMOCYCLER_MODULE_ID,
-        TEMPERATURE_MODULE_ID,
-        MAGNETIC_MODULE_ID,
-        HEATER_SHAKER_MODULE_ID,
+        [THERMOCYCLER_MODULE_ID, ["--socket", f"http://{EMULATOR_PROXY_ID}:10003"]],
+        [TEMPERATURE_MODULE_ID, [EMULATOR_PROXY_ID]],
+        [MAGNETIC_MODULE_ID, [EMULATOR_PROXY_ID]],
+        [HEATER_SHAKER_MODULE_ID, ["--socket", f"http://{EMULATOR_PROXY_ID}:10004"]],
     ],
 )
 def test_module_command(
-    service_name: str, robot_with_mount_and_modules_services: Dict[str, Any]
+    service_name: str,
+    expected_value: List[str],
+    robot_with_mount_and_modules_services: Dict[str, Any],
 ) -> None:
     """Confirm that modules depend on emulator proxy."""
-    assert (
-        robot_with_mount_and_modules_services[service_name].command == EMULATOR_PROXY_ID
-    )
+    assert robot_with_mount_and_modules_services[service_name].command == expected_value
 
 
 def test_robot_command(robot_with_mount_and_modules_services: Dict[str, Any]) -> None:


### PR DESCRIPTION
# Overview

Add custom command for heater-shaker and thermocycler when used at hw level.

# Changelog

- Add `get_hardware_level_command` and `get_firmware_level_command` to [hardware_model.py](https://github.com/Opentrons/opentrons-emulation/pull/65/files#diff-23187c61c270d5135c350f4faed79b015900d428c9f04c28ab15a9dcf102bc540)
- Add overrides where needed 
- Update tests

# Review requests

None

# Risk assessment

Low