### PR TITLE
fix: Change can-comm and can-mon to look at remote and local containers

### DIFF
--- a/emulation_system/emulation_system/commands/load_containers_command.py
+++ b/emulation_system/emulation_system/commands/load_containers_command.py
@@ -28,6 +28,7 @@ class LoadContainersCommand:
 
     input_path: io.TextIOWrapper
     filter: str
+    local_only: bool
     settings: OpentronsEmulationConfiguration
 
     @classmethod
@@ -35,7 +36,12 @@ class LoadContainersCommand:
         cls, args: argparse.Namespace, settings: OpentronsEmulationConfiguration
     ) -> LoadContainersCommand:
         """Construct EmulationSystemCommand from CLI input."""
-        return cls(input_path=args.input_path, filter=args.filter, settings=settings)
+        return cls(
+            input_path=args.input_path,
+            filter=args.filter,
+            local_only=args.local_only,
+            settings=settings,
+        )
 
     def execute(self) -> None:
         """Parse input file, apply filter, and print container names."""
@@ -51,6 +57,8 @@ class LoadContainersCommand:
         print(
             " ".join(
                 cast(str, container.container_name)
-                for container in system.load_containers_by_filter(self.filter, True)
+                for container in system.load_containers_by_filter(
+                    self.filter, self.local_only
+                )
             )
         )

--- a/emulation_system/emulation_system/parsers/load_containers_parser.py
+++ b/emulation_system/emulation_system/parsers/load_containers_parser.py
@@ -18,13 +18,19 @@ class LoadContainersParser(AbstractParser):
     ) -> None:
         """Build parser for "load-containers" command."""
         subparser = parser.add_parser(  # type: ignore
-            "load-local-containers",
+            "load-containers",
             aliases=["lc"],
             formatter_class=get_formatter(),
             help="Load Containers",
         )
 
         subparser.set_defaults(func=LoadContainersCommand.from_cli_input)
+
+        subparser.add_argument(
+            "--local-only",
+            action="store_true",
+            help="Filter to apply.",
+        )
 
         subparser.add_argument(
             "input_path",


### PR DESCRIPTION
# Overview

Fix bug where if can-server was built from a remote source you could not run `can-mon` or `can-comm` Makefile commands against it.

# Changelog

* Rename `load-local-containers ` cli command to `load-containers` and add a --local-only flag
* Add `load-containers` Makefile command
* Refactor `can-comm` and `can-mon` to use `load-containers` instead of `local-load-containers`
* Added `remove-build-run`, `remove-build-run-detached`, and `logs-follow` convenience commands

# Review requests

None

# Risk assessment

Low
