### PR TITLE
fix: Fix load-container-names Makefile Target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ load-container-names:
 
 	$(if $(file_path),,$(error file_path variable required))
 	$(if $(filter),,$(error filter variable required))
-	@(cd ./emulation_system && pipenv run python main.py load-container-names "${abs_path}" "${filter}")
+	@(cd ./emulation_system && pipenv run python main.py lc "${abs_path}" "${filter}")
 
 ###########################################
 ########## OT3 Specific Commands ##########


### PR DESCRIPTION
# Overview

Fix `load-container-names` Makefile Target.
When running `main.py` `load-container-names` is not a valid command. It is either `load-containers` or `lc`


