### PR TITLE
refactor: Refactor build commands into a single multi-arch command

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -32,5 +32,5 @@ runs:
       shell: bash
 
     - name: Build Emulation Docker Images
-      run: make build-amd64 file_path=${{ inputs.input-file }}
+      run: make build file_path=${{ inputs.input-file }}
       shell: bash

--- a/Makefile
+++ b/Makefile
@@ -23,23 +23,13 @@ COMPOSE_LOGS_COMMAND := docker-compose -f - logs -f
 
 abs_path := $(realpath ${file_path})
 
-.PHONY: build-amd64
-build-amd64:
-	# TODO: Remove tmp file creation when Buildx 0.8.0 is released.
-	# PR: https://github.com/docker/buildx/milestone/11
-	# Ticket: https://github.com/docker/buildx/pull/864
-	$(if $(file_path),@echo "Building system from $(file_path)",$(error file_path variable required))
-	@$(MAKE) --no-print-directory generate-compose-file file_path=${abs_path}  > tmp-compose.yaml && $(COMPOSE_BUILD_COMMAND)
-	@rm tmp-compose.yaml
 
-.PHONY: build-arm64
-build-arm64:
-	# TODO: Remove tmp file creation when Buildx 0.8.0 is released.
-	# PR: https://github.com/docker/buildx/milestone/11
-	# Ticket: https://github.com/docker/buildx/pull/864
+.PHONY: build
+build:
 	$(if $(file_path),@echo "Building system from $(file_path)",$(error file_path variable required))
-	@$(MAKE) --no-print-directory generate-compose-file file_path=${abs_path} > tmp-compose.yaml && $(COMPOSE_BUILD_COMMAND) --set *.platform=linux/x86_64
-	@rm tmp-compose.yaml
+	@$(MAKE) --no-print-directory generate-compose-file file_path=${abs_path} > ~/tmp-compose.yaml
+	./scripts/makefile/helper_scripts/build.sh ~/tmp-compose.yaml
+	@rm ~/tmp-compose.yaml
 
 .PHONY: run
 run:

--- a/README.md
+++ b/README.md
@@ -123,13 +123,11 @@ under the following conditions:
   branch of the source repo
 - If the underlying Dockerfile changes
 
-**Command:** `build-amd64` OR `build-arm64`
+**Command:** `build`
 
-Use `build-amd64` if you are on an Intel based processor.
+**Example:** `make build file_path=./samples/yaml/ot2.yaml`
 
-Use `build-arm64` if you are on a Mac M1 processor.
-
-**Example:** `make build-amd64 file_path=./samples/yaml/ot2.yaml`
+> Note: This repository supports building against `x86_64` and `arm64` type processors
 
 #### Running System
 

--- a/docs/team_specific_setup/CPX_SETUP.md
+++ b/docs/team_specific_setup/CPX_SETUP.md
@@ -14,18 +14,16 @@ a path to your mono repo.
 
 ### Build Docker Images
 
-From the root of the repo run Intel
-`make build-amd64 file_path=./samples/team_specific_setups/cpx_ot2.yaml`
-M1
-`make build-arm64 file_path=./samples/team_specific_setups/cpx_ot2.yaml`
+From the root of the repo run
+`make build file_path=./samples/team_specific_setups/cpx_ot2.yaml`
 
 > This may take 10 or more minutes on initial build.
 
 ### Run Emulation then Build and Start Robot Server
 
 1. From the root of the repo run
-   1. `make em-run-detached file_path=./samples/team_specific_setups/cpx_ot2.yaml`
-   1. `make em-local-rebuild file_path=./samples/team_specific_setups/cpx_ot2.yaml`
+   1. `make run-detached file_path=./samples/team_specific_setups/cpx_ot2.yaml`
+   1. `make local-rebuild file_path=./samples/team_specific_setups/cpx_ot2.yaml`
 
 > Note: This second step is necessary because we bound our monorepo code into the robot-server emulator. It is up to the user to execute the build and run of any containers they have their local source bound into.\*
 

--- a/docs/team_specific_setup/OT3_FIRMWARE_DEVELOPMENT_SETUP.md
+++ b/docs/team_specific_setup/OT3_FIRMWARE_DEVELOPMENT_SETUP.md
@@ -45,8 +45,7 @@ robot:
 From the root of the repo run
 
 ```
-Intel: make build-amd64 file_path=./samples/team_specific_setups/ot3_firmware_development.yaml
-Mac M1: make build-arm64 file_path=./samples/team_specific_setups/ot3_firmware_development.yaml
+make build file_path=./samples/team_specific_setups/ot3_firmware_development.yaml
 ```
 
 > This may take 10 or more minutes on initial build.

--- a/scripts/makefile/helper_scripts/build.sh
+++ b/scripts/makefile/helper_scripts/build.sh
@@ -6,6 +6,9 @@ FILE_PATH=$1
 
 
 if [ "${ARCH}" == "arm64" ]; then
+  # Platform is being set to linux/x86_64 because a requirement of M1 Mac is to use rosetta
+  # Rosetta emulates a x86_64 architecture and then Docker uses that
+  # Docker thinks it should be trying to build against an arm64 arch. So we have to override it.
   docker buildx bake --file ${FILE_PATH} --set *.platform=linux/x86_64
 else
   docker buildx bake --file ${FILE_PATH}

--- a/scripts/makefile/helper_scripts/build.sh
+++ b/scripts/makefile/helper_scripts/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+ARCH=`arch`
+
+FILE_PATH=$1
+
+if [ "${ARCH}" == "x86_64" ]; then
+  docker buildx bake --file ${FILE_PATH}
+elif [ "${ARCH}" == "arm64" ]; then
+  docker buildx bake --file ${FILE_PATH} --set *.platform=linux/x86_64
+else
+  echo "${ARCH} architecture not supported."
+  exit 1
+fi

--- a/scripts/makefile/helper_scripts/build.sh
+++ b/scripts/makefile/helper_scripts/build.sh
@@ -4,11 +4,9 @@ ARCH=`arch`
 
 FILE_PATH=$1
 
-if [ "${ARCH}" == "x86_64" ]; then
-  docker buildx bake --file ${FILE_PATH}
-elif [ "${ARCH}" == "arm64" ]; then
+
+if [ "${ARCH}" == "arm64" ]; then
   docker buildx bake --file ${FILE_PATH} --set *.platform=linux/x86_64
 else
-  echo "${ARCH} architecture not supported."
-  exit 1
+  docker buildx bake --file ${FILE_PATH}
 fi


### PR DESCRIPTION
# Overview

Refactor `build-amd64` and `build-arm64` into single build command. 
Update docs and Github Actions
