### PR TITLE
fix: Fix operand expansion in get_untranslated_arch.sh

### DIFF
--- a/scripts/makefile/helper_scripts/get_untranslated_arch.sh
+++ b/scripts/makefile/helper_scripts/get_untranslated_arch.sh
@@ -7,7 +7,7 @@
 arch_name=$(uname -m)
 os_name=$(uname)
 
-if [ ${os_name} == "Darwin" ] && [ ${arch_name} == "x86_64" ] && [ $(sysctl -in sysctl.proc_translated) == "1" ]; then
+if [[ ${os_name} == "Darwin" ]] && [[ ${arch_name} == "x86_64" ]] && [[ $(sysctl -in sysctl.proc_translated) == "1" ]]; then
     arch_name="arm64"
 fi
 


### PR DESCRIPTION
# Overview

This PR fixes some shell syntax in `get_untranslated_arch.sh`.

# The problem

I was getting this error when I did `make build`:

```
opentrons-emulation/scripts/makefile/helper_scripts/get_untranslated_arch.sh: line 10: [: ==: unary operator expected
```

The problem, I think, was that `sysctl -in sysctl.proc_translated` on my non-M1 Mac has no output. That caused this:

```
[ $(sysctl -in sysctl.proc_translated) == "1" ]
```

To get expanded as this:

```
[ == "1" ]
```

Which is a `[ ]` syntax error.

# The fix

Switch from `[ ]` to `[[ ]]`, which will expand the `$(...)` to an empty string that can be `==`-compared as we expect.

# Review requests

* Does this continue to work as expected on an M1 Mac?
* I'm far from an expert on shell syntax. Does this look like the appropriate fix?