### PR TITLE
chore: Only send slack message on failure for hardware tests

### DIFF
--- a/.github/workflows/run-hardware-tests.yaml
+++ b/.github/workflows/run-hardware-tests.yaml
@@ -82,7 +82,7 @@ jobs:
           command: teardown
 
       - name: Send results notification
-        if: ${{ always() }}
+        if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.EMULATION_NIGHTLY_TESTING_SLACK_WEBHOOK }}

--- a/.github/workflows/run-hardware-tests.yaml
+++ b/.github/workflows/run-hardware-tests.yaml
@@ -41,45 +41,49 @@ jobs:
         with:
           ref: "main"
 
-      - name: Checkout monorepo
-        uses: actions/checkout@v3
-        with:
-          repository: "Opentrons/opentrons"
-          path: opentrons
+      - name: Cause Failure
+        run: exit 1
+        shell: bash
 
-      - name: Setup Python for opentrons repository
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.7"
-
-      - name: Setup hardware project in opentrons repository
-        run: |
-          pip install pipenv==2022.3.24
-          make setup
-        working-directory: ./opentrons/hardware
-
-      - name: Setup opentrons-emulation project
-        uses: Opentrons/opentrons-emulation@main
-        with:
-          input-file: ${PWD}/samples/ot3/ot3_remote.yaml
-          cache-break: ${{ inputs.cache-break }}
-          command: setup
-
-      - name: Run emulated system
-        uses: Opentrons/opentrons-emulation@main
-        with:
-          input-file: ${PWD}/samples/ot3/ot3_remote.yaml
-          command: run
-
-      - name: Run hardware project integration tests
-        run: make test-with-opentrons-sock-emulator
-        working-directory: ./opentrons/hardware
-
-      - name: Teardown emulation
-        uses: Opentrons/opentrons-emulation@main
-        with:
-          input-file: ${PWD}/samples/ot3/ot3_remote.yaml
-          command: teardown
+      #      - name: Checkout monorepo
+      #        uses: actions/checkout@v3
+      #        with:
+      #          repository: "Opentrons/opentrons"
+      #          path: opentrons
+      #
+      #      - name: Setup Python for opentrons repository
+      #        uses: actions/setup-python@v2
+      #        with:
+      #          python-version: "3.7"
+      #
+      #      - name: Setup hardware project in opentrons repository
+      #        run: |
+      #          pip install pipenv==2022.3.24
+      #          make setup
+      #        working-directory: ./opentrons/hardware
+      #
+      #      - name: Setup opentrons-emulation project
+      #        uses: Opentrons/opentrons-emulation@main
+      #        with:
+      #          input-file: ${PWD}/samples/ot3/ot3_remote.yaml
+      #          cache-break: ${{ inputs.cache-break }}
+      #          command: setup
+      #
+      #      - name: Run emulated system
+      #        uses: Opentrons/opentrons-emulation@main
+      #        with:
+      #          input-file: ${PWD}/samples/ot3/ot3_remote.yaml
+      #          command: run
+      #
+      #      - name: Run hardware project integration tests
+      #        run: make test-with-opentrons-sock-emulator
+      #        working-directory: ./opentrons/hardware
+      #
+      #      - name: Teardown emulation
+      #        uses: Opentrons/opentrons-emulation@main
+      #        with:
+      #          input-file: ${PWD}/samples/ot3/ot3_remote.yaml
+      #          command: teardown
 
       - name: Send results notification
         if: ${{ failure() }}

--- a/.github/workflows/run-hardware-tests.yaml
+++ b/.github/workflows/run-hardware-tests.yaml
@@ -41,49 +41,45 @@ jobs:
         with:
           ref: "main"
 
-      - name: Cause Failure
-        run: exit 1
-        shell: bash
+      - name: Checkout monorepo
+        uses: actions/checkout@v3
+        with:
+          repository: "Opentrons/opentrons"
+          path: opentrons
 
-      #      - name: Checkout monorepo
-      #        uses: actions/checkout@v3
-      #        with:
-      #          repository: "Opentrons/opentrons"
-      #          path: opentrons
-      #
-      #      - name: Setup Python for opentrons repository
-      #        uses: actions/setup-python@v2
-      #        with:
-      #          python-version: "3.7"
-      #
-      #      - name: Setup hardware project in opentrons repository
-      #        run: |
-      #          pip install pipenv==2022.3.24
-      #          make setup
-      #        working-directory: ./opentrons/hardware
-      #
-      #      - name: Setup opentrons-emulation project
-      #        uses: Opentrons/opentrons-emulation@main
-      #        with:
-      #          input-file: ${PWD}/samples/ot3/ot3_remote.yaml
-      #          cache-break: ${{ inputs.cache-break }}
-      #          command: setup
-      #
-      #      - name: Run emulated system
-      #        uses: Opentrons/opentrons-emulation@main
-      #        with:
-      #          input-file: ${PWD}/samples/ot3/ot3_remote.yaml
-      #          command: run
-      #
-      #      - name: Run hardware project integration tests
-      #        run: make test-with-opentrons-sock-emulator
-      #        working-directory: ./opentrons/hardware
-      #
-      #      - name: Teardown emulation
-      #        uses: Opentrons/opentrons-emulation@main
-      #        with:
-      #          input-file: ${PWD}/samples/ot3/ot3_remote.yaml
-      #          command: teardown
+      - name: Setup Python for opentrons repository
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+
+      - name: Setup hardware project in opentrons repository
+        run: |
+          pip install pipenv==2022.3.24
+          make setup
+        working-directory: ./opentrons/hardware
+
+      - name: Setup opentrons-emulation project
+        uses: Opentrons/opentrons-emulation@main
+        with:
+          input-file: ${PWD}/samples/ot3/ot3_remote.yaml
+          cache-break: ${{ inputs.cache-break }}
+          command: setup
+
+      - name: Run emulated system
+        uses: Opentrons/opentrons-emulation@main
+        with:
+          input-file: ${PWD}/samples/ot3/ot3_remote.yaml
+          command: run
+
+      - name: Run hardware project integration tests
+        run: make test-with-opentrons-sock-emulator
+        working-directory: ./opentrons/hardware
+
+      - name: Teardown emulation
+        uses: Opentrons/opentrons-emulation@main
+        with:
+          input-file: ${PWD}/samples/ot3/ot3_remote.yaml
+          command: teardown
 
       - name: Send results notification
         if: ${{ failure() }}


### PR DESCRIPTION
# Overview

Update `run-hardware-tests` Github Action to only send messages on failure. 


https://github.com/Opentrons/opentrons-emulation/pull/151/commits/90c42acec7c237a7ba98f13f85b5e82ae0a18d4c forced a failure to make sure a message was sent.

https://github.com/Opentrons/opentrons-emulation/pull/151/commits/5c2ee65a84beefc85dd183cc1d2ea611d629124a and https://github.com/Opentrons/opentrons-emulation/pull/151/commits/b37abc4865cd4ea7eaa9d5efab68f673a1b49873 prove that the send message step is skipped on success