### PR TITLE
feat: Add scheduled runs of hardware tests

### DIFF
--- a/.github/workflows/run-hardware-tests.yaml
+++ b/.github/workflows/run-hardware-tests.yaml
@@ -15,6 +15,9 @@ on:
       - '.github/workflows/run-hardware-tests.yaml'
       - '.github/actions/**'
       - 'action.yaml'
+  schedule:
+    # Running at 1:37 AM, so we don't get delays from so many people running nightly actions at midnight/top of hour
+    - cron: "37 1 * * 1-5"
   workflow_dispatch:
     inputs:
       cache-break:


### PR DESCRIPTION
Add scheduled runs of hardware tests so they run Mon-Friday at 1:37 AM

`Running at 1:37 AM, so we don't get delays from so many people running nightly actions at midnight/top of hour`