### PR TITLE
chore: Add fun status badges

### DIFF
--- a/.github/workflows/emulation-system-lint-test.yaml
+++ b/.github/workflows/emulation-system-lint-test.yaml
@@ -17,6 +17,8 @@ on:
       - 'emulation_system/**'
       - '.github/workflows/emulation-system-lint-test.yaml'
       - './Makefile'
+      - 'docs/**'
+      - 'README.md'
   workflow_dispatch:
     inputs:
       cache-break:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Opentrons Emulation
 
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/Opentrons/opentrons-emulation)
+![GitHub Pipenv locked Python version](https://img.shields.io/github/pipenv/locked/python-version/Opentrons/opentrons-emulation)
+![GitHub](https://img.shields.io/github/license/Opentrons/opentrons-emulation)
+![GitHub repo size](https://img.shields.io/github/repo-size/Opentrons/opentrons-emulation)
+
 Opentrons has various software emulations of their hardware. This repository defines a framework to dynamically connect
 all these emulators together into systems.
 


### PR DESCRIPTION
Add status badges to README. 
Add docs to `emulation-system-lint-test` workflow so the docs can be validated