### PR TITLE
fix: Fix nproc arithmetic that was failing on Mac

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,14 +16,14 @@ if [ "$COMMAND" != "build" ] && [ "$COMMAND" != "run" ] && [ "$COMMAND" != "stop
 fi
 
 build_ot3_firmware_simulators()
-  (cd /ot3-firmware && cmake --preset host-gcc10 && cmake --build --preset=simulators -j $($(nproc) -1))
+  (cd /ot3-firmware && cmake --preset host-gcc10 && cmake --build --preset=simulators -j $(expr $(nproc) - 1))
 
 build_module_simulator() {
-  (cd /opentrons-modules && cmake --preset=stm32-host-gcc10 . && cmake --build ./build-stm32-host -j $($(nproc) -1) --target $1)
+  (cd /opentrons-modules && cmake --preset=stm32-host-gcc10 . && cmake --build ./build-stm32-host -j $(expr $(nproc) - 1) --target $1)
 }
 
 build_ot3_firmware_single_simulator() {
-  (cd /ot3-firmware && cmake --preset host-gcc10 && cmake --build ./build-host -j $($(nproc) -1) --target $1)
+  (cd /ot3-firmware && cmake --preset host-gcc10 && cmake --build ./build-host -j $(expr $(nproc) - 1) --target $1)
 }
 
 kill_process() {


### PR DESCRIPTION
# Overview

nproc arithmetic was not being evaluated correctly on Mac. Fixed it


# Review requests

Run `make build file_path=samples/ot3/ot3_remote.yaml` and `make build file_path=samples/ot2/ot2_with_all_modules.yaml` make sure they complete successfully

- [x] Linux
- [ ] Intel Mac
- [x] M1 Mac

# Risk assessment

Low
