### PR TITLE
feat: Add check-remote-only makefile command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ EMULATION_SYSTEM_DIR := emulation_system
 SUB = {SUB}
 
 EMULATION_SYSTEM_CMD := (cd ./emulation_system && pipenv run python main.py emulation-system {SUB} -)
+REMOTE_ONLY_EMULATION_SYSTEM_CMD := (cd ./emulation_system && pipenv run python main.py emulation-system {SUB} - --remote-only)
 COMPOSE_BUILD_COMMAND := docker buildx bake --file tmp-compose.yaml
 COMPOSE_RUN_COMMAND := docker-compose -f - up
 COMPOSE_KILL_COMMAND := docker-compose -f - kill
@@ -56,6 +57,13 @@ em-logs:
 generate-compose-file:
 	$(if $(file_path),,$(error file_path variable required))
 	$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD))
+
+
+.PHONY: check-remote-only
+check-remote-only:
+	$(if $(file_path),,$(error file_path variable required))
+	$(subst $(SUB), $(file_path), $(REMOTE_ONLY_EMULATION_SYSTEM_CMD)) > /dev/null
+	@echo "All services are remote"
 
 
 .PHONY: setup

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ em-build-amd64:
 	# PR: https://github.com/docker/buildx/milestone/11
 	# Ticket: https://github.com/docker/buildx/pull/864
 	$(if $(file_path),@echo "Building system from $(file_path)",$(error file_path variable required))
-	$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD)) > tmp-compose.yaml && $(COMPOSE_BUILD_COMMAND)
-	rm tmp-compose.yaml
+	@$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD)) > tmp-compose.yaml && $(COMPOSE_BUILD_COMMAND)
+	@rm tmp-compose.yaml
 
 .PHONY: em-build-arm64
 em-build-arm64:
@@ -25,44 +25,44 @@ em-build-arm64:
 	# PR: https://github.com/docker/buildx/milestone/11
 	# Ticket: https://github.com/docker/buildx/pull/864
 	$(if $(file_path),@echo "Building system from $(file_path)",$(error file_path variable required))
-	$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD)) > tmp-compose.yaml && $(COMPOSE_BUILD_COMMAND) --set *.platform=linux/x86_64
-	rm tmp-compose.yaml
+	@$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD)) > tmp-compose.yaml && $(COMPOSE_BUILD_COMMAND) --set *.platform=linux/x86_64
+	@rm tmp-compose.yaml
 
 .PHONY: em-run
 em-run:
 	$(if $(file_path),@echo "Running system from $(file_path)",$(error file_path variable required))
-	$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD)) | $(COMPOSE_RUN_COMMAND)
+	@$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD)) | $(COMPOSE_RUN_COMMAND)
 
 
 .PHONY: em-run-detached
 em-run-detached:
 	$(if $(file_path),@echo "Running system from $(file_path)",$(error file_path variable required))
-	$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD)) | $(COMPOSE_RUN_COMMAND) -d
+	@$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD)) | $(COMPOSE_RUN_COMMAND) -d
 
 
 .PHONY: em-remove
 em-remove:
 	$(if $(file_path),@echo "Removing system from $(file_path)",$(error file_path variable required))
-	$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD)) | $(COMPOSE_KILL_COMMAND)
-	$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD)) | $(COMPOSE_REMOVE_COMMAND)
+	@$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD)) | $(COMPOSE_KILL_COMMAND)
+	@$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD)) | $(COMPOSE_REMOVE_COMMAND)
 
 
 .PHONY: em-logs
 em-logs:
 	$(if $(file_path),@echo "Printing logs from $(file_path)",$(error file_path variable required))
-	$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD)) | $(COMPOSE_LOGS_COMMAND)
+	@$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD)) | $(COMPOSE_LOGS_COMMAND)
 
 
 .PHONY: generate-compose-file
 generate-compose-file:
 	$(if $(file_path),,$(error file_path variable required))
-	$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD))
+	@$(subst $(SUB), $(file_path), $(EMULATION_SYSTEM_CMD))
 
 
 .PHONY: check-remote-only
 check-remote-only:
 	$(if $(file_path),,$(error file_path variable required))
-	$(subst $(SUB), $(file_path), $(REMOTE_ONLY_EMULATION_SYSTEM_CMD)) > /dev/null
+	@$(subst $(SUB), $(file_path), $(REMOTE_ONLY_EMULATION_SYSTEM_CMD)) > /dev/null
 	@echo "All services are remote"
 
 
@@ -97,4 +97,4 @@ test:
 
 .PHONY: test-samples
 test-samples:
-	./scripts/test_samples.sh
+	@./scripts/test_samples.sh

--- a/emulation_system/emulation_system/compose_file_creator/conversion/conversion_functions.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/conversion_functions.py
@@ -49,6 +49,7 @@ def _convert(
     required_networks = _get_required_networks(config_model)
     services = create_services(config_model, required_networks, global_settings)
     return RuntimeComposeFileModel(
+        is_remote=config_model.is_remote,
         version=config_model.compose_file_version,
         services=services.services,
         networks={

--- a/emulation_system/emulation_system/compose_file_creator/errors.py
+++ b/emulation_system/emulation_system/compose_file_creator/errors.py
@@ -104,3 +104,12 @@ class ServiceDoesNotExistError(Exception):
         super().__init__(
             f"You do not have a {service_name} in your generated configuration."
         )
+
+
+class NotRemoteOnlyError(Exception):
+    """Exception thrown when not any robot or module is not of remote source-type."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            'Not all source-type parameters for passed system are "remote".'
+        )

--- a/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
@@ -131,10 +131,10 @@ class SystemConfigurationModel(BaseModel):
     @property
     def is_remote(self) -> bool:
         """Checks if all modules are robots are remote."""
-        robot_is_remote = self.robot.is_remote if self.robot_exists else True
+        robot_is_remote = self.robot.is_remote if self.robot is not None else True
         modules_are_remote = (
             all(module.is_remote for module in self.modules)
-            if self.modules_exist
+            if self.modules is not None and len(self.modules) > 0
             else True
         )
 

--- a/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
@@ -128,6 +128,18 @@ class SystemConfigurationModel(BaseModel):
         """Return hardware model by container id."""
         return self.containers[container_id]
 
+    @property
+    def is_remote(self) -> bool:
+        """Checks if all modules are robots are remote."""
+        robot_is_remote = self.robot.is_remote if self.robot_exists else True
+        modules_are_remote = (
+            all(module.is_remote for module in self.modules)
+            if self.modules_exist
+            else True
+        )
+
+        return robot_is_remote and modules_are_remote
+
     @classmethod
     def from_file(cls, file_path: str) -> SystemConfigurationModel:
         """Parse from file."""

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/hardware_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/hardware_model.py
@@ -184,3 +184,8 @@ class HardwareModel(BaseModel):
     ) -> Optional[List[str]]:
         """Get command for module when it is being emulated at hardware level."""
         return None
+
+    @property
+    def is_remote(self) -> bool:
+        """Check if all source-types are remote."""
+        return self.source_type == SourceType.REMOTE

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot3_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot3_model.py
@@ -79,3 +79,8 @@ class OT3InputModel(RobotInputModel):
             if self.can_server_source_type == SourceType.LOCAL
             else []
         )
+
+    @property
+    def is_remote(self) -> bool:
+        """Check if all source-types are remote."""
+        return super().is_remote and self.can_server_source_type == SourceType.REMOTE

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/robot_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/robot_model.py
@@ -68,3 +68,8 @@ class RobotInputModel(HardwareModel):
     def get_source_repo(self) -> OpentronsRepository:
         """Override get_source_repo for robot-server."""
         return OpentronsRepository.OPENTRONS
+
+    @property
+    def is_remote(self) -> bool:
+        """Check if all source-types are remote."""
+        return super().is_remote and self.robot_server_source_type == SourceType.REMOTE

--- a/emulation_system/emulation_system/compose_file_creator/output/runtime_compose_file_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/output/runtime_compose_file_model.py
@@ -39,6 +39,8 @@ yaml.add_representer(type(None), represent_none)
 class RuntimeComposeFileModel(ComposeSpecification):
     """Class to add functionality to generated ComposeSpecification model."""
 
+    is_remote: bool
+
     def __init__(self, **data: Any) -> None:
         """Initialize ComposeSpecification."""
         super().__init__(**data)
@@ -58,7 +60,7 @@ class RuntimeComposeFileModel(ComposeSpecification):
 
     def to_yaml(self) -> str:
         """Convert pydantic model to yaml."""
-        return yaml.dump(self.dict(exclude_none=True), default_flow_style=False)
+        return yaml.dump(self.dict(exclude={"is_remote"}, exclude_none=True), default_flow_style=False)
 
     @property
     def robot_server(self) -> Optional[Service]:

--- a/emulation_system/emulation_system/compose_file_creator/output/runtime_compose_file_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/output/runtime_compose_file_model.py
@@ -60,7 +60,10 @@ class RuntimeComposeFileModel(ComposeSpecification):
 
     def to_yaml(self) -> str:
         """Convert pydantic model to yaml."""
-        return yaml.dump(self.dict(exclude={"is_remote"}, exclude_none=True), default_flow_style=False)
+        return yaml.dump(
+            self.dict(exclude={"is_remote"}, exclude_none=True),
+            default_flow_style=False
+        )
 
     @property
     def robot_server(self) -> Optional[Service]:

--- a/emulation_system/emulation_system/parsers/emulation_system_parser.py
+++ b/emulation_system/emulation_system/parsers/emulation_system_parser.py
@@ -41,3 +41,7 @@ class EmulationSystemParser(AbstractParser):
             type=argparse.FileType("w"),
             help='Output path write compose file to. Specify "-" to write to stdout.',
         )
+
+        subparser.add_argument(
+            "--remote-only", action="store_true", help="Allow only remote source-types"
+        )

--- a/emulation_system/tests/command_creators/test_emulation_system.py
+++ b/emulation_system/tests/command_creators/test_emulation_system.py
@@ -83,7 +83,7 @@ def mocked_em_system(
 ) -> EmulationSystemCommand:
     """Get a mocked EmulationSystemCommand."""
     mock = Mock(spec=io.TextIOWrapper)
-    return EmulationSystemCommand(mock, mock, testing_global_em_config)
+    return EmulationSystemCommand(mock, mock, False, testing_global_em_config)
 
 
 def test_json_stdin(mocked_em_system: EmulationSystemCommand) -> None:

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_source_code_insertion.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_source_code_insertion.py
@@ -695,3 +695,32 @@ def test_ot2_local_source_build_args(
     assert robot_server_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_head
 
     assert build_args_are_none(smoothie)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        lazy_fixture("ot3_remote_everything_latest"),
+        lazy_fixture("ot3_remote_everything_commit_id"),
+        lazy_fixture("ot2_remote_everything_latest"),
+        lazy_fixture("ot2_remote_everything_commit_id"),
+    ],
+)
+def test_is_remote(config: RuntimeComposeFileModel) -> None:
+    """Confirm that when all source-types are remote, is_remote is True."""
+    assert config.is_remote
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        lazy_fixture("ot3_local_robot"),
+        lazy_fixture("ot3_local_source"),
+        lazy_fixture("ot3_local_can"),
+        lazy_fixture("ot2_local_source"),
+        lazy_fixture("ot2_local_robot"),
+    ],
+)
+def test_is_not_remote(config: RuntimeComposeFileModel) -> None:
+    """Confirm that when all source-types are not remote, is_remote is False."""
+    assert not config.is_remote


### PR DESCRIPTION
# Overview

Add `check-remote-only` Makefile command to confirm that all emulators in passed config file are remote.
This is in prep for creating a Github Action where it is required that all the source types for emulators are remote

# Changelog

See commits

# Review requests

None

# Risk assessment

Low