### PR TITLE
chore: Update GitHub Actions OS to Ubuntu 20.04

### DIFF
--- a/.github/workflows/emulation-system-lint-test.yaml
+++ b/.github/workflows/emulation-system-lint-test.yaml
@@ -28,7 +28,7 @@ defaults:
 jobs:
   lint-test:
     name: 'emulation-system linting and tests'
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-20.04'
     steps:
       - name: Checkout opentrons-emulation repository
         uses: actions/checkout@v3

--- a/.github/workflows/repo-action-validation.yaml
+++ b/.github/workflows/repo-action-validation.yaml
@@ -31,7 +31,7 @@ jobs:
           'ot2/ot2_with_all_modules.yaml',
           'ot3/ot3_remote.yaml',
         ]
-    runs-on: "ubuntu-18.04"
+    runs-on: "ubuntu-20.04"
     name: Opentrons Emulation Sanity Check (${{ matrix.file }})
     steps:
 

--- a/.github/workflows/run-hardware-tests.yaml
+++ b/.github/workflows/run-hardware-tests.yaml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   run-hardware-tests:
-    runs-on: "ubuntu-18.04"
+    runs-on: "ubuntu-20.04"
     name: Run Hardware Tests
     steps:
 

--- a/.github/workflows/test-samples-files.yaml
+++ b/.github/workflows/test-samples-files.yaml
@@ -26,7 +26,7 @@ defaults:
 jobs:
   lint-test:
     name: 'Run All Sample Files'
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-20.04'
     steps:
       - name: "Checkout Repo"
         uses: 'actions/checkout@v2'

--- a/.github/workflows/yaml-sub-sanity-check.yaml
+++ b/.github/workflows/yaml-sub-sanity-check.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   yaml-sub-sanity-check:
-    runs-on: "ubuntu-18.04"
+    runs-on: "ubuntu-20.04"
     name: YAML Substitution Sanity Check
     steps:
       - name: Checkout opentrons-emulation


### PR DESCRIPTION
# Overview

chore: Update GitHub Actions OS to Ubuntu 20.04

# Notes

- The failing hardware tests have nothing to do with upgrading to 20.04. They are the same failures as before upgrading