### PR TITLE
feat: Github Container Repository Image Caching

### DIFF
--- a/.github/actions/setup-python-only/action.yaml
+++ b/.github/actions/setup-python-only/action.yaml
@@ -29,9 +29,11 @@ runs:
         path: "~/.local/share/virtualenvs/**"
         key: ${{ runner.os }}-pipenv-${{ hashFiles('./emulation_system/Pipfile.lock') }}-${{ hashFiles('./Pipfile.lock') }}-${{ hashFiles('./Makefile') }}-${{ inputs.cache-break }}
 
+    - name: Install Pipenv
+      run: pip install pipenv==2022.3.24
+      shell: bash
+      
     - name: Setup repo
       if: steps.python-cache.outputs.cache-hit != 'true'
-      run: |
-        pip install pipenv==2022.3.24
-        make setup
+      run: make setup
       shell: bash

--- a/.github/actions/setup-python-only/action.yaml
+++ b/.github/actions/setup-python-only/action.yaml
@@ -24,11 +24,13 @@ runs:
 
     - name: Cache Python Dependencies
       uses: actions/cache@v2
+      id: python-cache
       with:
         path: "~/.local/share/virtualenvs/**"
         key: ${{ runner.os }}-pipenv-${{ hashFiles('./emulation_system/Pipfile.lock') }}-${{ hashFiles('./Pipfile.lock') }}-${{ hashFiles('./Makefile') }}-${{ inputs.cache-break }}
 
     - name: Setup repo
+      if: steps.python-cache.outputs.cache-hit != 'true'
       run: |
         pip install pipenv==2022.3.24
         make setup

--- a/.github/workflows/repo-action-validation.yaml
+++ b/.github/workflows/repo-action-validation.yaml
@@ -38,17 +38,17 @@ jobs:
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:
-          ref: "main"
+          ref: "ghcr-image-caching"
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@main
+        uses: Opentrons/opentrons-emulation@ghcr-image-caching
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           cache-break: ${{ inputs.cache-break }}
           command: setup
 
       - name: Run Emulation
-        uses: Opentrons/opentrons-emulation@main
+        uses: Opentrons/opentrons-emulation@ghcr-image-caching
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           command: run
@@ -60,7 +60,7 @@ jobs:
         run: "curl --request GET --header 'opentrons-version: *' http://localhost:31950/modules"
 
       - name: Teardown Emulation
-        uses: Opentrons/opentrons-emulation@main
+        uses: Opentrons/opentrons-emulation@ghcr-image-caching
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           command: teardown

--- a/.github/workflows/run-hardware-tests.yaml
+++ b/.github/workflows/run-hardware-tests.yaml
@@ -46,9 +46,12 @@ jobs:
         with:
           python-version: "3.7"
 
-      - name: Install Pipenv
-        run: pip install pipenv==2022.3.24
-        shell: bash
+      - name: Setup opentrons-emulation project
+        uses: Opentrons/opentrons-emulation@ghcr-image-caching
+        with:
+          input-file: ${PWD}/samples/ot3/ot3_remote.yaml
+          cache-break: ${{ inputs.cache-break }}
+          command: setup
 
       - name: Cache Python Dependencies
         uses: actions/cache@v2
@@ -61,13 +64,6 @@ jobs:
         if: steps.python-cache.outputs.cache-hit != 'true'
         run: make setup
         working-directory: ./opentrons/hardware
-
-      - name: Setup opentrons-emulation project
-        uses: Opentrons/opentrons-emulation@ghcr-image-caching
-        with:
-          input-file: ${PWD}/samples/ot3/ot3_remote.yaml
-          cache-break: ${{ inputs.cache-break }}
-          command: setup
 
       - name: Run emulated system
         uses: Opentrons/opentrons-emulation@ghcr-image-caching

--- a/.github/workflows/run-hardware-tests.yaml
+++ b/.github/workflows/run-hardware-tests.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout opentrons-emulation repository
         uses: actions/checkout@v3
         with:
-          ref: "main"
+          ref: "ghcr-image-caching"
 
       - name: Checkout monorepo
         uses: actions/checkout@v3
@@ -53,14 +53,14 @@ jobs:
         working-directory: ./opentrons/hardware
 
       - name: Setup opentrons-emulation project
-        uses: Opentrons/opentrons-emulation@main
+        uses: Opentrons/opentrons-emulation@ghcr-image-caching
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           cache-break: ${{ inputs.cache-break }}
           command: setup
 
       - name: Run emulated system
-        uses: Opentrons/opentrons-emulation@main
+        uses: Opentrons/opentrons-emulation@ghcr-image-caching
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           command: run
@@ -70,7 +70,7 @@ jobs:
         working-directory: ./opentrons/hardware
 
       - name: Teardown emulation
-        uses: Opentrons/opentrons-emulation@main
+        uses: Opentrons/opentrons-emulation@ghcr-image-caching
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           command: teardown

--- a/.github/workflows/run-hardware-tests.yaml
+++ b/.github/workflows/run-hardware-tests.yaml
@@ -46,10 +46,20 @@ jobs:
         with:
           python-version: "3.7"
 
+      - name: Install Pipenv
+        run: pip install pipenv==2022.3.24
+        shell: bash
+
+      - name: Cache Python Dependencies
+        uses: actions/cache@v2
+        id: python-cache
+        with:
+          path: "~/.local/share/virtualenvs/**"
+          key: ${{ runner.os }}-${{ hashFiles('./opentrons/hardware/Pipfile.lock') }}-${{ inputs.cache-break }}
+
       - name: Setup hardware project in opentrons repository
-        run: |
-          pip install pipenv==2022.3.24
-          make setup
+        if: steps.python-cache.outputs.cache-hit != 'true'
+        run: make setup
         working-directory: ./opentrons/hardware
 
       - name: Setup opentrons-emulation project

--- a/.github/workflows/upload-docker-image-bases.yaml
+++ b/.github/workflows/upload-docker-image-bases.yaml
@@ -1,0 +1,28 @@
+# Workflow to upload Docker Image Bases to Github Container Registry
+
+name: "Upload Docker Image Bases"
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release-*'
+    paths:
+      - '.github/workflows/upload-docker-image-bases.yaml'
+      - 'docker/bases_Dockerfile'
+      - 'docker/build_bases.sh'
+  workflow_dispatch:
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and push images
+        run: make push-docker-image-bases

--- a/.github/workflows/upload-docker-image-bases.yaml
+++ b/.github/workflows/upload-docker-image-bases.yaml
@@ -11,6 +11,7 @@ on:
       - '.github/workflows/upload-docker-image-bases.yaml'
       - 'docker/bases_Dockerfile'
       - 'docker/build_bases.sh'
+    pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/upload-docker-image-bases.yaml
+++ b/.github/workflows/upload-docker-image-bases.yaml
@@ -11,7 +11,6 @@ on:
       - '.github/workflows/upload-docker-image-bases.yaml'
       - 'docker/bases_Dockerfile'
       - 'docker/build_bases.sh'
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/upload-docker-image-bases.yaml
+++ b/.github/workflows/upload-docker-image-bases.yaml
@@ -25,4 +25,4 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build and push images
-        run: make push-docker-image-bases branch_name="${{ github.ref }}"
+        run: make push-docker-image-bases branch_name="${{ github.ref_name }}"

--- a/.github/workflows/upload-docker-image-bases.yaml
+++ b/.github/workflows/upload-docker-image-bases.yaml
@@ -25,4 +25,4 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build and push images
-        run: make push-docker-image-bases
+        run: make push-docker-image-bases branch_name="${{ github.ref }}"

--- a/.github/workflows/upload-docker-image-bases.yaml
+++ b/.github/workflows/upload-docker-image-bases.yaml
@@ -11,7 +11,7 @@ on:
       - '.github/workflows/upload-docker-image-bases.yaml'
       - 'docker/bases_Dockerfile'
       - 'docker/build_bases.sh'
-    pull_request:
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,11 @@ test-samples:
 
 	@./scripts/makefile/helper_scripts/test_samples.sh
 
+# Pushes image bases to Github Container Registry
+.PHONY: push-docker-image-bases
+push-docker-image-bases:
+	@(cd ./docker && ./build_bases.sh)
+
 ###########################################
 ######## emulation_system Commands ########
 ###########################################

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,8 @@ test-samples:
 # Pushes image bases to Github Container Registry
 .PHONY: push-docker-image-bases
 push-docker-image-bases:
-	@(cd ./docker && ./build_bases.sh)
+	$(if $(branch_name),,$(error branch_name variable required))
+	@(cd ./docker && ./build_bases.sh ${branch_name})
 
 ###########################################
 ######## emulation_system Commands ########

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,123 +1,4 @@
 #############################################################
-#                           BASES                           #
-#############################################################
-
-# The following targets are what final image that the end user will use should be based off of
-
-# ubuntu-base:
-#   * Lowest level build target that all other targets are based off of
-#   * Production targets should be based off of this to keep the images as small as possible
-
-# cpp-base:
-#   * Built on top of ubuntu-base
-#   * Contains common packages that all ot3-firmware and module firmware require
-#   * All firmware Development targets should be based off of this to ensure all packages required for building exist
-
-# python-base:
-#   * Will be built on top of ubuntu-base
-#   * All python level emulators will be based off of python-base
-#   * Will contain all packages needed for building python emulators
-
-###############
-# ubuntu-base #
-###############
-
-FROM ubuntu:20.04 as ubuntu-base
-# Only need to fill out these args, in CI builds to push images to AWS ECR.
-# Don't bother when you are doing manual builds. It will break your cache and your
-# build will take forever
-
-ARG TRIGGER
-ARG BUILD_DATE
-ARG VCS_REF
-ARG VCS_URL
-ARG URL
-ARG VENDOR
-ARG DOCKER_CMD
-ARG DESCRIPTION
-
-LABEL opentrons-emulation.trigger=$TRIGGER
-LABEL opentrons-emulation.build_date=$BUILD_DATE
-LABEL opentrons-emulation.vcs_ref=$VCS_REF
-LABEL opentons-emulation.vcs_url=$VCS_URL
-LABEL opentons-emulation.url=$URL
-LABEL opentons-emulation.vendor=$VENDOR
-LABEL opentons-emulation.docker_cmd=$DOCKER_CMD
-LABEL opentons-emulation.description=$DESCRIPTION
-
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN rm -rf /var/lib/apt/lists/*
-RUN echo "Updating apt" && apt-get update > /dev/null
-RUN apt-get update \
-    && apt-get install \
-       --no-install-recommends \
-       -y \
-      wget \
-      unzip \
-      software-properties-common \
-      build-essential \
-      curl \
-      git \
-      libssl-dev \
-      && rm -rf /var/lib/apt/lists/*
-RUN add-apt-repository ppa:deadsnakes/ppa && \
-    apt-get update && \
-    apt-get install \
-    	--no-install-recommends \
-       	-y \
-    	python3.7
-RUN (cd /usr/bin/ && ln -s /usr/bin/python3.7 python)
-
-
-############
-# cpp-base #
-############
-
-FROM ubuntu-base as cpp-base
-RUN apt-get update && \
-    apt-get install \
-    --no-install-recommends \
-    -y \
-    libgtest-dev \
-    libboost-test-dev \
-    gcc-10 \
-    g++-10 \
-    lsb-release \
-    python3.7-venv \
-    > /dev/null
-
-RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-linux-x86_64.tar.gz && \
-    tar -zxf cmake-3.21.2-linux-x86_64.tar.gz && \
-    rm cmake-3.21.2-linux-x86_64.tar.gz && \
-    mv cmake-3.21.2-linux-x86_64 cmake && \
-    (cd /usr/bin/ && ln -s /cmake/bin/cmake cmake)
-
-###############
-# python-base #
-###############
-
-FROM ubuntu-base as python-base
-
-RUN apt-get update && \
-    apt-get install \
-    --no-install-recommends \
-    -y \
-    pipenv \
-    libudev-dev \
-    libsystemd-dev \
-    python3-dev \
-    pkgconf \
-    libpython3.7-dev \
-    pip
-
-ENV NODE_VERSION 14
-ENV OT_PYTHON "/usr/bin/python3.7"
-
-RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -
-RUN apt-get install -y nodejs && npm install --global yarn
-
-#############################################################
 #                       LOCAL TARGETS                       #
 #############################################################
 
@@ -126,11 +7,11 @@ RUN apt-get install -y nodejs && npm install --global yarn
 # entrypoint.sh should also be bind-mounted in so do not copy it in either
 # Make sure to include the OPENTRONS_HARDWARE env variable
 
-FROM cpp-base as cpp-base-with-rebuild-script
+FROM ghcr.io/opentrons/cpp-base:latest as cpp-base-with-rebuild-script
 COPY rebuild.sh /rebuild.sh
 ENTRYPOINT ["/rebuild.sh"]
 
-FROM python-base as python-base-with-rebuild-script
+FROM ghcr.io/opentrons/python-base:latest as python-bast-with-rebuild-script
 COPY rebuild.sh /rebuild.sh
 ENTRYPOINT ["/rebuild.sh"]
 
@@ -231,14 +112,14 @@ ENV OPENTRONS_HARDWARE "can-server"
 #   * Contains modules source and entrypoint.sh
 
 # opentrons-source:
-#  * Based off of python-base
+#  * Based off of ghcr.io/opentrons/python-base:latest
 #  * Contains opentrons source and entrypoint.sh
 
 #######################
 # ot3-firmware-source #
 #######################
 
-FROM cpp-base as ot3-firmware-source
+FROM ghcr.io/opentrons/cpp-base:latest as ot3-firmware-source
 ARG FIRMWARE_SOURCE_DOWNLOAD_LOCATION
 ADD $FIRMWARE_SOURCE_DOWNLOAD_LOCATION /ot3-firmware.zip
 RUN (cd / &&  \
@@ -251,7 +132,7 @@ RUN (cd / &&  \
 # modules-source #
 ##################
 
-FROM cpp-base as opentrons-modules-source
+FROM ghcr.io/opentrons/cpp-base:latest as opentrons-modules-source
 ARG MODULE_SOURCE_DOWNLOAD_LOCATION
 ADD $MODULE_SOURCE_DOWNLOAD_LOCATION /opentrons-modules.zip
 RUN (cd / &&  \
@@ -263,7 +144,7 @@ RUN (cd / &&  \
 # opentrons-source #
 ####################
 
-FROM python-base as opentrons-source
+FROM ghcr.io/opentrons/python-base:latest as opentrons-source
 ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION
 ADD $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons.zip
 RUN (cd / &&  \
@@ -324,7 +205,7 @@ RUN /entrypoint.sh build
 # Added this firmware-common image because all firmware level emulator images are based off of
 # the opentrons monorepo, it's just a different command that is ran for each.
 
-FROM python-base as firmware-common
+FROM ghcr.io/opentrons/python-base:latest as firmware-common
 RUN mkdir /dist
 COPY --from=python-emulator-builder /dist/* /dist/
 RUN pip install /dist/*
@@ -345,49 +226,49 @@ RUN pip install /dist/*
 # Each Hardware Production Target should copy the executable from the Executable Builder target
 # Each Hardware Production Target should have a corresponding Executable Builder target
 
-FROM ubuntu-base as ot3-pipettes-hardware-remote
+FROM ghcr.io/opentrons/ubuntu-base:latest as ot3-pipettes-hardware-remote
 ENV OPENTRONS_HARDWARE "ot3-pipettes-hardware"
 COPY --from=ot3-firmware-builder /pipettes-simulator /pipettes-simulator
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
 
-FROM ubuntu-base as ot3-head-hardware-remote
+FROM ghcr.io/opentrons/ubuntu-base:latest as ot3-head-hardware-remote
 ENV OPENTRONS_HARDWARE "ot3-head-hardware"
 COPY --from=ot3-firmware-builder /head-simulator /head-simulator
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
 
-FROM ubuntu-base as ot3-gantry-x-hardware-remote
+FROM ghcr.io/opentrons/ubuntu-base:latest as ot3-gantry-x-hardware-remote
 ENV OPENTRONS_HARDWARE "ot3-gantry-x-hardware"
 COPY --from=ot3-firmware-builder /gantry-x-simulator /gantry-x-simulator
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
 
-FROM ubuntu-base as ot3-gantry-y-hardware-remote
+FROM ghcr.io/opentrons/ubuntu-base:latest as ot3-gantry-y-hardware-remote
 ENV OPENTRONS_HARDWARE "ot3-gantry-y-hardware"
 COPY --from=ot3-firmware-builder /gantry-y-simulator /gantry-y-simulator
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
 
-FROM ubuntu-base as ot3-bootloader-hardware-remote
+FROM ghcr.io/opentrons/ubuntu-base:latest as ot3-bootloader-hardware-remote
 ENV OPENTRONS_HARDWARE "ot3-bootloader-hardware"
 COPY --from=ot3-firmware-builder /bootloader-simulator /bootloader-simulator
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
 
-FROM ubuntu-base as ot3-gripper-hardware-remote
+FROM ghcr.io/opentrons/ubuntu-base:latest as ot3-gripper-hardware-remote
 ENV OPENTRONS_HARDWARE "ot3-gripper-hardware"
 COPY --from=ot3-firmware-builder /gripper-simulator /gripper-simulator
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
 
-FROM ubuntu-base as heater-shaker-hardware-remote
+FROM ghcr.io/opentrons/ubuntu-base:latest as heater-shaker-hardware-remote
 ENV OPENTRONS_HARDWARE "heater-shaker-hardware"
 COPY --from=heater-shaker-builder /heater-shaker-simulator /heater-shaker-simulator
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
 
-FROM ubuntu-base as thermocycler-hardware-remote
+FROM ghcr.io/opentrons/ubuntu-base:latest as thermocycler-hardware-remote
 ENV OPENTRONS_HARDWARE "thermocycler-hardware"
 COPY --from=thermocycler-builder /thermocycler-gen2-simulator /thermocycler-gen2-simulator
 COPY entrypoint.sh /entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ FROM ghcr.io/opentrons/cpp-base:latest as cpp-base-with-rebuild-script
 COPY rebuild.sh /rebuild.sh
 ENTRYPOINT ["/rebuild.sh"]
 
-FROM ghcr.io/opentrons/python-base:latest as python-bast-with-rebuild-script
+FROM ghcr.io/opentrons/python-base:latest as python-base-with-rebuild-script
 COPY rebuild.sh /rebuild.sh
 ENTRYPOINT ["/rebuild.sh"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -153,19 +153,6 @@ RUN (cd / &&  \
     mv opentrons* opentrons)
 
 #############################################################
-#                    DEPENDENCY GETTERS                     #
-#############################################################
-
-# The following targets get dependencies for their respective projects
-# To make the most of docker caching only dependencies that do not change often should be cached
-
-FROM ot3-firmware-source as ot3-firmware-dependencies
-RUN (cd /ot3-firmware && cmake --preset=host)
-
-FROM opentrons-modules-source as opentrons-modules-dependencies
-RUN (cd /opentrons-modules && cmake cmake --preset=stm32-host)
-
-#############################################################
 #                    EXECUTABLE BUILDERS                    #
 #############################################################
 
@@ -176,13 +163,11 @@ RUN (cd /opentrons-modules && cmake cmake --preset=stm32-host)
 # Building separately from the Production Target to reduce image size
 
 FROM opentrons-modules-source as heater-shaker-builder
-COPY --from=opentrons-modules-dependencies /opentrons-modules/stm32-tools /opentrons-modules/stm32-tools
 ENV OPENTRONS_HARDWARE "heater-shaker-hardware"
 COPY entrypoint.sh /entrypoint.sh
 RUN /entrypoint.sh build
 
 FROM opentrons-modules-source as thermocycler-builder
-COPY --from=opentrons-modules-dependencies /opentrons-modules/stm32-tools /opentrons-modules/stm32-tools
 ENV OPENTRONS_HARDWARE "thermocycler-hardware"
 COPY entrypoint.sh /entrypoint.sh
 RUN /entrypoint.sh build
@@ -193,7 +178,6 @@ COPY entrypoint.sh /entrypoint.sh
 RUN /entrypoint.sh build
 
 FROM ot3-firmware-source as ot3-firmware-builder
-COPY --from=ot3-firmware-dependencies /ot3-firmware/stm32-tools /ot3-firmware/stm32-tools
 ENV OPENTRONS_HARDWARE "common-ot3-firmware"
 COPY entrypoint.sh /entrypoint.sh
 RUN /entrypoint.sh build

--- a/docker/bases_Dockerfile
+++ b/docker/bases_Dockerfile
@@ -1,0 +1,118 @@
+#############################################################
+#                           BASES                           #
+#############################################################
+
+# The following targets are what final image that the end user will use should be based off of
+
+# ubuntu-base:
+#   * Lowest level build target that all other targets are based off of
+#   * Production targets should be based off of this to keep the images as small as possible
+
+# cpp-base:
+#   * Built on top of ubuntu-base
+#   * Contains common packages that all ot3-firmware and module firmware require
+#   * All firmware Development targets should be based off of this to ensure all packages required for building exist
+
+# python-base:
+#   * Will be built on top of ubuntu-base
+#   * All python level emulators will be based off of python-base
+#   * Will contain all packages needed for building python emulators
+
+###############
+# ubuntu-base #
+###############
+
+FROM ubuntu:20.04 as ubuntu-base
+# Only need to fill out these args, in CI builds to push images to AWS ECR.
+# Don't bother when you are doing manual builds. It will break your cache and your
+# build will take forever
+
+ARG TRIGGER
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VCS_URL
+ARG URL
+ARG VENDOR
+ARG DOCKER_CMD
+ARG DESCRIPTION
+
+LABEL opentrons-emulation.trigger=$TRIGGER
+LABEL opentrons-emulation.build_date=$BUILD_DATE
+LABEL opentrons-emulation.vcs_ref=$VCS_REF
+LABEL opentons-emulation.vcs_url=$VCS_URL
+LABEL opentons-emulation.url=$URL
+LABEL opentons-emulation.vendor=$VENDOR
+LABEL opentons-emulation.docker_cmd=$DOCKER_CMD
+LABEL opentons-emulation.description=$DESCRIPTION
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN rm -rf /var/lib/apt/lists/*
+RUN echo "Updating apt" && apt-get update > /dev/null
+RUN apt-get update \
+    && apt-get install \
+       --no-install-recommends \
+       -y \
+      wget \
+      unzip \
+      software-properties-common \
+      build-essential \
+      curl \
+      git \
+      libssl-dev \
+      && rm -rf /var/lib/apt/lists/*
+RUN add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install \
+    	--no-install-recommends \
+       	-y \
+    	python3.7
+RUN (cd /usr/bin/ && ln -s /usr/bin/python3.7 python)
+
+
+############
+# cpp-base #
+############
+
+FROM ubuntu-base as cpp-base
+RUN apt-get update && \
+    apt-get install \
+    --no-install-recommends \
+    -y \
+    libgtest-dev \
+    libboost-test-dev \
+    gcc-10 \
+    g++-10 \
+    lsb-release \
+    python3.7-venv \
+    > /dev/null
+
+RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-linux-x86_64.tar.gz && \
+    tar -zxf cmake-3.21.2-linux-x86_64.tar.gz && \
+    rm cmake-3.21.2-linux-x86_64.tar.gz && \
+    mv cmake-3.21.2-linux-x86_64 cmake && \
+    (cd /usr/bin/ && ln -s /cmake/bin/cmake cmake)
+
+###############
+# python-base #
+###############
+
+FROM ubuntu-base as python-base
+
+RUN apt-get update && \
+    apt-get install \
+    --no-install-recommends \
+    -y \
+    pipenv \
+    libudev-dev \
+    libsystemd-dev \
+    python3-dev \
+    pkgconf \
+    libpython3.7-dev \
+    pip
+
+ENV NODE_VERSION 14
+ENV OT_PYTHON "/usr/bin/python3.7"
+
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -
+RUN apt-get install -y nodejs && npm install --global yarn

--- a/docker/build_bases.sh
+++ b/docker/build_bases.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+docker buildx build --file ./bases_Dockerfile --target ubuntu-base --push --tag ghcr.io/opentrons/ubuntu-base:latest .
+docker buildx build --file ./bases_Dockerfile --target cpp-base --push --tag ghcr.io/opentrons/cpp-base:latest .
+docker buildx build --file ./bases_Dockerfile --target python-base --push --tag ghcr.io/opentrons/python-base:latest .

--- a/docker/build_bases.sh
+++ b/docker/build_bases.sh
@@ -1,4 +1,49 @@
 #!/usr/bin/env bash
-docker buildx build --file ./bases_Dockerfile --target ubuntu-base --push --tag ghcr.io/opentrons/ubuntu-base:latest .
-docker buildx build --file ./bases_Dockerfile --target cpp-base --push --tag ghcr.io/opentrons/cpp-base:latest .
-docker buildx build --file ./bases_Dockerfile --target python-base --push --tag ghcr.io/opentrons/python-base:latest .
+
+if [ $# -lt 1 ]; then
+  echo "Must provide \"branch_name\""
+  echo "Usage: $(basename "${BASH_SOURCE[0]}") <branch_name>"
+  exit 1
+fi
+
+BRANCH_NAME=$1
+
+if [[ "${BRANCH_NAME}" =~ release-v.* ]]; then
+  docker buildx build \
+  --file ./bases_Dockerfile \
+  --target ubuntu-base \
+  --push \
+  --tag ghcr.io/opentrons/ubuntu-base:latest \
+  --tag ghcr.io/opentrons/ubuntu-base:${BRANCH_NAME} \
+  .
+  docker buildx build \
+  --file ./bases_Dockerfile \
+  --target cpp-base \
+  --push \
+  --tag ghcr.io/opentrons/cpp-base:latest \
+  --tag ghcr.io/opentrons/cpp-base:${BRANCH_NAME} \
+  .
+  docker buildx build \
+  --file ./bases_Dockerfile \
+  --target python-base \
+  --push \
+  --tag ghcr.io/opentrons/python-base:latest \
+  --tag ghcr.io/opentrons/python-base:${BRANCH_NAME} \
+  .
+else
+  docker buildx build \
+  --file ./bases_Dockerfile \
+  --target ubuntu-base \
+  --push \
+  --tag ghcr.io/opentrons/ubuntu-base:latest .
+  docker buildx build \
+  --file ./bases_Dockerfile \
+  --target cpp-base \
+  --push \
+  --tag ghcr.io/opentrons/cpp-base:latest .
+  docker buildx build \
+  --file ./bases_Dockerfile \
+  --target python-base \
+  --push \
+  --tag ghcr.io/opentrons/python-base:latest .
+fi


### PR DESCRIPTION
# Overview

- Cache `ubuntu-base`, `cpp-base`, and `python-base` in Github Container Registry
- Add caching improvements to Github Actions 

# Changelog

- Split Dockerfile into `bases_Dockerfile` and `Dockerfile`
  - `bases_Dockerfile` contains information for building `ubuntu-base`, `cpp-base`, and `python-base`
  - `Dockerfile` contains everything else
- Add `build_bases.sh` script to push bases to Github Container Registry
- Add `upload-docker-image-bases.yaml` which builds and pushes bases to registry on update to `upload-docker-image-bases.yaml`, `bases_Dockerfile`, or `build_bases.sh`
- Add `push-docker-image-bases` Makefile target
- Add caching if statement to setup-python-only action
- Add caching of `hardware` project to `Run Hardware Tests` action

# Review requests

Try to build with this branch and see if it works. Nothing should new should be required.

# Risk assessment

Low