### PR TITLE
feat: Build all OT3 simulations at once to optimize for build speed

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -255,22 +255,6 @@ COPY entrypoint.sh /entrypoint.sh
 # from the executable builder target
 # Building separately from the Production Target to reduce image size
 
-FROM ot3-firmware-source as ot3-pipettes-builder
-ENV OPENTRONS_HARDWARE "ot3-pipettes-hardware"
-RUN /entrypoint.sh build
-
-FROM ot3-firmware-source as ot3-head-builder
-ENV OPENTRONS_HARDWARE "ot3-head-hardware"
-RUN /entrypoint.sh build
-
-FROM ot3-firmware-source as ot3-gantry-x-builder
-ENV OPENTRONS_HARDWARE "ot3-gantry-x-hardware"
-RUN /entrypoint.sh build
-
-FROM ot3-firmware-source as ot3-gantry-y-builder
-ENV OPENTRONS_HARDWARE "ot3-gantry-y-hardware"
-RUN /entrypoint.sh build
-
 FROM opentrons-modules-source as heater-shaker-builder
 ENV OPENTRONS_HARDWARE "heater-shaker-hardware"
 RUN /entrypoint.sh build
@@ -281,6 +265,10 @@ RUN /entrypoint.sh build
 
 FROM opentrons-source as firmware-builder
 ENV OPENTRONS_HARDWARE "common-firmware"
+RUN /entrypoint.sh build
+
+FROM ot3-firmware-source as ot3-firmware-builder
+ENV OPENTRONS_HARDWARE "common-ot3-firmware"
 RUN /entrypoint.sh build
 
 ##################
@@ -313,25 +301,25 @@ RUN pip install /dist/*
 
 FROM ubuntu-base as ot3-pipettes-hardware-remote
 ENV OPENTRONS_HARDWARE "ot3-pipettes-hardware"
-COPY --from=ot3-pipettes-builder /ot3-firmware/build-host/pipettes/simulator/pipettes-simulator /ot3-firmware/build-host/pipettes/simulator/pipettes-simulator
+COPY --from=ot3-firmware-builder /ot3-firmware/build-host/pipettes/simulator/pipettes-simulator /ot3-firmware/build-host/pipettes/simulator/pipettes-simulator
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
 
 FROM ubuntu-base as ot3-head-hardware-remote
 ENV OPENTRONS_HARDWARE "ot3-head-hardware"
-COPY --from=ot3-head-builder /ot3-firmware/build-host/head/simulator/head-simulator /ot3-firmware/build-host/head/simulator/head-simulator
+COPY --from=ot3-firmware-builder /ot3-firmware/build-host/head/simulator/head-simulator /ot3-firmware/build-host/head/simulator/head-simulator
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
 
 FROM ubuntu-base as ot3-gantry-x-hardware-remote
 ENV OPENTRONS_HARDWARE "ot3-gantry-x-hardware"
-COPY --from=ot3-gantry-x-builder /ot3-firmware/build-host/gantry/simulator/gantry-x-simulator /ot3-firmware/build-host/gantry/simulator/gantry-x-simulator
+COPY --from=ot3-firmware-builder /ot3-firmware/build-host/gantry/simulator/gantry-x-simulator /ot3-firmware/build-host/gantry/simulator/gantry-x-simulator
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
 
 FROM ubuntu-base as ot3-gantry-y-hardware-remote
 ENV OPENTRONS_HARDWARE "ot3-gantry-y-hardware"
-COPY --from=ot3-gantry-y-builder /ot3-firmware/build-host/gantry/simulator/gantry-y-simulator /ot3-firmware/build-host/gantry/simulator/gantry-y-simulator
+COPY --from=ot3-firmware-builder /ot3-firmware/build-host/gantry/simulator/gantry-y-simulator /ot3-firmware/build-host/gantry/simulator/gantry-y-simulator
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,12 +15,6 @@ if [ "$COMMAND" != "build" ] && [ "$COMMAND" != "run" ]; then
   exit 1
 fi
 
-build_ot3_simulator() {
-  cd /ot3-firmware && \
-  cmake --preset host-gcc10 && \
-  cmake --build ./build-host --target $1
-}
-
 build_module_simulator() {
   cd /opentrons-modules && \
   cmake --preset=stm32-host-gcc10 . && \
@@ -50,17 +44,11 @@ case $FULL_COMMAND in
     (cd /opentrons/robot-server && python3 setup.py bdist_wheel -d /dist/)
     pip install /dist/*
     ;;
-  build-ot3-pipettes-hardware)
-    build_ot3_simulator "pipettes-simulator"
-    ;;
-  build-ot3-head-hardware)
-    build_ot3_simulator "head-simulator"
-    ;;
-  build-ot3-gantry-x-hardware)
-    build_ot3_simulator "gantry-x-simulator"
-    ;;
-  build-ot3-gantry-y-hardware)
-    build_ot3_simulator "gantry-y-simulator"
+
+  build-common-ot3-firmware)
+    cd /ot3-firmware && \
+    cmake --preset host-gcc10 && \
+    cmake --build --preset=simulators
     ;;
 
   run-heater-shaker-hardware)


### PR DESCRIPTION
# Overview

Instead of building common firmware separately built it all at once and pull the executables into final targets
