### PR TITLE
feat: Firmware Level Heater-Shaker Emulation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,6 +57,9 @@ ENV OPENTRONS_HARDWARE "ot3-gripper-hardware"
 FROM python-base-with-rebuild-script as thermocycler-firmware-local
 ENV OPENTRONS_HARDWARE "thermocycler-firmware"
 
+FROM python-base-with-rebuild-script as heater-shaker-firmware-local
+ENV OPENTRONS_HARDWARE "heatershaker-firmware"
+
 FROM python-base-with-rebuild-script as magdeck-firmware-local
 ENV OPENTRONS_HARDWARE "magdeck-firmware"
 
@@ -267,6 +270,11 @@ ENTRYPOINT ["/entrypoint.sh", "run"]
 
 FROM firmware-common as thermocycler-firmware-remote
 ENV OPENTRONS_HARDWARE "thermocycler-firmware"
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh", "run"]
+
+FROM firmware-common as heater-shaker-firmware-remote
+ENV OPENTRONS_HARDWARE "heater-shaker-firmware"
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -128,7 +128,7 @@ case $FULL_COMMAND in
 
   # Firmware Level
 
-  build-thermocycler-firmware|build-magdeck-firmware|build-tempdeck-firmware|build-emulator-proxy|build-robot-server|build-common-firmware|build-smoothie|build-can-server)
+  build-thermocycler-firmware|build-heater-shaker-firmware|build-magdeck-firmware|build-tempdeck-firmware|build-emulator-proxy|build-robot-server|build-common-firmware|build-smoothie|build-can-server)
     pip uninstall --yes /dist/*
     (cd /opentrons/shared-data/python && python3 setup.py bdist_wheel -d /dist/)
     (cd /opentrons/api && python3 setup.py bdist_wheel -d /dist/)
@@ -140,6 +140,10 @@ case $FULL_COMMAND in
 
   run-thermocycler-firmware)
     bash -c "python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator thermocycler $OTHER_ARGS"
+    ;;
+
+  run-heater-shaker-firmware)
+    bash -c "python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator heatershaker $OTHER_ARGS"
     ;;
   run-tempdeck-firmware)
     bash -c "python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator tempdeck $OTHER_ARGS"

--- a/docs/EMULATION_CONFIGURATION_FILE_KEY_DEFINITIONS.md
+++ b/docs/EMULATION_CONFIGURATION_FILE_KEY_DEFINITIONS.md
@@ -3,24 +3,24 @@
 The following paramteters are available for usage in the emulation configuration file.
 
 - [Emulation Configuration File Key Definitions](#emulation-configuration-file-key-definitions)
-  - [Universal Parameters](#universal-parameters)
-    - [ID](#id)
-    - [System Unique ID](#system-unique-id)
-    - [Hardware](#hardware)
-    - [Source Type](#source-type)
-    - [Source Location](#source-location)
-    - [Emulation level](#emulation-level)
-  - [Robot Specific Parameters (OT2 and OT3)](#robot-specific-parameters--ot2-and-ot3-)
-    - [Robot Server Source Type](#robot-server-source-type)
-    - [Robot Server Source Location](#robot-server-source-location)
-    - [Expose Port](#expose-port)
-  - [OT3 Specific Parameters](#ot3-specific-parameters)
-    - [CAN Server Source Type](#can-server-source-type)
-    - [CAN Server Source Location](#can-server-source-location)
-  - [Hardware Specific Attributes](#hardware-specific-attributes)
-    - [Pipettes](#pipettes)
-      - [Available Pipette Models:](#available-pipette-models-)
-    - [Temperature Model for Thermocycler and Temperature Modules](#temperature-model-for-thermocycler-and-temperature-modules)
+    - [Universal Parameters](#universal-parameters)
+        - [ID](#id)
+        - [System Unique ID](#system-unique-id)
+        - [Hardware](#hardware)
+        - [Source Type](#source-type)
+        - [Source Location](#source-location)
+        - [Emulation level](#emulation-level)
+    - [Robot Specific Parameters (OT2 and OT3)](#robot-specific-parameters--ot2-and-ot3-)
+        - [Robot Server Source Type](#robot-server-source-type)
+        - [Robot Server Source Location](#robot-server-source-location)
+        - [Expose Port](#expose-port)
+    - [OT3 Specific Parameters](#ot3-specific-parameters)
+        - [CAN Server Source Type](#can-server-source-type)
+        - [CAN Server Source Location](#can-server-source-location)
+    - [Hardware Specific Attributes](#hardware-specific-attributes)
+        - [Pipettes](#pipettes)
+            - [Available Pipette Models:](#available-pipette-models-)
+        - [Temperature Model for Thermocycler and Temperature Modules](#temperature-model-for-thermocycler-and-temperature-modules)
 
 ## Universal Parameters
 
@@ -107,10 +107,10 @@ The various emulators in this repository support different levels of emulation b
 table with the supported levels for each emulator.
 
 | Hardware                 | Firmware Emulation | Hardware Emulation         |
-| ------------------------ | ------------------ | -------------------------- |
+| ------------------------ |--------------------| -------------------------- |
 | **OT2**                  | Yes                | No                         |
 | **OT3**                  | No                 | Yes                        |
-| **Heater-Shaker Module** | No                 | Yes                        |
+| **Heater-Shaker Module** | Yes                | Yes                        |
 | **Thermocycler Module**  | Yes                | Yes (Thermocycler Refresh) |
 | **Magnetic Module**      | Yes                | No                         |
 | **Temperature Module**   | Yes                | No                         |

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/heater_shaker_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/heater_shaker_module.py
@@ -8,6 +8,7 @@ from emulation_system.compose_file_creator.input.hardware_models.hardware_specif
     HardwareSpecificAttributes,
 )
 from emulation_system.compose_file_creator.input.hardware_models.modules.module_model import (  # noqa: E501
+    FirmwareSerialNumberModel,
     ModuleInputModel,
     ProxyInfoModel,
 )
@@ -16,7 +17,9 @@ from emulation_system.compose_file_creator.settings.config_file_settings import 
     Hardware,
     HeaterShakerModes,
     OpentronsRepository,
+    RPMModelSettings,
     SourceRepositories,
+    TemperatureModelSettings,
 )
 
 
@@ -24,6 +27,8 @@ class HeaterShakerModuleAttributes(HardwareSpecificAttributes):
     """Attributes specific to Heater Shaker Module."""
 
     mode: HeaterShakerModes = HeaterShakerModes.SOCKET
+    temperature: TemperatureModelSettings = Field(default=TemperatureModelSettings())
+    rpm: RPMModelSettings = Field(default=RPMModelSettings())
 
     class Config:  # noqa: D106
         use_enum_values = True
@@ -32,7 +37,7 @@ class HeaterShakerModuleAttributes(HardwareSpecificAttributes):
 class HeaterShakerModuleSourceRepositories(SourceRepositories):
     """Source repositories for Heater-Shaker."""
 
-    firmware_repo_name: Literal[None] = None
+    firmware_repo_name: OpentronsRepository = OpentronsRepository.OPENTRONS
     hardware_repo_name: OpentronsRepository = OpentronsRepository.OPENTRONS_MODULES
 
 
@@ -40,7 +45,11 @@ class HeaterShakerModuleInputModel(ModuleInputModel):
     """Model for Heater Shaker Module."""
 
     # Not defined because Heater Shaker does not have a firmware level implementation
-    firmware_serial_number_info: ClassVar[Literal[None]] = None
+    firmware_serial_number_info: ClassVar[
+        FirmwareSerialNumberModel
+    ] = FirmwareSerialNumberModel(
+        model="v01", version="v0.0.1", env_var_name="OT_EMULATOR_heatershaker"
+    )
     proxy_info: ClassVar[ProxyInfoModel] = ProxyInfoModel(
         env_var_name="OT_EMULATOR_heatershaker_proxy",
         emulator_port=10004,
@@ -54,7 +63,9 @@ class HeaterShakerModuleInputModel(ModuleInputModel):
     hardware_specific_attributes: HeaterShakerModuleAttributes = Field(
         alias="hardware-specific-attributes", default=HeaterShakerModuleAttributes()
     )
-    emulation_level: Literal[EmulationLevels.HARDWARE] = Field(alias="emulation-level")
+    emulation_level: Literal[
+        EmulationLevels.HARDWARE, EmulationLevels.FIRMWARE
+    ] = Field(alias="emulation-level")
 
     def get_hardware_level_command(
         self, emulator_proxy_name: str
@@ -64,3 +75,9 @@ class HeaterShakerModuleInputModel(ModuleInputModel):
             "--socket",
             f"http://{emulator_proxy_name}:{self.proxy_info.emulator_port}",
         ]
+
+    def get_firmware_level_command(
+        self, emulator_proxy_name: str
+    ) -> Optional[List[str]]:
+        """Get command for module when it is being emulated at hardware level."""
+        return [emulator_proxy_name]

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
@@ -56,7 +56,11 @@ class ModuleInputModel(HardwareModel):
             "version": self.firmware_serial_number_info.version,
         }
 
-        if self.hardware in [Hardware.THERMOCYCLER_MODULE, Hardware.TEMPERATURE_MODULE]:
+        if self.hardware in [
+            Hardware.THERMOCYCLER_MODULE,
+            Hardware.TEMPERATURE_MODULE,
+            Hardware.HEATER_SHAKER_MODULE,
+        ]:
             value.update(self.hardware_specific_attributes.dict())
 
         return {self.firmware_serial_number_info.env_var_name: json.dumps(value)}

--- a/emulation_system/emulation_system/compose_file_creator/settings/config_file_settings.py
+++ b/emulation_system/emulation_system/compose_file_creator/settings/config_file_settings.py
@@ -71,6 +71,13 @@ class TemperatureModelSettings(BaseModel):
     starting: float = float(ROOM_TEMPERATURE)
 
 
+class RPMModelSettings(BaseModel):
+    """RPM behavior model."""
+
+    rpm_per_tick: float = Field(alias="rpm-per-tick", default=100.0)
+    starting: float = 0.0
+
+
 class PipetteSettings(BaseModel):
     """Pipette defintions for OT-2 and OT-3."""
 

--- a/emulation_system/emulation_system/compose_file_creator/settings/images.py
+++ b/emulation_system/emulation_system/compose_file_creator/settings/images.py
@@ -37,9 +37,9 @@ class Images(BaseModel):
 class HeaterShakerModuleImages(Images):
     """Image names for Heater-Shaker."""
 
-    local_firmware_image_name: Literal[None] = None
+    local_firmware_image_name: str = "heater-shaker-firmware-local"
     local_hardware_image_name: str = "heater-shaker-hardware-local"
-    remote_firmware_image_name: Literal[None] = None
+    remote_firmware_image_name: str = "heater-shaker-firmware-remote"
     remote_hardware_image_name: str = "heater-shaker-hardware-remote"
 
 

--- a/emulation_system/tests/compose_file_creator/input/hardware_models/modules/test_heater_shaker_module.py
+++ b/emulation_system/tests/compose_file_creator/input/hardware_models/modules/test_heater_shaker_module.py
@@ -2,7 +2,7 @@
 from typing import Any, Dict
 
 import pytest
-from pydantic import ValidationError, parse_obj_as
+from pydantic import parse_obj_as
 
 from emulation_system.compose_file_creator.input.hardware_models import (
     HeaterShakerModuleInputModel,
@@ -62,20 +62,10 @@ def test_heater_shaker_with_stdin(
     assert hs.hardware_specific_attributes.mode == HeaterShakerModes.STDIN
 
 
-def test_heater_shaker_with_bad_emulation_level(
-    heater_shaker_module_bad_emulation_level: Dict[str, Any]
-) -> None:
-    """Confirm that there is a validation error when a bad emulation level is passed."""
-    with pytest.raises(ValidationError):
-        parse_obj_as(
-            HeaterShakerModuleInputModel, heater_shaker_module_bad_emulation_level
-        )
-
-
 def test_heater_shaker_source_repos(
     heater_shaker_module_default: Dict[str, Any]
 ) -> None:
     """Confirm that defined source repos are correct."""
     hs = parse_obj_as(HeaterShakerModuleInputModel, heater_shaker_module_default)
-    assert hs.source_repos.firmware_repo_name is None
+    assert hs.source_repos.firmware_repo_name == OpentronsRepository.OPENTRONS
     assert hs.source_repos.hardware_repo_name == OpentronsRepository.OPENTRONS_MODULES

--- a/emulation_system/tests/compose_file_creator/input/hardware_models/test_hardware_model.py
+++ b/emulation_system/tests/compose_file_creator/input/hardware_models/test_hardware_model.py
@@ -72,13 +72,13 @@ CONFIGURATIONS = [
         Hardware.HEATER_SHAKER_MODULE,
         EmulationLevels.FIRMWARE,
         SourceType.LOCAL,
-        None,
+        "heater-shaker-firmware-local",
     ],
     [
         Hardware.HEATER_SHAKER_MODULE,
         EmulationLevels.FIRMWARE,
         SourceType.REMOTE,
-        None,
+        "heater-shaker-firmware-remote",
     ],
     # Temperature Module
     [


### PR DESCRIPTION
# Overview

Enable opentrons-emulation to build and run the Heater-Shaker Firmware Emulator added in [this PR](https://github.com/Opentrons/opentrons/pull/11207)

# Changelog

- Add `heater-shaker-firmware-remote` and `heater-shaker-firmware-local` docker images
- Modify HeaterShakerModuleInputModel to support firmware images
- Add run commands to entrypoint
- Update README


# Review requests

None

# Risk assessment

