### PR TITLE
feat: Add can server exposed port

### DIFF
--- a/.github/actions/setup-python-only/action.yaml
+++ b/.github/actions/setup-python-only/action.yaml
@@ -26,7 +26,7 @@ runs:
       uses: actions/cache@v2
       with:
         path: "~/.local/share/virtualenvs/**"
-        key: ${{ runner.os }}-pipenv-${{ hashFiles('./emulation_system/Pipfile.lock') }}-${{ hashFiles('./Pipfile.lock') }}-${{ inputs.cache-break }}
+        key: ${{ runner.os }}-pipenv-${{ hashFiles('./emulation_system/Pipfile.lock') }}-${{ hashFiles('./Pipfile.lock') }}-${{ hashFiles('./Makefile') }}-${{ inputs.cache-break }}
 
     - name: Setup repo
       run: |

--- a/.github/workflows/emulation-system-lint-test.yaml
+++ b/.github/workflows/emulation-system-lint-test.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.local/share/virtualenvs/**"
-          key: ${{ runner.os }}-pipenv-${{ hashFiles('./emulation_system/Pipfile.lock') }}-${{ hashFiles('./Pipfile.lock') }}-${{ inputs.cache-break }}
+          key: ${{ runner.os }}-pipenv-${{ hashFiles('./emulation_system/Pipfile.lock') }}-${{ hashFiles('./Pipfile.lock') }}-${{ hashFiles('./Makefile') }}-${{ inputs.cache-break }}
 
       - name: "Setup Project"
         run: |

--- a/.github/workflows/emulation-system-lint-test.yaml
+++ b/.github/workflows/emulation-system-lint-test.yaml
@@ -32,8 +32,6 @@ jobs:
     steps:
       - name: "Checkout Repo"
         uses: 'actions/checkout@v2'
-        with:
-          node-version: '12'
 
       - name: "Setup Python"
         uses: 'actions/setup-python@v2'

--- a/.github/workflows/repo-action-validation.yaml
+++ b/.github/workflows/repo-action-validation.yaml
@@ -18,6 +18,11 @@ on:
       - '.github/actions/**'
       - 'action.yaml'
   workflow_dispatch:
+    inputs:
+      cache-break:
+        description: Break the Cache
+        required: false
+        default: default
 
 jobs:
   opentrons-emulation-sanity-check:
@@ -40,6 +45,7 @@ jobs:
         uses: Opentrons/opentrons-emulation@main
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
+          cache-break: ${{ inputs.cache-break }}
           command: setup
 
       - name: Run Emulation

--- a/.github/workflows/repo-action-validation.yaml
+++ b/.github/workflows/repo-action-validation.yaml
@@ -39,17 +39,17 @@ jobs:
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:
-          ref: "main"
+          ref: "add-can-server-exposed-port"
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@main
+        uses: Opentrons/opentrons-emulation@add-can-server-exposed-port
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           cache-break: ${{ inputs.cache-break }}
           command: setup
 
       - name: Run Emulation
-        uses: Opentrons/opentrons-emulation@main
+        uses: Opentrons/opentrons-emulation@add-can-server-exposed-port
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           command: run
@@ -61,7 +61,7 @@ jobs:
         run: "curl --request GET --header 'opentrons-version: *' http://localhost:31950/modules"
 
       - name: Teardown Emulation
-        uses: Opentrons/opentrons-emulation@main
+        uses: Opentrons/opentrons-emulation@add-can-server-exposed-port
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           command: teardown

--- a/.github/workflows/yaml-sub-sanity-check.yaml
+++ b/.github/workflows/yaml-sub-sanity-check.yaml
@@ -27,10 +27,10 @@ jobs:
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:
-          ref: "main"
+          ref: "add-can-server-exposed-port"
 
       - name: YAML Substitution
-        uses: Opentrons/opentrons-emulation@main
+        uses: Opentrons/opentrons-emulation@add-can-server-exposed-port
         with:
           command: yaml-sub
           substitutions: >-

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,6 @@ SHX := npx shx
 pipenv_opts := --dev
 
 
-include ./scripts/makefile/rebuilding.mk
-
 EMULATION_SYSTEM_DIR := emulation_system
 
 SUB = {SUB}

--- a/action.yaml
+++ b/action.yaml
@@ -16,6 +16,11 @@ inputs:
   command:
     description: 'Command to run'
     required: true
+  cache-break:
+    description: Break the Cache
+    required: false
+    default: default
+
 
 runs:
   using: "composite"
@@ -44,6 +49,7 @@ runs:
       uses: ./.github/actions/setup-break-cache
       with:
         input-file: ${{ inputs.input-file }}
+        cache-break: ${{ inputs.cache-break }}
 
 
     - name: Setup Command (Python Only)
@@ -51,6 +57,7 @@ runs:
       uses: ./.github/actions/setup-python-only
       with:
         input-file: ${{ inputs.input-file }}
+        cache-break: ${{ inputs.cache-break }}
 
 
     - name: Teardown Command

--- a/docs/team_specific_setup/OT3_FIRMWARE_DEVELOPMENT_SETUP.md
+++ b/docs/team_specific_setup/OT3_FIRMWARE_DEVELOPMENT_SETUP.md
@@ -17,11 +17,11 @@ Go into `samples/team_specific_setups/ot3_firmware_development.yaml` and replace
 **_TOP_** level of your repos:
 
 - `robot.source-location` - Absolute path to your `ot3-firmware` repo.
-    - Example: `/home/derek-maggio/Documents/repos/ot3-firmware`
+  - Example: `/home/derek-maggio/Documents/repos/ot3-firmware`
 - `robot.robot-server-source-location` - Absolute path to your `opentrons` repo.
-    - Example: `/home/derek-maggio/Documents/repos/opentrons`
+  - Example: `/home/derek-maggio/Documents/repos/opentrons`
 - `robot.can-server-source-location` - Absolute path to your `opentrons` repo.
-    - Example: `/home/derek-maggio/Documents/repos/opentrons`
+  - Example: `/home/derek-maggio/Documents/repos/opentrons`
 
 Your configuration should look something like the following:
 

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_creation/can_server_creation.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_creation/can_server_creation.py
@@ -106,5 +106,5 @@ def create_can_server_service(
         tty=True,
         networks=required_networks.networks,
         volumes=mounts,
-        ports=ot3.get_can_server_bound_port()
+        ports=ot3.get_can_server_bound_port(),
     )

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_creation/can_server_creation.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_creation/can_server_creation.py
@@ -106,4 +106,5 @@ def create_can_server_service(
         tty=True,
         networks=required_networks.networks,
         volumes=mounts,
+        ports=ot3.get_can_server_bound_port()
     )

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot3_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot3_model.py
@@ -1,7 +1,12 @@
 """OT-3 Module and it's attributes."""
 import os
 import pathlib
-from typing import List
+from typing import (
+    List,
+    Optional,
+    Union,
+    cast,
+)
 
 from pydantic import Field
 from typing_extensions import Literal
@@ -12,6 +17,7 @@ from emulation_system.compose_file_creator.input.hardware_models.hardware_specif
 from emulation_system.compose_file_creator.input.hardware_models.robots.robot_model import (  # noqa: E501
     RobotInputModel,
 )
+from emulation_system.compose_file_creator.output.compose_file_model import Port
 from emulation_system.compose_file_creator.settings.config_file_settings import (
     CAN_SERVER_MOUNT_NAME,
     DirectoryMount,
@@ -57,6 +63,8 @@ class OT3InputModel(RobotInputModel):
     )
     emulation_level: Literal[EmulationLevels.HARDWARE] = Field(alias="emulation-level")
     bound_port: int = Field(alias="bound-port", default=31950)
+    can_server_exposed_port: Optional[int] = Field(alias="can-server-exposed-port")
+    can_server_bound_port: int = Field(alias="can-server-bound-port", default=9898)
 
     def get_can_mount_strings(self) -> List[str]:
         """Get mount strings for can service."""
@@ -74,6 +82,17 @@ class OT3InputModel(RobotInputModel):
             ]
             if self.can_server_source_type == SourceType.LOCAL
             else []
+        )
+
+    def get_can_server_bound_port(self) -> Optional[List[Union[float, str, Port]]]:
+        """Get can server port string."""
+        return (
+            cast(
+                 List[Union[float, str, Port]],
+                 [f"{self.can_server_exposed_port}:{self.can_server_bound_port}"]
+            )
+            if self.can_server_exposed_port is not None
+            else None
         )
 
     @property

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot3_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot3_model.py
@@ -1,12 +1,7 @@
 """OT-3 Module and it's attributes."""
 import os
 import pathlib
-from typing import (
-    List,
-    Optional,
-    Union,
-    cast,
-)
+from typing import List, Optional, Union, cast
 
 from pydantic import Field
 from typing_extensions import Literal
@@ -88,8 +83,8 @@ class OT3InputModel(RobotInputModel):
         """Get can server port string."""
         return (
             cast(
-                 List[Union[float, str, Port]],
-                 [f"{self.can_server_exposed_port}:{self.can_server_bound_port}"]
+                List[Union[float, str, Port]],
+                [f"{self.can_server_exposed_port}:{self.can_server_bound_port}"],
             )
             if self.can_server_exposed_port is not None
             else None

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_conversion_logic.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_conversion_logic.py
@@ -131,6 +131,32 @@ def test_robot_port(robot_with_mount_and_modules_services: Dict[str, Any]) -> No
     assert robot_with_mount_and_modules_services[OT2_ID].ports == ["5000:31950"]
 
 
+def test_can_server_port_exposed(
+    ot3_default: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration
+) -> None:
+    """Confirm that when can-server-exposed-port is specified, ports are added to the can-server"""  # noqa: E501
+    ot3_default["can-server-exposed-port"] = 9898
+    runtime_compose_file_model = convert_from_obj(
+        {"robot": ot3_default}, testing_global_em_config
+    )
+    can_server = runtime_compose_file_model.can_server
+    assert can_server is not None
+    assert can_server.ports is not None
+    assert can_server.ports == ["9898:9898"]
+
+
+def test_can_server_port_not_exposed(
+    ot3_only: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration
+) -> None:
+    """Confirm that when can-server-exposed-port is not specified, ports are not added to the can-server"""  # noqa: E501
+    runtime_compose_file_model = convert_from_obj(ot3_only, testing_global_em_config)
+    can_server = runtime_compose_file_model.can_server
+    assert can_server is not None
+    assert can_server.ports is None
+
+
 @pytest.mark.parametrize(
     "service_name, expected_value",
     [

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_conversion_logic.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_conversion_logic.py
@@ -133,7 +133,7 @@ def test_robot_port(robot_with_mount_and_modules_services: Dict[str, Any]) -> No
 
 def test_can_server_port_exposed(
     ot3_default: Dict[str, Any],
-    testing_global_em_config: OpentronsEmulationConfiguration
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Confirm that when can-server-exposed-port is specified, ports are added to the can-server"""  # noqa: E501
     ot3_default["can-server-exposed-port"] = 9898
@@ -147,8 +147,7 @@ def test_can_server_port_exposed(
 
 
 def test_can_server_port_not_exposed(
-    ot3_only: Dict[str, Any],
-    testing_global_em_config: OpentronsEmulationConfiguration
+    ot3_only: Dict[str, Any], testing_global_em_config: OpentronsEmulationConfiguration
 ) -> None:
     """Confirm that when can-server-exposed-port is not specified, ports are not added to the can-server"""  # noqa: E501
     runtime_compose_file_model = convert_from_obj(ot3_only, testing_global_em_config)

--- a/samples/team_specific_setups/ot3_firmware_development.yaml
+++ b/samples/team_specific_setups/ot3_firmware_development.yaml
@@ -22,3 +22,4 @@ robot:
   can-server-source-location: /home/derek-maggio/Documents/repos/opentrons
   emulation-level: hardware
   exposed-port: 31950
+  can-server-exposed-port: 9898


### PR DESCRIPTION
# Overview

Add ability to expose port to can-server in docker
This is in preparation for running ot3-firmware integration in CI