### PR TITLE
chore: Revert release-v2.3.3 due to Github Action Issues

### DIFF
--- a/.github/workflows/emulation-system-lint-test.yaml
+++ b/.github/workflows/emulation-system-lint-test.yaml
@@ -28,15 +28,15 @@ defaults:
 jobs:
   lint-test:
     name: 'emulation-system linting and tests'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-18.04'
     steps:
       - name: Checkout opentrons-emulation repository
         uses: actions/checkout@v3
         with:
-          ref: "release-v2.3.3"
+          ref: "release-v2.3.2"
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@release-v2.3.3
+        uses: Opentrons/opentrons-emulation@release-v2.3.2
         with:
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup-python-only

--- a/.github/workflows/repo-action-validation.yaml
+++ b/.github/workflows/repo-action-validation.yaml
@@ -31,24 +31,24 @@ jobs:
           'ot2/ot2_with_all_modules.yaml',
           'ot3/ot3_remote.yaml',
         ]
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-18.04"
     name: Opentrons Emulation Sanity Check (${{ matrix.file }})
     steps:
 
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:
-          ref: "release-v2.3.3"
+          ref: "release-v2.3.2"
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@release-v2.3.3
+        uses: Opentrons/opentrons-emulation@release-v2.3.2
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup
 
       - name: Run Emulation
-        uses: Opentrons/opentrons-emulation@release-v2.3.3
+        uses: Opentrons/opentrons-emulation@release-v2.3.2
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           command: run
@@ -60,7 +60,7 @@ jobs:
         run: "curl --request GET --header 'opentrons-version: *' http://localhost:31950/modules"
 
       - name: Teardown Emulation
-        uses: Opentrons/opentrons-emulation@release-v2.3.3
+        uses: Opentrons/opentrons-emulation@release-v2.3.2
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           command: teardown

--- a/.github/workflows/run-hardware-tests.yaml
+++ b/.github/workflows/run-hardware-tests.yaml
@@ -26,14 +26,14 @@ on:
 
 jobs:
   run-hardware-tests:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-18.04"
     name: Run Hardware Tests
     steps:
 
       - name: Checkout opentrons-emulation repository
         uses: actions/checkout@v3
         with:
-          ref: "release-v2.3.3"
+          ref: "release-v2.3.2"
 
       - name: Checkout monorepo
         uses: actions/checkout@v3
@@ -49,7 +49,7 @@ jobs:
           cache-dependency-path: ./opentrons/hardware/Pipfile.lock
 
       - name: Setup opentrons-emulation project
-        uses: Opentrons/opentrons-emulation@release-v2.3.3
+        uses: Opentrons/opentrons-emulation@release-v2.3.2
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           cache-break: ${{ github.event.inputs.cache-break }}
@@ -60,7 +60,7 @@ jobs:
         working-directory: ./opentrons/hardware
 
       - name: Run emulated system
-        uses: Opentrons/opentrons-emulation@release-v2.3.3
+        uses: Opentrons/opentrons-emulation@release-v2.3.2
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           command: run
@@ -70,7 +70,7 @@ jobs:
         working-directory: ./opentrons/hardware
 
       - name: Teardown emulation
-        uses: Opentrons/opentrons-emulation@release-v2.3.3
+        uses: Opentrons/opentrons-emulation@release-v2.3.2
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           command: teardown

--- a/.github/workflows/test-samples-files.yaml
+++ b/.github/workflows/test-samples-files.yaml
@@ -26,7 +26,7 @@ defaults:
 jobs:
   lint-test:
     name: 'Run All Sample Files'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-18.04'
     steps:
       - name: "Checkout Repo"
         uses: 'actions/checkout@v2'

--- a/.github/workflows/yaml-sub-sanity-check.yaml
+++ b/.github/workflows/yaml-sub-sanity-check.yaml
@@ -25,22 +25,22 @@ on:
 
 jobs:
   yaml-sub-sanity-check:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-18.04"
     name: YAML Substitution Sanity Check
     steps:
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:
-          ref: "release-v2.3.3"
+          ref: "release-v2.3.2"
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@release-v2.3.3
+        uses: Opentrons/opentrons-emulation@release-v2.3.2
         with:
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup-python-only
 
       - name: YAML Substitution
-        uses: Opentrons/opentrons-emulation@release-v2.3.3
+        uses: Opentrons/opentrons-emulation@release-v2.3.2
         with:
           command: yaml-sub
           substitutions: >-

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ load-container-names:
 
 	$(if $(file_path),,$(error file_path variable required))
 	$(if $(filter),,$(error filter variable required))
-	@(cd ./emulation_system && pipenv run python main.py lc "${abs_path}" "${filter}")
+	@(cd ./emulation_system && pipenv run python main.py load-container-names "${abs_path}" "${filter}")
 
 ###########################################
 ########## OT3 Specific Commands ##########

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,9 +57,6 @@ ENV OPENTRONS_HARDWARE "ot3-gripper-hardware"
 FROM python-base-with-rebuild-script as thermocycler-firmware-local
 ENV OPENTRONS_HARDWARE "thermocycler-firmware"
 
-FROM python-base-with-rebuild-script as heater-shaker-firmware-local
-ENV OPENTRONS_HARDWARE "heatershaker-firmware"
-
 FROM python-base-with-rebuild-script as magdeck-firmware-local
 ENV OPENTRONS_HARDWARE "magdeck-firmware"
 
@@ -270,11 +267,6 @@ ENTRYPOINT ["/entrypoint.sh", "run"]
 
 FROM firmware-common as thermocycler-firmware-remote
 ENV OPENTRONS_HARDWARE "thermocycler-firmware"
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-FROM firmware-common as heater-shaker-firmware-remote
-ENV OPENTRONS_HARDWARE "heater-shaker-firmware"
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh", "run"]
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -128,7 +128,7 @@ case $FULL_COMMAND in
 
   # Firmware Level
 
-  build-thermocycler-firmware|build-heater-shaker-firmware|build-magdeck-firmware|build-tempdeck-firmware|build-emulator-proxy|build-robot-server|build-common-firmware|build-smoothie|build-can-server)
+  build-thermocycler-firmware|build-magdeck-firmware|build-tempdeck-firmware|build-emulator-proxy|build-robot-server|build-common-firmware|build-smoothie|build-can-server)
     pip uninstall --yes /dist/*
     (cd /opentrons/shared-data/python && python3 setup.py bdist_wheel -d /dist/)
     (cd /opentrons/api && python3 setup.py bdist_wheel -d /dist/)
@@ -140,10 +140,6 @@ case $FULL_COMMAND in
 
   run-thermocycler-firmware)
     bash -c "python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator thermocycler $OTHER_ARGS"
-    ;;
-
-  run-heater-shaker-firmware)
-    bash -c "python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator heatershaker $OTHER_ARGS"
     ;;
   run-tempdeck-firmware)
     bash -c "python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator tempdeck $OTHER_ARGS"

--- a/docs/EMULATION_CONFIGURATION_FILE_KEY_DEFINITIONS.md
+++ b/docs/EMULATION_CONFIGURATION_FILE_KEY_DEFINITIONS.md
@@ -110,7 +110,7 @@ table with the supported levels for each emulator.
 | ------------------------ | ------------------ | -------------------------- |
 | **OT2**                  | Yes                | No                         |
 | **OT3**                  | No                 | Yes                        |
-| **Heater-Shaker Module** | Yes                | Yes                        |
+| **Heater-Shaker Module** | No                 | Yes                        |
 | **Thermocycler Module**  | Yes                | Yes (Thermocycler Refresh) |
 | **Magnetic Module**      | Yes                | No                         |
 | **Temperature Module**   | Yes                | No                         |

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,20 +1,5 @@
 # Opentrons Emulation Release Notes
 
-## v2.3.3 (2022-08-12)
-
-### Bug Fixes
-
-- Fix load-container-names Makefile command [\[PR #172\]](https://github.com/Opentrons/opentrons-emulation/pull/172)
-
-### Features
-
-- Firmware Level Heater-Shaker Emulation [\[PR #173\]](https://github.com/Opentrons/opentrons-emulation/pull/173)
-
-### Chores
-
-- Update Github Action OS's from Ubuntu 18.04 to Ubuntu
-  20.04 [\[PR #175\]](https://github.com/Opentrons/opentrons-emulation/pull/175)
-
 ## v2.3.2 (2022-07-08)
 
 ### Bug Fixes

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/heater_shaker_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/heater_shaker_module.py
@@ -8,7 +8,6 @@ from emulation_system.compose_file_creator.input.hardware_models.hardware_specif
     HardwareSpecificAttributes,
 )
 from emulation_system.compose_file_creator.input.hardware_models.modules.module_model import (  # noqa: E501
-    FirmwareSerialNumberModel,
     ModuleInputModel,
     ProxyInfoModel,
 )
@@ -17,9 +16,7 @@ from emulation_system.compose_file_creator.settings.config_file_settings import 
     Hardware,
     HeaterShakerModes,
     OpentronsRepository,
-    RPMModelSettings,
     SourceRepositories,
-    TemperatureModelSettings,
 )
 
 
@@ -27,8 +24,6 @@ class HeaterShakerModuleAttributes(HardwareSpecificAttributes):
     """Attributes specific to Heater Shaker Module."""
 
     mode: HeaterShakerModes = HeaterShakerModes.SOCKET
-    temperature: TemperatureModelSettings = Field(default=TemperatureModelSettings())
-    rpm: RPMModelSettings = Field(default=RPMModelSettings())
 
     class Config:  # noqa: D106
         use_enum_values = True
@@ -37,7 +32,7 @@ class HeaterShakerModuleAttributes(HardwareSpecificAttributes):
 class HeaterShakerModuleSourceRepositories(SourceRepositories):
     """Source repositories for Heater-Shaker."""
 
-    firmware_repo_name: OpentronsRepository = OpentronsRepository.OPENTRONS
+    firmware_repo_name: Literal[None] = None
     hardware_repo_name: OpentronsRepository = OpentronsRepository.OPENTRONS_MODULES
 
 
@@ -45,11 +40,7 @@ class HeaterShakerModuleInputModel(ModuleInputModel):
     """Model for Heater Shaker Module."""
 
     # Not defined because Heater Shaker does not have a firmware level implementation
-    firmware_serial_number_info: ClassVar[
-        FirmwareSerialNumberModel
-    ] = FirmwareSerialNumberModel(
-        model="v01", version="v0.0.1", env_var_name="OT_EMULATOR_heatershaker"
-    )
+    firmware_serial_number_info: ClassVar[Literal[None]] = None
     proxy_info: ClassVar[ProxyInfoModel] = ProxyInfoModel(
         env_var_name="OT_EMULATOR_heatershaker_proxy",
         emulator_port=10004,
@@ -63,9 +54,7 @@ class HeaterShakerModuleInputModel(ModuleInputModel):
     hardware_specific_attributes: HeaterShakerModuleAttributes = Field(
         alias="hardware-specific-attributes", default=HeaterShakerModuleAttributes()
     )
-    emulation_level: Literal[
-        EmulationLevels.HARDWARE, EmulationLevels.FIRMWARE
-    ] = Field(alias="emulation-level")
+    emulation_level: Literal[EmulationLevels.HARDWARE] = Field(alias="emulation-level")
 
     def get_hardware_level_command(
         self, emulator_proxy_name: str
@@ -75,9 +64,3 @@ class HeaterShakerModuleInputModel(ModuleInputModel):
             "--socket",
             f"http://{emulator_proxy_name}:{self.proxy_info.emulator_port}",
         ]
-
-    def get_firmware_level_command(
-        self, emulator_proxy_name: str
-    ) -> Optional[List[str]]:
-        """Get command for module when it is being emulated at hardware level."""
-        return [emulator_proxy_name]

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
@@ -56,11 +56,7 @@ class ModuleInputModel(HardwareModel):
             "version": self.firmware_serial_number_info.version,
         }
 
-        if self.hardware in [
-            Hardware.THERMOCYCLER_MODULE,
-            Hardware.TEMPERATURE_MODULE,
-            Hardware.HEATER_SHAKER_MODULE,
-        ]:
+        if self.hardware in [Hardware.THERMOCYCLER_MODULE, Hardware.TEMPERATURE_MODULE]:
             value.update(self.hardware_specific_attributes.dict())
 
         return {self.firmware_serial_number_info.env_var_name: json.dumps(value)}

--- a/emulation_system/emulation_system/compose_file_creator/settings/config_file_settings.py
+++ b/emulation_system/emulation_system/compose_file_creator/settings/config_file_settings.py
@@ -71,13 +71,6 @@ class TemperatureModelSettings(BaseModel):
     starting: float = float(ROOM_TEMPERATURE)
 
 
-class RPMModelSettings(BaseModel):
-    """RPM behavior model."""
-
-    rpm_per_tick: float = Field(alias="rpm-per-tick", default=100.0)
-    starting: float = 0.0
-
-
 class PipetteSettings(BaseModel):
     """Pipette defintions for OT-2 and OT-3."""
 

--- a/emulation_system/emulation_system/compose_file_creator/settings/images.py
+++ b/emulation_system/emulation_system/compose_file_creator/settings/images.py
@@ -37,9 +37,9 @@ class Images(BaseModel):
 class HeaterShakerModuleImages(Images):
     """Image names for Heater-Shaker."""
 
-    local_firmware_image_name: str = "heater-shaker-firmware-local"
+    local_firmware_image_name: Literal[None] = None
     local_hardware_image_name: str = "heater-shaker-hardware-local"
-    remote_firmware_image_name: str = "heater-shaker-firmware-remote"
+    remote_firmware_image_name: Literal[None] = None
     remote_hardware_image_name: str = "heater-shaker-hardware-remote"
 
 

--- a/emulation_system/tests/compose_file_creator/input/hardware_models/modules/test_heater_shaker_module.py
+++ b/emulation_system/tests/compose_file_creator/input/hardware_models/modules/test_heater_shaker_module.py
@@ -2,7 +2,7 @@
 from typing import Any, Dict
 
 import pytest
-from pydantic import parse_obj_as
+from pydantic import ValidationError, parse_obj_as
 
 from emulation_system.compose_file_creator.input.hardware_models import (
     HeaterShakerModuleInputModel,
@@ -62,10 +62,20 @@ def test_heater_shaker_with_stdin(
     assert hs.hardware_specific_attributes.mode == HeaterShakerModes.STDIN
 
 
+def test_heater_shaker_with_bad_emulation_level(
+    heater_shaker_module_bad_emulation_level: Dict[str, Any]
+) -> None:
+    """Confirm that there is a validation error when a bad emulation level is passed."""
+    with pytest.raises(ValidationError):
+        parse_obj_as(
+            HeaterShakerModuleInputModel, heater_shaker_module_bad_emulation_level
+        )
+
+
 def test_heater_shaker_source_repos(
     heater_shaker_module_default: Dict[str, Any]
 ) -> None:
     """Confirm that defined source repos are correct."""
     hs = parse_obj_as(HeaterShakerModuleInputModel, heater_shaker_module_default)
-    assert hs.source_repos.firmware_repo_name == OpentronsRepository.OPENTRONS
+    assert hs.source_repos.firmware_repo_name is None
     assert hs.source_repos.hardware_repo_name == OpentronsRepository.OPENTRONS_MODULES

--- a/emulation_system/tests/compose_file_creator/input/hardware_models/test_hardware_model.py
+++ b/emulation_system/tests/compose_file_creator/input/hardware_models/test_hardware_model.py
@@ -72,13 +72,13 @@ CONFIGURATIONS = [
         Hardware.HEATER_SHAKER_MODULE,
         EmulationLevels.FIRMWARE,
         SourceType.LOCAL,
-        "heater-shaker-firmware-local",
+        None,
     ],
     [
         Hardware.HEATER_SHAKER_MODULE,
         EmulationLevels.FIRMWARE,
         SourceType.REMOTE,
-        "heater-shaker-firmware-remote",
+        None,
     ],
     # Temperature Module
     [


### PR DESCRIPTION
# Overview

Reverting due to some pipenv issues happening on initial runs of the `Run Hardware Tests` Github Action 

[Issue Example](https://github.com/Opentrons/opentrons-emulation/runs/8018300886?check_suite_focus=true)