### PR TITLE
feat: Create Public Github Action for Repository

### DIFF
--- a/.github/actions/run/action.yaml
+++ b/.github/actions/run/action.yaml
@@ -13,14 +13,6 @@ runs:
   using: "composite"
   steps:
 
-    - name: Where am I?
-      run: pwd
-      shell: bash
-
-    - name: What is in here?
-      run: ls -l
-      shell: bash
-
     - name: Run Emulation Docker System
       run: make em-run-detached file_path=${{ inputs.input-file }}
       shell: bash

--- a/.github/actions/run/action.yaml
+++ b/.github/actions/run/action.yaml
@@ -1,0 +1,26 @@
+name: 'Run Emulation'
+description: |
+  Run emulated robot based off of passed input-file parameter.
+  The file located at input-file must be the format described in https://github.com/Opentrons/opentrons-emulation/blob/main/README.md.
+  See https://github.com/Opentrons/opentrons-emulation/tree/main/samples for examples
+
+author: Derek Maggio
+inputs:
+  input-file:
+    description: 'YAML or JSON system configuration'
+    required: true
+runs:
+  using: "composite"
+  steps:
+
+    - name: Where am I?
+      run: pwd
+      shell: bash
+
+    - name: What is in here?
+      run: ls -l
+      shell: bash
+
+    - name: Run Emulation Docker System
+      run: make em-run-detached file_path=${{ inputs.input-file }}
+      shell: bash

--- a/.github/actions/setup-break-cache/action.yaml
+++ b/.github/actions/setup-break-cache/action.yaml
@@ -1,0 +1,20 @@
+name: 'Setup Emulation (Break Cache)'
+description: |
+  Install all dependencies and build docker images. Do not use caching.
+  The file located at input-file must be the format described in https://github.com/Opentrons/opentrons-emulation/blob/main/README.md.
+  See https://github.com/Opentrons/opentrons-emulation/tree/main/samples for examples
+
+author: Derek Maggio
+inputs:
+  input-file:
+    description: 'YAML or JSON system configuration'
+    required: true
+runs:
+  using: "composite"
+  steps:
+
+    - name: Setup Emulation (Break Cache)
+      uses: ./.github/actions/setup
+      with:
+        input-file: ${PWD}/samples/${{ matrix.file }}
+        break-cache: $(date +%s%3N)

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,6 +1,6 @@
-name: 'Run Emulation'
+name: 'Setup Emulation'
 description: |
-  Run emulated robot based off of passed input-file parameter.
+  Install all dependencies and build docker images
   The file located at input-file must be the format described in https://github.com/Opentrons/opentrons-emulation/blob/main/README.md.
   See https://github.com/Opentrons/opentrons-emulation/tree/main/samples for examples
 
@@ -9,10 +9,6 @@ inputs:
   input-file:
     description: 'YAML or JSON system configuration'
     required: true
-  python-version:
-    description: 'Version of python to install'
-    required: false
-    default: "3.10"
   cache-break:
     description: 'Specify a value here to break cache'
     required: false
@@ -20,16 +16,17 @@ inputs:
 runs:
   using: "composite"
   steps:
+
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ inputs.python-version }}
+        python-version: "3.10"
 
     - name: Cache Python Dependencies
       uses: actions/cache@v2
       with:
         path: "~/.local/share/virtualenvs/**"
-        key: ${{ runner.os }}-python-${{ inputs.python-version }}-pipenv-${{ hashFiles('./emulation_system/Pipfile.lock') }}-${{ inputs.cache-break }}
+        key: ${{ runner.os }}-pipenv-${{ hashFiles('./emulation_system/Pipfile.lock') }}-${{ inputs.cache-break }}
 
     - name: Setup repo
       run: |
@@ -41,14 +38,18 @@ runs:
       run: cp configuration_ci.json configuration.json
       shell: bash
 
+    - name: Where am I?
+      run: pwd
+      shell: bash
+
+    - name: What is in here?
+      run: ls -l
+      shell: bash
+
     - name: Validate Configuration File is Remote Only
       run: make check-remote-only file_path=${{ inputs.input-file }}
       shell: bash
 
     - name: Build Emulation Docker Images
       run: make em-build-amd64 file_path=${{ inputs.input-file }}
-      shell: bash
-
-    - name: Run Emulation Docker System
-      run: make em-run-detached file_path=${{ inputs.input-file }}
       shell: bash

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -38,14 +38,6 @@ runs:
       run: cp configuration_ci.json configuration.json
       shell: bash
 
-    - name: Where am I?
-      run: pwd
-      shell: bash
-
-    - name: What is in here?
-      run: ls -l
-      shell: bash
-
     - name: Validate Configuration File is Remote Only
       run: make check-remote-only file_path=${{ inputs.input-file }}
       shell: bash

--- a/.github/actions/teardown/action.yaml
+++ b/.github/actions/teardown/action.yaml
@@ -1,5 +1,8 @@
 name: 'Teardown Emulation'
-description: 'Bring down docker container emulation'
+description: |
+  Remove all emulation containers, if any exist.
+  The file located at input-file must be the format described in https://github.com/Opentrons/opentrons-emulation/blob/main/README.md.
+  See https://github.com/Opentrons/opentrons-emulation/tree/main/samples for examples
 author: Derek Maggio
 inputs:
   input-file:

--- a/.github/workflows/repo-action-validation.yaml
+++ b/.github/workflows/repo-action-validation.yaml
@@ -3,7 +3,7 @@
 on: [ pull_request, push ]
 
 jobs:
-  ot3-emulator-sanity-check:
+  opentrons-emulation-sanity-check:
     strategy:
       matrix:
         file: [
@@ -11,15 +11,25 @@ jobs:
           'ot3/ot3_remote.yaml',
         ]
     runs-on: "ubuntu-18.04"
-    name: OT-3 Emulation Sanity Check (${{ matrix.file }})
+    name: Opentrons Emulation Sanity Check (${{ matrix.file }})
     steps:
+
       - name: Checkout opentrons-emulation
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: "break-out-actions"
 
       - name: Setup Emulation
-        uses: ./.github/actions/run_emulation
+        uses: Opentrons/opentrons-emulation@break-out-actions
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
+          command: setup
+
+      - name: Run Emulation
+        uses: Opentrons/opentrons-emulation@break-out-actions
+        with:
+          input-file: ${PWD}/samples/${{ matrix.file }}
+          command: run
 
       - name: Give it some time to start up
         run: sleep 10s
@@ -28,6 +38,7 @@ jobs:
         run: "curl --request GET --header 'opentrons-version: *' http://localhost:31950/modules"
 
       - name: Teardown Emulation
-        uses: ./.github/actions/teardown_emulation
+        uses: Opentrons/opentrons-emulation@break-out-actions
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
+          command: teardown

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,44 @@
+name: Opentrons Emulation
+description: Run commands from opentrons-emulation repo
+author: Derek Maggio
+inputs:
+  input-file:
+    description: 'YAML or JSON system configuration'
+    required: true
+  command:
+    description: 'Command to run'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Validate Command
+      if: ${{ !contains(fromJson('["setup", "setup-break-cache", "run", "teardown"]'), inputs.command)}}
+      run:
+        exit 1
+      shell: bash
+
+    - name: Run Command
+      if: inputs.command == 'run'
+      uses: ./.github/actions/run
+      with:
+        input-file: ${{ inputs.input-file }}
+
+    - name: Setup Command
+      if: inputs.command == 'setup'
+      uses: ./.github/actions/setup
+      with:
+        input-file: ${{ inputs.input-file }}
+
+
+    - name: Setup Command (Break Cache)
+      if: inputs.command == 'setup-break-cache'
+      uses: ./.github/actions/setup-break-cache
+      with:
+        input-file: ${{ inputs.input-file }}
+
+
+    - name: Teardown Command
+      if: inputs.command == 'teardown'
+      uses: ./.github/actions/teardown
+      with:
+        input-file: ${{ inputs.input-file }}


### PR DESCRIPTION
# Overview

Created public Github Action for use in other repositories

# Changelog

- There are now 4 local actions inside `.github/actions/`:
  - `setup` - Get all dependencies and build docker images
  - `setup-break-cache` - Same as above but does not use cache (For debugging)
  - `run` - Start emulation Docker containers
  - `teardown` - Remove emulation Docker containers
- There is now an `action.yaml` in the root of the repository
  - This action takes an `input-file` and `command` parameter
  - The input file must match the format from this repository. See [samples](https://github.com/Opentrons/opentrons-emulation/tree/main/samples) for more info
  - Takes one of the above commands
- Refactor `repo-action-validation.yaml` to use public actions

# Review requests

None

# Risk assessment

Low