### PR TITLE
refactor(ot3-pipettes): modify path to pipettes simulator

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -56,7 +56,7 @@ case $FULL_COMMAND in
   # and choosing which executeable is sent to which container
   build-common-ot3-firmware)
     build_ot3_firmware_simulators
-    cp /ot3-firmware/build-host/pipettes/simulator/pipettes-simulator /pipettes-simulator
+    cp /ot3-firmware/build-host/pipettes/simulator/pipettes-single-simulator /pipettes-simulator
     cp /ot3-firmware/build-host/head/simulator/head-simulator /head-simulator
     cp /ot3-firmware/build-host/gantry/simulator/gantry-x-simulator /gantry-x-simulator
     cp /ot3-firmware/build-host/gantry/simulator/gantry-y-simulator /gantry-y-simulator
@@ -83,7 +83,7 @@ case $FULL_COMMAND in
 
   build-ot3-pipettes-hardware)
     build_ot3_firmware_simulators
-    cp /ot3-firmware/build-host/pipettes/simulator/pipettes-simulator /pipettes-simulator
+    cp /ot3-firmware/build-host/pipettes/simulator/pipettes-single-simulator /pipettes-simulator
     ;;
 
   build-ot3-bootloader-hardware)


### PR DESCRIPTION
# Overview

The pipettes simulator location has changed since we are now compiling the firmware based on pipette
type.

# Changelog
- change pipettes simulator path in the entrypoint script

# Review requests
Let me know if there is any location I missed, and also whether I now need to bust the cache once this has merged.

# Risk assessment

Low.
