### PR TITLE
fix: Add handling for if your shell is running inside Rosetta

### DIFF
--- a/.github/workflows/repo-action-validation.yaml
+++ b/.github/workflows/repo-action-validation.yaml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/repo-action-validation.yaml'
       - '.github/actions/**'
       - 'action.yaml'
+      - 'scripts/makefile/helper_scripts/**'
     tags-ignore:
       - '*'
   pull_request:
@@ -17,6 +18,7 @@ on:
       - '.github/workflows/repo-action-validation.yaml'
       - '.github/actions/**'
       - 'action.yaml'
+      - 'scripts/makefile/helper_scripts/**'
   workflow_dispatch:
     inputs:
       cache-break:

--- a/.github/workflows/test-samples-files.yaml
+++ b/.github/workflows/test-samples-files.yaml
@@ -9,6 +9,7 @@ on:
       - 'emulation_system/**'
       - 'samples/**'
       - '.github/workflows/test-samples-files.yaml'
+      - 'scripts/makefile/helper_scripts/**'
     tags-ignore:
       - '*'
 
@@ -17,6 +18,7 @@ on:
       - 'emulation_system/**'
       - 'samples/**'
       - '.github/workflows/test-samples-files.yaml'
+      - 'scripts/makefile/helper_scripts/**'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/yaml-sub-sanity-check.yaml
+++ b/.github/workflows/yaml-sub-sanity-check.yaml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/yaml-sub-sanity-check.yaml'
       - '.github/actions/**'
       - 'action.yaml'
+      - 'scripts/makefile/helper_scripts/**'
     tags-ignore:
       - '*'
   pull_request:
@@ -17,6 +18,7 @@ on:
       - '.github/workflows/yaml-sub-sanity-check.yaml'
       - '.github/actions/**'
       - 'action.yaml'
+      - 'scripts/makefile/helper_scripts/**'
   workflow_dispatch:
 
 jobs:

--- a/scripts/makefile/helper_scripts/build.sh
+++ b/scripts/makefile/helper_scripts/build.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-ARCH=`./scripts/makefile/helper_scripts/get_untranslated_arch.sh`
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+ARCH=`${SCRIPT_DIR}/get_untranslated_arch.sh`
 
 FILE_PATH=$1
 

--- a/scripts/makefile/helper_scripts/build.sh
+++ b/scripts/makefile/helper_scripts/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ARCH=`arch`
+ARCH=`./get_untranslated_arch.sh`
 
 FILE_PATH=$1
 

--- a/scripts/makefile/helper_scripts/build.sh
+++ b/scripts/makefile/helper_scripts/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ARCH=`./get_untranslated_arch.sh`
+ARCH=`./scripts/makefile/helper_scripts/get_untranslated_arch.sh`
 
 FILE_PATH=$1
 
@@ -9,6 +9,7 @@ if [ "${ARCH}" == "arm64" ]; then
   # Platform is being set to linux/x86_64 because a requirement of M1 Mac is to use rosetta
   # Rosetta emulates a x86_64 architecture and then Docker uses that
   # Docker thinks it should be trying to build against an arm64 arch. So we have to override it.
+  echo "On arm64 specifying platform in build command."
   docker buildx bake --file ${FILE_PATH} --set *.platform=linux/x86_64
 else
   docker buildx bake --file ${FILE_PATH}

--- a/scripts/makefile/helper_scripts/get_untranslated_arch.sh
+++ b/scripts/makefile/helper_scripts/get_untranslated_arch.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Have to write this script because Mac M1 is confusing
+# If you are running your shell on a mac in Rosetta, the arch command will return x86_64.
+# This causes problems if you are trying to perform an action based on what the arch command returns
+
+arch_name=$(uname -m)
+os_name=$(uname)
+
+if [ ${os_name} == "Darwin" ] && [ ${arch_name} == "x86_64" ] && [ $(sysctl -in sysctl.proc_translated) == "1" ]; then
+    arch_name="arm64"
+fi
+
+echo ${arch_name}


### PR DESCRIPTION
# Overview

Add script to check if arch has been translated to x86_64

# Review Requests

@y3rsh can you confirm this works for you?

I have confirmed that this works on Linux, and Mac M1 not running the shell in rosetta.
CI will cover the rest