### PR TITLE
fix: Fix Thermocycler and Tempdeck not starting

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
@@ -20,6 +20,7 @@ from emulation_system.compose_file_creator.input.hardware_models.hardware_model 
 )
 from emulation_system.compose_file_creator.settings.config_file_settings import (
     EmulationLevels,
+    Hardware,
 )
 
 
@@ -61,6 +62,10 @@ class ModuleInputModel(HardwareModel):
             "model": self.firmware_serial_number_info.model,
             "version": self.firmware_serial_number_info.version,
         }
+
+        if self.hardware in [Hardware.THERMOCYCLER_MODULE, Hardware.TEMPERATURE_MODULE]:
+            value.update(self.hardware_specific_attributes.dict())
+
         return {self.firmware_serial_number_info.env_var_name: json.dumps(value)}
 
     def _get_hardware_serial_number_env_var(self) -> Dict[str, str]:

--- a/emulation_system/tests/compose_file_creator/conftest.py
+++ b/emulation_system/tests/compose_file_creator/conftest.py
@@ -189,11 +189,11 @@ def thermocycler_module_set_plate_temp(
 
 
 @pytest.fixture
-def thermocycler_module_hardware_emulation_level(
+def thermocycler_module_firmware_emulation_level(
     thermocycler_module_default: Dict[str, Any]
 ) -> Dict[str, Any]:
     """Return heater-shaker configuration with an invalid emulation level."""
-    thermocycler_module_default["emulation-level"] = EmulationLevels.HARDWARE.value
+    thermocycler_module_default["emulation-level"] = EmulationLevels.FIRMWARE.value
     return thermocycler_module_default
 
 

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_environment_variables.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_environment_variables.py
@@ -72,22 +72,51 @@ def test_ot3_feature_flag_added(
 
 
 @pytest.mark.parametrize(
-    "service_name,input_class",
+    "model,input_class,expected_value",
     [
-        [TEMPERATURE_MODULE_ID, TemperatureModuleInputModel],
-        [MAGNETIC_MODULE_ID, MagneticModuleInputModel],
+        [
+            lazy_fixture("temperature_module_default"),
+            TemperatureModuleInputModel,
+            {
+                "serial_number": "temperamental",
+                "model": "temp_deck_v20",
+                "version": "v2.0.1",
+                "temperature": {"degrees_per_tick": 2.0, "starting": 23.0}
+            }
+        ],
+        [
+            lazy_fixture("magnetic_module_default"),
+            MagneticModuleInputModel,
+            {
+                "serial_number": "fatal-attraction",
+                "model": "mag_deck_v20",
+                "version": "2.0.0"
+            }
+        ],
+        [
+            lazy_fixture("thermocycler_module_firmware_emulation_level"),
+            ThermocyclerModuleInputModel,
+            {
+                "serial_number": "t00-hot-to-handle",
+                "model": "v02",
+                "version": "v1.1.0",
+                "lid_temperature": {"degrees_per_tick": 2.0, "starting": 23.0},
+                "plate_temperature": {"degrees_per_tick": 2.0, "starting": 23.0}
+            }
+        ],
     ],
 )
 def test_firmware_serial_number_env_vars(
-    service_name: str,
+    model: Dict[str, Any],
     input_class: Type[ModuleInputModel],
-    robot_with_mount_and_modules_services: Dict[str, Service],
+    expected_value: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration
 ) -> None:
     """Confirm that serial number env vars are created correctly on firmware modules."""
-    services = robot_with_mount_and_modules_services
+    services = convert_from_obj({"modules": [model]}, testing_global_em_config).services
     assert services is not None
 
-    module_env = services[service_name].environment
+    module_env = services[model["id"]].environment
     assert module_env is not None
     assert input_class.firmware_serial_number_info is not None
     assert input_class.firmware_serial_number_info.env_var_name in module_env.__root__
@@ -95,13 +124,7 @@ def test_firmware_serial_number_env_vars(
     module_root = cast(Dict[str, str], module_env.__root__)
     assert module_root[
         input_class.firmware_serial_number_info.env_var_name
-    ] == json.dumps(
-        {
-            "serial_number": service_name,
-            "model": input_class.firmware_serial_number_info.model,
-            "version": input_class.firmware_serial_number_info.version,
-        }
-    )
+    ] == json.dumps(expected_value)
 
 
 @pytest.mark.parametrize(

--- a/emulation_system/tests/compose_file_creator/input/hardware_models/modules/test_thermocycler_module.py
+++ b/emulation_system/tests/compose_file_creator/input/hardware_models/modules/test_thermocycler_module.py
@@ -67,12 +67,10 @@ def test_thermocycler_with_plate_temp(
 
 
 def test_thermocycler_hardware_emulation_level(
-    thermocycler_module_hardware_emulation_level: Dict[str, Any]
+    thermocycler_module_default: Dict[str, Any]
 ) -> None:
     """Confirm you can set Thermocycler to be emulated at the hardware level."""
-    therm = parse_obj_as(
-        ThermocyclerModuleInputModel, thermocycler_module_hardware_emulation_level
-    )
+    therm = parse_obj_as(ThermocyclerModuleInputModel, thermocycler_module_default)
     assert therm.emulation_level == EmulationLevels.HARDWARE.value
 
 


### PR DESCRIPTION
# Overview

Fix Thermocycler and Tempdeck not starting up correctly. 

Thermocycler and Tempdeck require temperature settings as defined in [settings.py](https://github.com/Opentrons/opentrons/blob/edge/api/src/opentrons/hardware_control/emulation/settings.py). So I defined them