### PR TITLE
chore: Configuration for cpx

### DIFF
--- a/CPX_SETUP.md
+++ b/CPX_SETUP.md
@@ -1,0 +1,19 @@
+# CPX Setup Instructions
+
+Below are the instructions for settings up an OT-2 robot-server emulator with your own local source. Connected to it
+will be a Heater-Shaker Module, Magnetic Module, Thermocycler Module, and Temperature Module.
+
+1. Follow instructions in README for initial setup
+2. Go into `samples/yaml/ot2_local_with_all_modules.yaml` and replace the value for `robot.robot-server-source-location`
+   with a path to your mono repo
+3. From the root of the repo run `make em-build-amd64 file_path=${PWD}/samples/yaml/ot2_local_with_all_modules.yaml`.
+   This will take forever for the intial build, probably around 10 minutes.
+4. From the root of the repo run `make em-run file_path=${PWD}/samples/yaml/ot2_local_with_all_modules.yaml`
+5. Run `docker exec -it ot2-with-all-modules-otie bash -c "/entrypoint.sh build && /entrypoint.sh run"` to build and
+   start your dev server
+6. Hit localhost:31950/modules in postman
+7. Change something to change the api in the mono repo. For instance I changed `displayName` on get_modules
+   in `/opentrons/robot-server/robot_server/service/legacy/routers/modules.py` to `BOOOOOOP`
+8. Run `docker exec -it ot2-with-all-modules-otie bash -c "/entrypoint.sh build && /entrypoint.sh run"` to rebuild and
+   restart your dev server
+9. Hit localhost:31950/modules in postman again

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -37,14 +37,6 @@ case $FULL_COMMAND in
     build_module_simulator "thermocycler-refresh-simulator"
     ;;
 
-  build-thermocycler-firmware|build-magdeck-firmware|build-tempdeck-firmware|build-emulator-proxy|build-robot-server|build-common-firmware|build-smoothie)
-    (cd /opentrons/shared-data/python && python3 setup.py bdist_wheel -d /dist/)
-    (cd /opentrons/api && python3 setup.py bdist_wheel -d /dist/)
-    (cd /opentrons/notify-server && python3 setup.py bdist_wheel -d /dist/)
-    (cd /opentrons/robot-server && python3 setup.py bdist_wheel -d /dist/)
-    pip install /dist/*
-    ;;
-
   build-common-ot3-firmware)
     cd /ot3-firmware && \
     cmake --preset host-gcc10 && \
@@ -74,6 +66,7 @@ case $FULL_COMMAND in
   # Firmware Level
 
   build-thermocycler-firmware|build-magdeck-firmware|build-tempdeck-firmware|build-emulator-proxy|build-robot-server|build-common-firmware)
+    rm -rf /usr/local/lib/python3.8/dist-packages/*
     (cd /opentrons/shared-data/python && python3 setup.py bdist_wheel -d /dist/)
     (cd /opentrons/api && python3 setup.py bdist_wheel -d /dist/)
     (cd /opentrons/notify-server && python3 setup.py bdist_wheel -d /dist/)
@@ -91,7 +84,7 @@ case $FULL_COMMAND in
     bash -c "python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator magdeck $OTHER_ARGS"
     ;;
   run-robot-server)
-    bash -c "uvicorn "robot_server:app" --host 0.0.0.0 --port 31950 --ws wsproto --reload"
+    bash -c "uvicorn "robot_server:app" --host 0.0.0.0 --port 31950 --ws wsproto"
     ;;
   run-emulator-proxy)
     python3 -m opentrons.hardware_control.emulation.app

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/robot_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/robot_model.py
@@ -24,6 +24,7 @@ from emulation_system.compose_file_creator.settings.config_file_settings import 
     ROBOT_SERVER_MOUNT_NAME,
     SourceType,
 )
+from emulation_system.compose_file_creator.settings.images import get_image_name
 
 
 class RobotInputModel(HardwareModel):
@@ -63,3 +64,9 @@ class RobotInputModel(HardwareModel):
     def get_port_binding_string(self) -> str:
         """Get port binding string for Docker Compose file."""
         return f"{self.exposed_port}:{self.bound_port}"
+
+    def get_image_name(self) -> str:
+        """Get image name to run based off of passed parameters."""
+        return get_image_name(
+            self.hardware, self.robot_server_source_type, self.emulation_level
+        )

--- a/samples/yaml/ot2_local_with_all_modules.yaml
+++ b/samples/yaml/ot2_local_with_all_modules.yaml
@@ -1,0 +1,31 @@
+system-unique-id: ot2-with-all-modules
+robot:
+  id: otie
+  hardware: ot2
+  source-type: remote
+  source-location: latest
+  robot-server-source-type: local
+  robot-server-source-location: /home/derek-maggio/Documents/repos/opentrons
+  emulation-level: firmware
+  exposed-port: 31950
+modules:
+  - id: shakey-and-warm
+    hardware: heater-shaker-module
+    source-type: remote
+    source-location: latest
+    emulation_level: hardware
+  - id: t00-hot-to-handle
+    hardware: thermocycler-module
+    source-type: remote
+    source-location: latest
+    emulation_level: firmware
+  - id: fatal-attraction
+    hardware: magnetic-module
+    source-type: remote
+    source-location: latest
+    emulation_level: firmware
+  - id: temperamental
+    hardware: temperature-module
+    source-type: remote
+    source-location: latest
+    emulation_level: firmware


### PR DESCRIPTION
# Overview

Add configuration for CPX to use emulation

# Changelog

- Create configuration for CPX. `samples/yaml/ot2_local_with_all_modules.yaml`
- Fix robot server not using `robot_server_source_type` when looking for what image to use
- Fix up `entrypoint.sh` to get uvicorn to rebuild correctly

# Review requests

1. Follow instructions in [README](https://github.com/Opentrons/opentrons-emulation/blob/configuration_for_cpx/README.md) for initial setup
2. Go into `samples/yaml/ot2_local_with_all_modules.yaml` and replace the value for `robot.robot-server-source-location` with a path to your mono repo
3. From the root of the repo run `make em-build-amd64 file_path=${PWD}/samples/yaml/ot2_local_with_all_modules.yaml`. This will take forever for the intial build, probably around 10 minutes.
4. From the root of the repo run `make em-run file_path=${PWD}/samples/yaml/ot2_local_with_all_modules.yaml`
5. Run `docker exec -it ot2-with-all-modules-otie bash -c "/entrypoint.sh build && /entrypoint.sh run"` to build and start your dev server
6. Hit localhost:31950/modules in postman
7. Change something to change the api in the mono repo. For instance I changed `displayName` on get_modules in `/opentrons/robot-server/robot_server/service/legacy/routers/modules.py` to `BOOOOOOP`
8. Run `docker exec -it ot2-with-all-modules-otie bash -c "/entrypoint.sh build && /entrypoint.sh run"` to rebuild and restart your dev server
9. Hit localhost:31950/modules in postman again
10. Hopefully the response changed
11. **When this inevitably doesn't work ping me and we will get it fixed**

# Risk assessment

Nothing, what could go wrong? 