### PR TITLE
fix: Custom Pipettes being ignored

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot2_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot2_model.py
@@ -20,12 +20,8 @@ from emulation_system.compose_file_creator.settings.config_file_settings import 
 class OT2Attributes(HardwareSpecificAttributes):
     """Attributes specific to OT2."""
 
-    left_pipette: PipetteSettings = Field(
-        alias="left-pipette", default=PipetteSettings()
-    )
-    right_pipette: PipetteSettings = Field(
-        alias="right-pipette", default=PipetteSettings()
-    )
+    left: PipetteSettings = Field(alias="left-pipette", default=PipetteSettings())
+    right: PipetteSettings = Field(alias="right-pipette", default=PipetteSettings())
 
 
 class OT2SourceRepositories(SourceRepositories):

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot3_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot3_model.py
@@ -28,12 +28,8 @@ from emulation_system.compose_file_creator.settings.config_file_settings import 
 class OT3Attributes(HardwareSpecificAttributes):
     """Attributes specific to OT3."""
 
-    left_pipette: PipetteSettings = Field(
-        alias="left-pipette", default=PipetteSettings()
-    )
-    right_pipette: PipetteSettings = Field(
-        alias="right-pipette", default=PipetteSettings()
-    )
+    left: PipetteSettings = Field(alias="left-pipette", default=PipetteSettings())
+    right: PipetteSettings = Field(alias="right-pipette", default=PipetteSettings())
 
 
 class OT3SourceRepositories(SourceRepositories):

--- a/emulation_system/tests/compose_file_creator/input/hardware_models/robots/test_ot2.py
+++ b/emulation_system/tests/compose_file_creator/input/hardware_models/robots/test_ot2.py
@@ -53,10 +53,10 @@ def test_default_ot2(ot2_default: Dict[str, Any]) -> None:
     assert ot2.source_type == OT2_SOURCE_TYPE
     assert ot2.exposed_port == 5000
     assert ot2.bound_port == 31950
-    assert ot2.hardware_specific_attributes.left_pipette.model == "p20_single_v2.0"
-    assert ot2.hardware_specific_attributes.left_pipette.id == "P20SV202020070101"
-    assert ot2.hardware_specific_attributes.right_pipette.model == "p20_single_v2.0"
-    assert ot2.hardware_specific_attributes.right_pipette.id == "P20SV202020070101"
+    assert ot2.hardware_specific_attributes.left.model == "p20_single_v2.0"
+    assert ot2.hardware_specific_attributes.left.id == "P20SV202020070101"
+    assert ot2.hardware_specific_attributes.right.model == "p20_single_v2.0"
+    assert ot2.hardware_specific_attributes.right.id == "P20SV202020070101"
 
 
 def test_ot2_with_overridden_bound_port(
@@ -70,10 +70,10 @@ def test_ot2_with_overridden_bound_port(
     assert ot2.source_type == OT2_SOURCE_TYPE
     assert ot2.exposed_port == 5000
     assert ot2.bound_port == 2500
-    assert ot2.hardware_specific_attributes.left_pipette.model == "p20_single_v2.0"
-    assert ot2.hardware_specific_attributes.left_pipette.id == "P20SV202020070101"
-    assert ot2.hardware_specific_attributes.right_pipette.model == "p20_single_v2.0"
-    assert ot2.hardware_specific_attributes.right_pipette.id == "P20SV202020070101"
+    assert ot2.hardware_specific_attributes.left.model == "p20_single_v2.0"
+    assert ot2.hardware_specific_attributes.left.id == "P20SV202020070101"
+    assert ot2.hardware_specific_attributes.right.model == "p20_single_v2.0"
+    assert ot2.hardware_specific_attributes.right.id == "P20SV202020070101"
 
 
 def test_ot2_with_custom_pipettes(ot2_with_pipettes: Dict[str, Any]) -> None:
@@ -85,10 +85,10 @@ def test_ot2_with_custom_pipettes(ot2_with_pipettes: Dict[str, Any]) -> None:
     assert ot2.source_type == OT2_SOURCE_TYPE
     assert ot2.exposed_port == 5000
     assert ot2.bound_port == 31950
-    assert ot2.hardware_specific_attributes.left_pipette.model == "test_1"
-    assert ot2.hardware_specific_attributes.left_pipette.id == "test_1_id"
-    assert ot2.hardware_specific_attributes.right_pipette.model == "test_2"
-    assert ot2.hardware_specific_attributes.right_pipette.id == "test_2_id"
+    assert ot2.hardware_specific_attributes.left.model == "test_1"
+    assert ot2.hardware_specific_attributes.left.id == "test_1_id"
+    assert ot2.hardware_specific_attributes.right.model == "test_2"
+    assert ot2.hardware_specific_attributes.right.id == "test_2_id"
 
 
 def test_ot2_with_bad_emulation_level(ot2_bad_emulation_level: Dict[str, Any]) -> None:


### PR DESCRIPTION
When passing custom pipettes to smoothie they were being ignore. 

The custom pipettes were expecting to be called `left` and `right`. They were being called `left-pipette` and `right-pipettes`.

Changed pydantic model so they were exported correctly