### PR TITLE
fix: Remove extraneous mounts (RET-496, RET-497 RET-498)

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_creation/ot3_service_creation.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_creation/ot3_service_creation.py
@@ -1,6 +1,10 @@
 """Logic for creating OT3 emulated hardware services."""
 from dataclasses import dataclass
-from typing import List
+from typing import (
+    List,
+    Optional,
+    Union,
+)
 
 from emulation_system.opentrons_emulation_configuration import (
     OpentronsEmulationConfiguration,
@@ -8,7 +12,7 @@ from emulation_system.opentrons_emulation_configuration import (
 from .shared_functions import (
     generate_container_name,
     get_build_args,
-    get_mount_strings,
+    get_entrypoint_mount_string,
     get_service_build,
 )
 from ..intermediate_types import RequiredNetworks
@@ -17,7 +21,10 @@ from ...errors import (
     IncorrectHardwareError,
 )
 from ...input.configuration_file import SystemConfigurationModel
-from ...output.compose_file_model import Service
+from ...output.compose_file_model import (
+    Service,
+    Volume1,
+)
 from ...settings.config_file_settings import (
     Hardware,
     OT3Hardware,
@@ -85,13 +92,18 @@ def create_ot3_services(
             if ot3.source_type == SourceType.REMOTE
             else None
         )
+
+        mounts: Optional[List[Union[str, Volume1]]] = None
+        if ot3.source_type == SourceType.LOCAL:
+            mounts = [get_entrypoint_mount_string()] + ot3.get_mount_strings()
+
         ot3_services.append(
             Service(
                 container_name=container_name,
                 image=image_name,
                 build=get_service_build(image_name, build_args),
                 networks=required_networks.networks,
-                volumes=get_mount_strings(ot3),
+                volumes=mounts,
                 tty=True,
             )
         )

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_creation/ot3_service_creation.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_creation/ot3_service_creation.py
@@ -95,7 +95,8 @@ def create_ot3_services(
 
         mounts: Optional[List[Union[str, Volume1]]] = None
         if ot3.source_type == SourceType.LOCAL:
-            mounts = [get_entrypoint_mount_string()] + ot3.get_mount_strings()
+            mounts = [get_entrypoint_mount_string()]
+            mounts.extend(ot3.get_mount_strings())
 
         ot3_services.append(
             Service(

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_creation/shared_functions.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_creation/shared_functions.py
@@ -62,6 +62,16 @@ def get_mount_strings(container: Containers) -> Optional[List[Union[str, Volume1
     )
 
 
+def get_entrypoint_mount_string() -> str:
+    """Return bind mount string to entrypoint.sh."""
+    return FileMount(
+        name=ENTRYPOINT_MOUNT_NAME,
+        type=MountTypes.FILE,
+        source_path=pathlib.Path(ENTRYPOINT_FILE_LOCATION),
+        mount_path="/entrypoint.sh",
+    ).get_bind_mount_string()
+
+
 def get_build_args(
     source_repo: OpentronsRepository,
     source_location: str,

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_creation/smoothie_service_creation.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_creation/smoothie_service_creation.py
@@ -10,16 +10,9 @@ from typing import (
 from emulation_system.compose_file_creator.conversion.intermediate_types import (
     RequiredNetworks,
 )
-from emulation_system.opentrons_emulation_configuration import (
-    OpentronsEmulationConfiguration,
-)
-from .shared_functions import (
-    generate_container_name,
-    get_build_args,
-    get_entrypoint_mount_string,
-    get_mount_strings,
-    get_service_build,
-    get_service_image,
+from emulation_system.compose_file_creator.errors import (
+    HardwareDoesNotExistError,
+    IncorrectHardwareError,
 )
 from emulation_system.compose_file_creator.input.configuration_file import (
     SystemConfigurationModel,
@@ -35,9 +28,15 @@ from emulation_system.compose_file_creator.settings.config_file_settings import 
     SourceType,
 )
 from emulation_system.compose_file_creator.settings.images import SmoothieImages
-from emulation_system.compose_file_creator.errors import (
-    HardwareDoesNotExistError,
-    IncorrectHardwareError,
+from emulation_system.opentrons_emulation_configuration import (
+    OpentronsEmulationConfiguration,
+)
+from .shared_functions import (
+    generate_container_name,
+    get_build_args,
+    get_entrypoint_mount_string,
+    get_service_build,
+    get_service_image,
 )
 
 
@@ -82,7 +81,8 @@ def create_smoothie_service(
     )
     mounts: Optional[List[Union[str, Volume1]]] = None
     if ot2.source_type == SourceType.LOCAL:
-        mounts = [get_entrypoint_mount_string()] + ot2.get_mount_strings()
+        mounts = [get_entrypoint_mount_string()]
+        mounts.extend(ot2.get_mount_strings())
 
     return Service(
         container_name=smoothie_name,

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_creation/smoothie_service_creation.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_creation/smoothie_service_creation.py
@@ -1,6 +1,11 @@
 """Pure functions related to the creation of the smoothie Service."""
 
 import json
+from typing import (
+    List,
+    Optional,
+    Union,
+)
 
 from emulation_system.compose_file_creator.conversion.intermediate_types import (
     RequiredNetworks,
@@ -11,6 +16,7 @@ from emulation_system.opentrons_emulation_configuration import (
 from .shared_functions import (
     generate_container_name,
     get_build_args,
+    get_entrypoint_mount_string,
     get_mount_strings,
     get_service_build,
     get_service_image,
@@ -21,6 +27,7 @@ from emulation_system.compose_file_creator.input.configuration_file import (
 from emulation_system.compose_file_creator.output.compose_file_model import (
     ListOrDict,
     Service,
+    Volume1,
 )
 from emulation_system.compose_file_creator.settings.config_file_settings import (
     Hardware,
@@ -73,6 +80,9 @@ def create_smoothie_service(
         if ot2.source_type == SourceType.REMOTE
         else None
     )
+    mounts: Optional[List[Union[str, Volume1]]] = None
+    if ot2.source_type == SourceType.LOCAL:
+        mounts = [get_entrypoint_mount_string()] + ot2.get_mount_strings()
 
     return Service(
         container_name=smoothie_name,
@@ -82,7 +92,7 @@ def create_smoothie_service(
         # Using ot2 mount strings here. This will add the constraint that robot-server
         # and smoothie use same source code. Going to leave this for now until it
         # becomes a problem.
-        volumes=get_mount_strings(ot2),
+        volumes=mounts,
         tty=True,
         environment=converted_env,
         # Intentionally not specifying command. Smoothie uses a separate executable

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/hardware_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/hardware_model.py
@@ -85,7 +85,7 @@ class HardwareModel(BaseModel):
         """Methods to always run after initialization."""
         # Note that at this point, any extra-mounts defined in the configuration
         # file, exist in the mounts list.
-        self.mounts + self._get_source_code_mount()
+        self.mounts.extend(self._get_source_code_mount())
 
     @staticmethod
     def validate_source_location(key: str, v: str, values: Dict[str, Any]) -> str:

--- a/emulation_system/tests/compose_file_creator/conftest.py
+++ b/emulation_system/tests/compose_file_creator/conftest.py
@@ -206,8 +206,8 @@ def ot2_default(opentrons_dir: str) -> Dict[str, Any]:
         "emulation-level": OT2_EMULATION_LEVEL,
         "source-type": OT2_SOURCE_TYPE,
         "source-location": opentrons_dir,
-        "robot-server-source-type": "remote",
-        "robot-server-source-location": "latest",
+        "robot-server-source-type": "local",
+        "robot-server-source-location": opentrons_dir,
         "exposed-port": 5000,
         "hardware-specific-attributes": {},
     }

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_extra_service_creation.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_extra_service_creation.py
@@ -31,7 +31,6 @@ from emulation_system.opentrons_emulation_configuration import (
 )
 from tests.compose_file_creator.conftest import (
     EMULATOR_PROXY_ID,
-    OT3_ID,
     SMOOTHIE_ID,
 )
 from tests.compose_file_creator.conversion_logic.conftest import partial_string_in_mount

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_extra_service_creation.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_extra_service_creation.py
@@ -34,6 +34,7 @@ from tests.compose_file_creator.conftest import (
     OT3_ID,
     SMOOTHIE_ID,
 )
+from tests.compose_file_creator.conversion_logic.conftest import partial_string_in_mount
 
 
 @pytest.mark.parametrize(
@@ -136,5 +137,5 @@ def test_local_ot3_services_created(
     service = services[container_name]
     assert service.image == expected_image_name
 
-    ot3 = services[OT3_ID]
-    assert service.volumes == ot3.volumes
+    partial_string_in_mount("entrypoint.sh:/entrypoint.sh", service)
+    partial_string_in_mount("ot3-firmware:/ot3-firmware", service)

--- a/samples/yaml/ot2_local.yaml
+++ b/samples/yaml/ot2_local.yaml
@@ -1,0 +1,10 @@
+system-unique-id: "ot2-only"
+robot:
+  id: "otie"
+  hardware: "ot2"
+  source-type: "local"
+  source-location: "/home/derek-maggio/Documents/repos/opentrons"
+  robot-server-source-type: "local"
+  robot-server-source-location: "/home/derek-maggio/Documents/repos/opentrons"
+  emulation-level: "firmware"
+  exposed-port: 31950

--- a/samples/yaml/ot2_remote.yaml
+++ b/samples/yaml/ot2_remote.yaml
@@ -4,5 +4,7 @@ robot:
   hardware: "ot2"
   source-type: "remote"
   source-location: "latest"
+  robot-server-source-type: "remote"
+  robot-server-source-location: "latest"
   emulation-level: "firmware"
   exposed-port: 31950

--- a/samples/yaml/ot3_local.yaml
+++ b/samples/yaml/ot3_local.yaml
@@ -1,0 +1,10 @@
+system-unique-id: "ot3-only"
+robot:
+  id: "otie"
+  hardware: "ot3"
+  source-type: "local"
+  source-location: "/home/derek-maggio/Documents/repos/ot3-firmware"
+  robot-server-source-type: "local"
+  robot-server-source-location: "/home/derek-maggio/Documents/repos/opentrons"
+  emulation-level: "hardware"
+  exposed-port: 31950

--- a/samples/yaml/ot3_remote.yaml
+++ b/samples/yaml/ot3_remote.yaml
@@ -4,5 +4,7 @@ robot:
   hardware: "ot3"
   source-type: "remote"
   source-location: "latest"
+  robot-server-source-type: "remote"
+  robot-server-source-location: "latest"
   emulation-level: "hardware"
   exposed-port: 31950


### PR DESCRIPTION
# Overview

- In robot-server, remove source code mounts that are meant for emulator only
- In smoothie and ot3 emulators, remove source code mounts that are meant for robot-server only
- Add entrypoint.sh mount if anything else is mounted. (Scoping it like this is a little broad, but it doesn't hurt anything)

# Changelog

Look at the commits, I broke up individual changes into their own commits. 

# Review requests

None

# Risk assessment

Low