### PR TITLE
feat: Add yaml-sub Github Action

### DIFF
--- a/.github/actions/setup-python-only/action.yaml
+++ b/.github/actions/setup-python-only/action.yaml
@@ -1,17 +1,22 @@
-name: 'YAML Sub'
-description: Utility to substitute values in YAML file
+name: 'Setup Emulation (Python Only)'
+description: |
+  Install all dependencies
+  The file located at input-file must be the format described in https://github.com/Opentrons/opentrons-emulation/blob/main/README.md.
+  See https://github.com/Opentrons/opentrons-emulation/tree/main/samples for examples
 
 author: Derek Maggio
 inputs:
   input-file:
     description: 'YAML or JSON system configuration'
     required: true
-  substitutions:
-    description: 'TEST'
-    required: true
+  cache-break:
+    description: 'Specify a value here to break cache'
+    required: false
+    default: "default"
 runs:
   using: "composite"
   steps:
+
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
@@ -27,9 +32,4 @@ runs:
       run: |
         pip install pipenv
         make setup
-      shell: bash
-
-    - name: Substitute YAML
-      run: pipenv run python -m emulation_system.compose_file_creator.utilities.substitute_yaml_values ${{ inputs.input-file }} ${{ toJSON(inputs.substitutions) }}
-      working-directory: ./emulation_system
       shell: bash

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -17,22 +17,11 @@ runs:
   using: "composite"
   steps:
 
-    - name: Setup Python
-      uses: actions/setup-python@v2
+    - name: Setup Emulation
+      uses: ./.github/actions/setup-python-only
       with:
-        python-version: "3.10"
-
-    - name: Cache Python Dependencies
-      uses: actions/cache@v2
-      with:
-        path: "~/.local/share/virtualenvs/**"
-        key: ${{ runner.os }}-pipenv-${{ hashFiles('./emulation_system/Pipfile.lock') }}-${{ inputs.cache-break }}
-
-    - name: Setup repo
-      run: |
-        pip install pipenv
-        make setup
-      shell: bash
+        cache-break: ${{ inputs.cache-break }}
+        input-file: ${PWD}/samples/${{ inputs.input-file }}
 
     - name: Create configuration.json
       run: cp configuration_ci.json configuration.json

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -17,7 +17,7 @@ runs:
   using: "composite"
   steps:
 
-    - name: Setup Emulation
+    - name: Setup Emulation (Python Only)
       uses: ./.github/actions/setup-python-only
       with:
         cache-break: ${{ inputs.cache-break }}

--- a/.github/actions/yaml-sub/action.yaml
+++ b/.github/actions/yaml-sub/action.yaml
@@ -7,7 +7,9 @@ inputs:
     description: 'YAML or JSON system configuration'
     required: true
   substitutions:
-    description: 'TEST'
+    description: |
+      List of lists containing substitutions you want to make to the file.
+      In the format of [[service_name, property_to_replace, replacement_value], ...]
     required: true
 runs:
   using: "composite"

--- a/.github/actions/yaml-sub/action.yaml
+++ b/.github/actions/yaml-sub/action.yaml
@@ -14,22 +14,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Python
-      uses: actions/setup-python@v2
+    - name: Setup Emulation
+      uses: ./.github/actions/setup-python-only
       with:
-        python-version: "3.10"
-
-    - name: Cache Python Dependencies
-      uses: actions/cache@v2
-      with:
-        path: "~/.local/share/virtualenvs/**"
-        key: ${{ runner.os }}-pipenv-${{ hashFiles('./emulation_system/Pipfile.lock') }}-${{ inputs.cache-break }}
-
-    - name: Setup repo
-      run: |
-        pip install pipenv
-        make setup
-      shell: bash
+        cache-break: ${{ inputs.cache-break }}
+        input-file: ${PWD}/samples/${{ inputs.input-file }}
 
     - name: Substitute YAML
       run: pipenv run python -m emulation_system.compose_file_creator.utilities.substitute_yaml_values ${{ inputs.input-file }} ${{ toJSON(inputs.substitutions) }}

--- a/.github/actions/yaml-sub/action.yaml
+++ b/.github/actions/yaml-sub/action.yaml
@@ -1,0 +1,25 @@
+name: 'YAML Sub'
+description: Utility to substitute values in YAML file
+
+author: Derek Maggio
+inputs:
+  input-file:
+    description: 'YAML or JSON system configuration'
+    required: true
+  subs:
+    description: |
+    List of lists containing substitutions you want to make to the file.
+    In the format of [[service_name, property_to_replace, replacement_value], ...]
+    required: true
+runs:
+  using: "composite"
+  steps:
+
+    - name: Setup Emulation
+      uses: ./.github/actions/setup
+      with:
+        input-file: ${PWD}/samples/${{ inputs.input-file }}
+
+    - name: Substitute YAML
+      run: pipenv run python -m emulation_system.compose_file_creator.utilities.substitute_yaml_values ${{ inputs.input-file }} ${{ inputs.subs }}
+      shell: bash

--- a/.github/workflows/repo-action-validation.yaml
+++ b/.github/workflows/repo-action-validation.yaml
@@ -1,4 +1,4 @@
-# Workflow to verify that repo's custom actions are working correctly.
+# Workflow to verify that repo's emulation actions are working correctly.
 
 on: [ pull_request, push ]
 

--- a/.github/workflows/yaml-sub-sanity-check.yaml
+++ b/.github/workflows/yaml-sub-sanity-check.yaml
@@ -1,0 +1,36 @@
+# Workflow to verify that yaml-substitution are working correctly.
+
+on: [ pull_request, push ]
+
+jobs:
+  yaml-sub-sanity-check:
+    strategy:
+      matrix:
+        file: [
+          'ot3/ot3_remote.yaml',
+        ]
+        subs: [
+          [ "ot3-only-otie", "source_location", "48038c4d189536a0862a2c20ed832dc34bd1c8b2" ]
+        ]
+    runs-on: "ubuntu-18.04"
+    name: YAML Substitution Sanity Check (${{ matrix.file }})
+    steps:
+
+      - name: Checkout opentrons-emulation
+        uses: actions/checkout@v3
+        with:
+          ref: "main"
+
+      - name: Setup Emulation
+        uses: Opentrons/opentrons-emulation@main
+        with:
+          command: setup
+          input-file: ${PWD}/samples/${{ matrix.file }}
+
+
+      - name: YAML Substitution
+        uses: Opentrons/opentrons-emulation@main
+        with:
+          command: yaml-sub
+          subs: toJson(${{ matrix.subs }})
+          input-file: ${PWD}/samples/${{ matrix.file }}

--- a/.github/workflows/yaml-sub-sanity-check.yaml
+++ b/.github/workflows/yaml-sub-sanity-check.yaml
@@ -7,7 +7,6 @@ jobs:
     runs-on: "ubuntu-18.04"
     name: YAML Substitution Sanity Check
     steps:
-
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/yaml-sub-sanity-check.yaml
+++ b/.github/workflows/yaml-sub-sanity-check.yaml
@@ -4,33 +4,22 @@ on: [ pull_request, push ]
 
 jobs:
   yaml-sub-sanity-check:
-    strategy:
-      matrix:
-        file: [
-          'ot3/ot3_remote.yaml',
-        ]
-        subs: [
-          [ "ot3-only-otie", "source_location", "48038c4d189536a0862a2c20ed832dc34bd1c8b2" ]
-        ]
     runs-on: "ubuntu-18.04"
-    name: YAML Substitution Sanity Check (${{ matrix.file }})
+    name: YAML Substitution Sanity Check
     steps:
 
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:
-          ref: "main"
-
-      - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@main
-        with:
-          command: setup
-          input-file: ${PWD}/samples/${{ matrix.file }}
-
+          ref: "yaml-sub"
 
       - name: YAML Substitution
-        uses: Opentrons/opentrons-emulation@main
+        uses: ./.github/actions/yaml-sub
         with:
           command: yaml-sub
-          subs: toJson(${{ matrix.subs }})
-          input-file: ${PWD}/samples/${{ matrix.file }}
+          substitutions: >-
+            [
+              ["otie", "source-location", "48038c4d189536a0862a2c20ed832dc34bd1c8b2"],
+              ["otie", "exposed-port", "5000"]
+            ]
+          input-file: ${{ github.workspace }}/samples/ot3/ot3_remote.yaml

--- a/.github/workflows/yaml-sub-sanity-check.yaml
+++ b/.github/workflows/yaml-sub-sanity-check.yaml
@@ -13,7 +13,7 @@ jobs:
           ref: "yaml-sub"
 
       - name: YAML Substitution
-        uses: ./.github/actions/yaml-sub
+        uses: Opentrons/opentrons-emulation@yaml-sub
         with:
           command: yaml-sub
           substitutions: >-

--- a/.github/workflows/yaml-sub-sanity-check.yaml
+++ b/.github/workflows/yaml-sub-sanity-check.yaml
@@ -18,7 +18,6 @@ jobs:
           command: yaml-sub
           substitutions: >-
             [
-              ["otie", "source-location", "48038c4d189536a0862a2c20ed832dc34bd1c8b2"],
               ["otie", "exposed-port", "5000"]
             ]
           input-file: ${{ github.workspace }}/samples/ot3/ot3_remote.yaml

--- a/action.yaml
+++ b/action.yaml
@@ -61,4 +61,4 @@ runs:
       uses: ./.github/actions/yaml-sub
       with:
         input-file: ${{ inputs.input-file }}
-        substitutions: ${{ inputs.subs }}
+        substitutions: ${{ inputs.substitutions }}

--- a/action.yaml
+++ b/action.yaml
@@ -5,10 +5,10 @@ inputs:
   input-file:
     description: 'YAML or JSON system configuration'
     required: true
-  substitution:
+  substitutions:
     description: |
-    List of lists containing substitutions you want to make to the file.
-    In the format of [[service_name, property_to_replace, replacement_value], ...]
+      List of lists containing substitutions you want to make to the file.
+      In the format of [[service_name, property_to_replace, replacement_value], ...]
     required: false
   command:
     description: 'Command to run'
@@ -61,4 +61,4 @@ runs:
       uses: ./.github/actions/yaml-sub
       with:
         input-file: ${{ inputs.input-file }}
-#        substitution: ${{ inputs.subs }}
+        substitutions: ${{ inputs.subs }}

--- a/action.yaml
+++ b/action.yaml
@@ -5,6 +5,11 @@ inputs:
   input-file:
     description: 'YAML or JSON system configuration'
     required: true
+  subs:
+    description: |
+    List of lists containing substitutions you want to make to the file.
+    In the format of [[service_name, property_to_replace, replacement_value], ...]
+    required: false
   command:
     description: 'Command to run'
     required: true
@@ -12,7 +17,7 @@ runs:
   using: "composite"
   steps:
     - name: Validate Command
-      if: ${{ !contains(fromJson('["setup", "setup-break-cache", "run", "teardown"]'), inputs.command)}}
+      if: ${{ !contains(fromJson('["setup", "setup-break-cache", "run", "teardown", "yaml-sub"]'), inputs.command)}}
       run:
         exit 1
       shell: bash
@@ -42,3 +47,11 @@ runs:
       uses: ./.github/actions/teardown
       with:
         input-file: ${{ inputs.input-file }}
+
+
+    - name: YAML Sub
+      if: inputs.command == 'yaml-sub'
+      uses: ./.github/actions/yaml-sub
+      with:
+        input-file: ${{ inputs.input-file }}
+        subs: ${{ inputs.subs }}

--- a/action.yaml
+++ b/action.yaml
@@ -42,7 +42,7 @@ runs:
         input-file: ${{ inputs.input-file }}
 
 
-    - name: Setup Command (Break Cache)
+    - name: Setup Command (Python Only)
       if: inputs.command == 'setup-python-only'
       uses: ./.github/actions/setup-python-only
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -5,7 +5,7 @@ inputs:
   input-file:
     description: 'YAML or JSON system configuration'
     required: true
-  subs:
+  substitution:
     description: |
     List of lists containing substitutions you want to make to the file.
     In the format of [[service_name, property_to_replace, replacement_value], ...]
@@ -17,7 +17,7 @@ runs:
   using: "composite"
   steps:
     - name: Validate Command
-      if: ${{ !contains(fromJson('["setup", "setup-break-cache", "run", "teardown", "yaml-sub"]'), inputs.command)}}
+      if: ${{ !contains(fromJson('["setup", "setup-break-cache", "setup-python-only", "run", "teardown", "yaml-sub"]'), inputs.command)}}
       run:
         exit 1
       shell: bash
@@ -42,6 +42,13 @@ runs:
         input-file: ${{ inputs.input-file }}
 
 
+    - name: Setup Command (Break Cache)
+      if: inputs.command == 'setup-python-only'
+      uses: ./.github/actions/setup-python-only
+      with:
+        input-file: ${{ inputs.input-file }}
+
+
     - name: Teardown Command
       if: inputs.command == 'teardown'
       uses: ./.github/actions/teardown
@@ -54,4 +61,4 @@ runs:
       uses: ./.github/actions/yaml-sub
       with:
         input-file: ${{ inputs.input-file }}
-        subs: ${{ inputs.subs }}
+#        substitution: ${{ inputs.subs }}

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/heater_shaker_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/heater_shaker_module.py
@@ -25,6 +25,9 @@ class HeaterShakerModuleAttributes(HardwareSpecificAttributes):
 
     mode: HeaterShakerModes = HeaterShakerModes.SOCKET
 
+    class Config:  # noqa: D106
+        use_enum_values = True
+
 
 class HeaterShakerModuleSourceRepositories(SourceRepositories):
     """Source repositories for Heater-Shaker."""
@@ -46,7 +49,7 @@ class HeaterShakerModuleInputModel(ModuleInputModel):
 
     hardware: Literal[Hardware.HEATER_SHAKER_MODULE]
     source_repos: HeaterShakerModuleSourceRepositories = Field(
-        default=HeaterShakerModuleSourceRepositories(), const=True
+        default=HeaterShakerModuleSourceRepositories(), const=True, exclude=True
     )
     hardware_specific_attributes: HeaterShakerModuleAttributes = Field(
         alias="hardware-specific-attributes", default=HeaterShakerModuleAttributes()

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/magnetic_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/magnetic_module.py
@@ -49,7 +49,7 @@ class MagneticModuleInputModel(ModuleInputModel):
 
     hardware: Literal[Hardware.MAGNETIC_MODULE]
     source_repos: MagneticModuleSourceRepositories = Field(
-        default=MagneticModuleSourceRepositories(), const=True
+        default=MagneticModuleSourceRepositories(), const=True, exclude=True
     )
     hardware_specific_attributes: MagneticModuleAttributes = Field(
         alias="hardware-specific-attributes", default=MagneticModuleAttributes()

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/temperature_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/temperature_module.py
@@ -50,7 +50,7 @@ class TemperatureModuleInputModel(ModuleInputModel):
 
     hardware: Literal[Hardware.TEMPERATURE_MODULE]
     source_repos: TemperatureModuleSourceRepositories = Field(
-        default=TemperatureModuleSourceRepositories(), const=True
+        default=TemperatureModuleSourceRepositories(), const=True, exclude=True
     )
     hardware_specific_attributes: TemperatureModuleAttributes = Field(
         alias="hardware-specific-attributes", default=TemperatureModuleAttributes()

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/thermocycler_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/thermocycler_module.py
@@ -55,7 +55,7 @@ class ThermocyclerModuleInputModel(ModuleInputModel):
 
     hardware: Literal[Hardware.THERMOCYCLER_MODULE]
     source_repos: ThermocyclerModuleSourceRepositories = Field(
-        default=ThermocyclerModuleSourceRepositories(), const=True
+        default=ThermocyclerModuleSourceRepositories(), const=True, exclude=True
     )
     hardware_specific_attributes: ThermocyclerModuleAttributes = Field(
         alias="hardware-specific-attributes", default=ThermocyclerModuleAttributes()

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot2_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot2_model.py
@@ -40,7 +40,7 @@ class OT2InputModel(RobotInputModel):
 
     hardware: Literal[Hardware.OT2]
     source_repos: OT2SourceRepositories = Field(
-        default=OT2SourceRepositories(), const=True
+        default=OT2SourceRepositories(), const=True, exclude=True
     )
     hardware_specific_attributes: OT2Attributes = Field(
         alias="hardware-specific-attributes", default=OT2Attributes()

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot3_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot3_model.py
@@ -51,7 +51,7 @@ class OT3InputModel(RobotInputModel):
 
     hardware: Literal[Hardware.OT3]
     source_repos: OT3SourceRepositories = Field(
-        default=OT3SourceRepositories(), const=True
+        default=OT3SourceRepositories(), const=True, exclude=True
     )
     can_server_source_type: SourceType = Field(alias="can-server-source-type")
     can_server_source_location: str = Field(alias="can-server-source-location")

--- a/emulation_system/emulation_system/compose_file_creator/utilities/__init__.py
+++ b/emulation_system/emulation_system/compose_file_creator/utilities/__init__.py
@@ -1,0 +1,1 @@
+"""utilities package."""

--- a/emulation_system/emulation_system/compose_file_creator/utilities/substitute_yaml_values.py
+++ b/emulation_system/emulation_system/compose_file_creator/utilities/substitute_yaml_values.py
@@ -50,7 +50,8 @@ class YamlSubstitution:
 def parse_to_subs(args: str) -> List[Substitution]:
     """Parse passed json to a list of Substitution classes."""
     try:
-        parsed_json = json.loads(args)
+        # Stripping literal \n here because it sometimes gets added by Github Actions
+        parsed_json = json.loads(args.replace("\\n", ""))
     except json.decoder.JSONDecodeError:
         raise Exception("Error parsing json passed to subs arg.")
     except Exception:

--- a/emulation_system/emulation_system/compose_file_creator/utilities/substitute_yaml_values.py
+++ b/emulation_system/emulation_system/compose_file_creator/utilities/substitute_yaml_values.py
@@ -1,0 +1,86 @@
+"""Script to perform yaml substitutions to opentrons-emulation config files."""
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from typing import List
+
+import yaml
+from pydantic import parse_obj_as
+from pydantic.utils import deepcopy
+
+from emulation_system.compose_file_creator.input.configuration_file import (
+    SystemConfigurationModel,
+)
+
+
+@dataclass
+class Substitution:
+    """Definition of what to substitute in yaml file."""
+
+    service_name: str
+    value_to_replace: str
+    replacement_value: str
+
+
+@dataclass
+class YamlSubstitution:
+    """Class containing functionality to perform yaml substitutions."""
+
+    raw_string: str
+    subs: List[Substitution]
+
+    def perform_substitution(self) -> SystemConfigurationModel:
+        """Substitute all values in sub and return new model."""
+        system_config = parse_obj_as(
+            SystemConfigurationModel, yaml.safe_load(self.raw_string)
+        )
+
+        copied_model = deepcopy(system_config)
+        for sub in self.subs:
+            setattr(
+                copied_model.get_by_id(sub.service_name),
+                sub.value_to_replace.replace("-", "_"),
+                sub.replacement_value,
+            )
+        return copied_model
+
+
+def parse_to_subs(args: str) -> List[Substitution]:
+    """Parse passed json to a list of Substitution classes."""
+    try:
+        parsed_json = json.loads(args)
+    except json.decoder.JSONDecodeError:
+        raise Exception("Error parsing json passed to subs arg.")
+    except Exception:
+        raise
+    return [Substitution(*sub) for sub in parsed_json]
+
+
+def main() -> SystemConfigurationModel:
+    """Parse cli args and perform substitution."""
+    parser = argparse.ArgumentParser("Substitute yaml values")
+    parser.add_argument(
+        "raw_string",
+        metavar="<yaml_input>",
+        type=argparse.FileType("r"),
+        nargs="?",
+        help="Yaml string to modify",
+        default=sys.stdin,
+    )
+
+    parser.add_argument(
+        "subs",
+        type=parse_to_subs,
+        help="value to replace",
+    )
+
+    args = parser.parse_args(sys.argv[1:])
+    args.raw_string = args.raw_string.read()
+    parsed_yaml = YamlSubstitution(**vars(args))
+    return parsed_yaml.perform_substitution()
+
+
+if __name__ == "__main__":
+    print(yaml.dump(main().dict(by_alias=True)))

--- a/emulation_system/tests/compose_file_creator/utilities/__init__.py
+++ b/emulation_system/tests/compose_file_creator/utilities/__init__.py
@@ -1,0 +1,1 @@
+"""utilities test package."""

--- a/emulation_system/tests/compose_file_creator/utilities/test_substitute_yaml_values.py
+++ b/emulation_system/tests/compose_file_creator/utilities/test_substitute_yaml_values.py
@@ -1,0 +1,49 @@
+"""Test that yaml substitution works."""
+
+import pytest
+import yaml
+
+from emulation_system.compose_file_creator.utilities.substitute_yaml_values import (
+    Substitution,
+    YamlSubstitution,
+)
+
+SUB_LIST = [
+    Substitution("otie", "source-location", "48038c4d189536a0862a2c20ed832dc34bd1c8b2"),
+    Substitution("otie", "exposed-port", "5000"),
+]
+
+
+@pytest.fixture
+def remote_only_ot3() -> str:
+    """Remote only OT-3 for testing."""
+    return yaml.dump(
+        {
+            "robot": {
+                "id": "otie",
+                "hardware": "ot3",
+                "emulation-level": "hardware",
+                "source-type": "remote",
+                "source-location": "latest",
+                "robot-server-source-type": "remote",
+                "robot-server-source-location": "latest",
+                "can-server-source-type": "remote",
+                "can-server-source-location": "latest",
+                "exposed-port": 31950,
+                "hardware-specific-attributes": {},
+            }
+        }
+    )
+
+
+def test_yaml_substitution(remote_only_ot3: str) -> None:
+    """Confirm that yaml substitutions work correctly."""
+    resultant_config_model = YamlSubstitution(
+        remote_only_ot3, SUB_LIST
+    ).perform_substitution()
+    assert resultant_config_model.robot is not None
+    assert (
+        resultant_config_model.robot.source_location
+        == "48038c4d189536a0862a2c20ed832dc34bd1c8b2"
+    )
+    assert resultant_config_model.robot.exposed_port == 5000


### PR DESCRIPTION
# Overview

Add Github action `yaml-sub` to make substitutions to `opentrons-emulation` configuration file

# Changelog

- Factor out Python only setup into `setup-python-only` action
- Add `yaml-sub` action
- Add `yaml-sub-sanity-check.yaml`
- Add `exclude=True` to all source_repo fields so they are not included in export of SystemConfigurationModel
- Fix mode rendering in HeaterShakerModuleInputModel
- Add substitute_yaml_values.py script
- Add tests for above

# Review requests

None

# Risk assessment

Low