### PR TITLE
refactor: OT-3 Firmware Header Creation Script Compatability (RQA-219)

### DIFF
--- a/.github/workflows/emulation-system-lint-test.yaml
+++ b/.github/workflows/emulation-system-lint-test.yaml
@@ -33,10 +33,10 @@ jobs:
       - name: Checkout opentrons-emulation repository
         uses: actions/checkout@v3
         with:
-          ref: "input-service-creation-RQA-254"
+          ref: "ot3-firmware-header-creation-script-compatability-RQA-219"
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@input-service-creation-RQA-254
+        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
         with:
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup-python-only

--- a/.github/workflows/repo-action-validation.yaml
+++ b/.github/workflows/repo-action-validation.yaml
@@ -38,17 +38,17 @@ jobs:
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:
-          ref: "input-service-creation-RQA-254"
+          ref: "ot3-firmware-header-creation-script-compatability-RQA-219"
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@input-service-creation-RQA-254
+        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup
 
       - name: Run Emulation
-        uses: Opentrons/opentrons-emulation@input-service-creation-RQA-254
+        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           command: run
@@ -60,7 +60,7 @@ jobs:
         run: "curl --request GET --header 'opentrons-version: *' http://localhost:31950/modules"
 
       - name: Teardown Emulation
-        uses: Opentrons/opentrons-emulation@input-service-creation-RQA-254
+        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           command: teardown

--- a/.github/workflows/run-hardware-tests.yaml
+++ b/.github/workflows/run-hardware-tests.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout opentrons-emulation repository
         uses: actions/checkout@v3
         with:
-          ref: "input-service-creation-RQA-254"
+          ref: "ot3-firmware-header-creation-script-compatability-RQA-219"
 
       - name: Checkout monorepo
         uses: actions/checkout@v3
@@ -59,14 +59,14 @@ jobs:
         working-directory: ./opentrons/hardware
 
       - name: Setup opentrons-emulation project
-        uses: Opentrons/opentrons-emulation@input-service-creation-RQA-254
+        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup
 
       - name: Run emulated system
-        uses: Opentrons/opentrons-emulation@input-service-creation-RQA-254
+        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           command: run
@@ -78,7 +78,7 @@ jobs:
         working-directory: ./opentrons/hardware
 
       - name: Teardown emulation
-        uses: Opentrons/opentrons-emulation@input-service-creation-RQA-254
+        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           command: teardown

--- a/.github/workflows/yaml-sub-sanity-check.yaml
+++ b/.github/workflows/yaml-sub-sanity-check.yaml
@@ -31,16 +31,16 @@ jobs:
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:
-          ref: "input-service-creation-RQA-254"
+          ref: "ot3-firmware-header-creation-script-compatability-RQA-219"
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@input-service-creation-RQA-254
+        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
         with:
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup-python-only
 
       - name: YAML Substitution
-        uses: Opentrons/opentrons-emulation@input-service-creation-RQA-254
+        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
         with:
           command: yaml-sub
           substitutions: >-

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ generate-compose-file:
 dev-generate-compose-file:
 
 	$(if $(file_path),,$(error file_path variable required))
+	@./scripts/docker_convenience_scripts/create_dev_dockerfile.sh
 	@$(subst $(SUB), ${abs_path}, $(DEV_EMULATION_SYSTEM_CMD))
 
 
@@ -52,7 +53,6 @@ build:
 .PHONY: dev-build
 dev-build:
 	$(if $(file_path),@echo "Building system from $(file_path)",$(error file_path variable required))
-	./scripts/docker_convenience_scripts/create_dev_dockerfile.sh
 	@$(MAKE) --no-print-directory --quiet dev-generate-compose-file file_path=${abs_path} > ~/tmp-compose.yaml
 	./scripts/makefile/helper_scripts/build.sh ~/tmp-compose.yaml
 #	@rm ~/tmp-compose.yaml ./docker/dev_Dockerfile

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ An example dev workflow is as follows.
 ## Debugging Docker-Compose File Generation
 
 The generation of the docker-compose file is complex. Business logic is built into the code.
-Two log files are generated for any command that calls `generate-compose-file` so that the logic may be audited. 
+Two log files are generated for any command that calls `generate-compose-file` so that the logic may be audited.
 
 There are two versions of the log file:
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -124,12 +124,19 @@ ENV OPENTRONS_HARDWARE "can-server"
 
 FROM ghcr.io/opentrons/cpp-base:latest as ot3-firmware-source
 ARG FIRMWARE_SOURCE_DOWNLOAD_LOCATION
+ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION
+
 ADD $FIRMWARE_SOURCE_DOWNLOAD_LOCATION /ot3-firmware.zip
+ADD $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons.zip
+
 RUN (cd / &&  \
     unzip -q ot3-firmware.zip && \
     rm -f ot3-firmware.zip && \
     mv ot3-firmware* ot3-firmware)
-
+RUN (cd / &&  \
+    unzip -q opentrons.zip && \
+    rm -f opentrons.zip && \
+    mv opentrons* opentrons)
 
 ##################
 # modules-source #

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,7 +19,6 @@ build_ot3_firmware_simulators()
   (
     cd /ot3-firmware && \
     cmake --preset host-gcc10 && \
-    cmake --build --preset state-manager --target state-manager-setup && \
     cmake --build --preset=simulators -j $(expr $(nproc) - 1)
   )
 
@@ -31,7 +30,6 @@ build_ot3_firmware_single_simulator() {
   (
     cd /ot3-firmware && \
     cmake --preset host-gcc10 && \
-    cmake --build --preset state-manager --target state-manager-setup && \
     cmake --build ./build-host -j $(expr $(nproc) - 1) --target $1
     )
 }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,7 +19,7 @@ build_ot3_firmware_simulators()
   (
     cd /ot3-firmware && \
     cmake --preset host-gcc10 && \
-    cmake --build --preset ot3-state-manager --target ot3-state-manager-setup && \
+    cmake --build --preset state-manager --target state-manager-setup && \
     cmake --build --preset=simulators -j $(expr $(nproc) - 1)
   )
 
@@ -31,7 +31,7 @@ build_ot3_firmware_single_simulator() {
   (
     cd /ot3-firmware && \
     cmake --preset host-gcc10 && \
-    cmake --build --preset ot3-state-manager --target ot3-state-manager-setup && \
+    cmake --build --preset state-manager --target state-manager-setup && \
     cmake --build ./build-host -j $(expr $(nproc) - 1) --target $1
     )
 }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,14 +16,24 @@ if [ "$COMMAND" != "build" ] && [ "$COMMAND" != "run" ] && [ "$COMMAND" != "stop
 fi
 
 build_ot3_firmware_simulators()
-  (cd /ot3-firmware && cmake --preset host-gcc10 && cmake --build --preset=simulators -j $(expr $(nproc) - 1))
+  (
+    cd /ot3-firmware && \
+    cmake --preset host-gcc10 && \
+    cmake --build --preset ot3-state-manager --target ot3-state-manager-setup && \
+    cmake --build --preset=simulators -j $(expr $(nproc) - 1)
+  )
 
 build_module_simulator() {
   (cd /opentrons-modules && cmake --preset=stm32-host-gcc10 . && cmake --build ./build-stm32-host -j $(expr $(nproc) - 1) --target $1)
 }
 
 build_ot3_firmware_single_simulator() {
-  (cd /ot3-firmware && cmake --preset host-gcc10 && cmake --build ./build-host -j $(expr $(nproc) - 1) --target $1)
+  (
+    cd /ot3-firmware && \
+    cmake --preset host-gcc10 && \
+    cmake --build --preset ot3-state-manager --target ot3-state-manager-setup && \
+    cmake --build ./build-host -j $(expr $(nproc) - 1) --target $1
+    )
 }
 
 kill_process() {

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_service_builder.py
@@ -99,7 +99,8 @@ class ConcreteOT3ServiceBuilder(AbstractServiceBuilder):
         """Generates value for build parameter."""
         ot3_firmware_repo = OpentronsRepository.OT3_FIRMWARE
         monorepo = OpentronsRepository.OPENTRONS
-        build_args: Optional[IntermediateBuildArgs] = {}
+        build_args: IntermediateBuildArgs = {}
+
         if self._ot3.source_type == SourceType.REMOTE:
             ot3_firmware_build_args = get_build_args(
                 ot3_firmware_repo,
@@ -108,6 +109,7 @@ class ConcreteOT3ServiceBuilder(AbstractServiceBuilder):
                 self._global_settings.get_repo_head(ot3_firmware_repo),
             )
             build_args.update(ot3_firmware_build_args)
+
         if self._ot3.opentrons_hardware_source_type == SourceType.REMOTE:
             monorepo_build_args = get_build_args(
                 monorepo,
@@ -116,15 +118,19 @@ class ConcreteOT3ServiceBuilder(AbstractServiceBuilder):
                 self._global_settings.get_repo_head(monorepo),
             )
             build_args.update(monorepo_build_args)
-        else:
-            build_args = None
-        self._logging_client.log_build_args(build_args)
-        return build_args
+
+        args_to_pass = build_args if len(build_args) > 0 else None
+
+        self._logging_client.log_build_args(args_to_pass)
+        return args_to_pass
 
     def generate_volumes(self) -> Optional[IntermediateVolumes]:
         """Generates value for volumes parameter."""
-        volumes: Optional[IntermediateVolumes] = []
-        if SourceType.LOCAL in [self._ot3.source_type, self._ot3.opentrons_hardware_source_type]:
+        volumes: IntermediateVolumes = []
+        if SourceType.LOCAL in [
+            self._ot3.source_type,
+            self._ot3.opentrons_hardware_source_type,
+        ]:
             volumes.append(self.ENTRYPOINT_MOUNT_STRING)
             volumes.extend(self._ot3.get_mount_strings())
 
@@ -134,10 +140,9 @@ class ConcreteOT3ServiceBuilder(AbstractServiceBuilder):
             if self._ot3.opentrons_hardware_source_type == SourceType.LOCAL:
                 add_opentrons_named_volumes(volumes)
 
-        else:
-            volumes = None
-        self._logging_client.log_volumes(volumes)
-        return volumes
+        arg_to_pass = volumes if len(volumes) > 0 else None
+        self._logging_client.log_volumes(arg_to_pass)
+        return arg_to_pass
 
     def generate_command(self) -> Optional[IntermediateCommand]:
         """Generates value for command parameter."""

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_service_builder.py
@@ -1,10 +1,7 @@
 """Module containing ConcreteOT3ServiceBuilder class."""
 from typing import Optional
 
-from emulation_system import (
-    OpentronsEmulationConfiguration,
-    SystemConfigurationModel,
-)
+from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
 from emulation_system.compose_file_creator.config_file_settings import (
     OpentronsRepository,
     SourceType,
@@ -23,10 +20,11 @@ from emulation_system.compose_file_creator.utilities.shared_functions import (
     add_ot3_firmware_named_volumes,
     get_build_args,
 )
-from .abstract_service_builder import AbstractServiceBuilder
-from .service_info import ServiceInfo
+
 from ...images import OT3PipettesImages
 from ...logging import OT3LoggingClient
+from .abstract_service_builder import AbstractServiceBuilder
+from .service_info import ServiceInfo
 
 
 class ConcreteOT3ServiceBuilder(AbstractServiceBuilder):

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_service_builder.py
@@ -1,7 +1,10 @@
 """Module containing ConcreteOT3ServiceBuilder class."""
 from typing import Optional
 
-from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
+from emulation_system import (
+    OpentronsEmulationConfiguration,
+    SystemConfigurationModel,
+)
 from emulation_system.compose_file_creator.config_file_settings import (
     OpentronsRepository,
     SourceType,
@@ -16,14 +19,14 @@ from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediateVolumes,
 )
 from emulation_system.compose_file_creator.utilities.shared_functions import (
+    add_opentrons_named_volumes,
     add_ot3_firmware_named_volumes,
     get_build_args,
 )
-
-from ...images import OT3PipettesImages
-from ...logging import OT3LoggingClient
 from .abstract_service_builder import AbstractServiceBuilder
 from .service_info import ServiceInfo
+from ...images import OT3PipettesImages
+from ...logging import OT3LoggingClient
 
 
 class ConcreteOT3ServiceBuilder(AbstractServiceBuilder):
@@ -96,16 +99,25 @@ class ConcreteOT3ServiceBuilder(AbstractServiceBuilder):
 
     def generate_build_args(self) -> Optional[IntermediateBuildArgs]:
         """Generates value for build parameter."""
-        repo = OpentronsRepository.OT3_FIRMWARE
+        ot3_firmware_repo = OpentronsRepository.OT3_FIRMWARE
+        monorepo = OpentronsRepository.OPENTRONS
+        build_args: Optional[IntermediateBuildArgs] = {}
         if self._ot3.source_type == SourceType.REMOTE:
-            build_args = get_build_args(
-                repo,
+            ot3_firmware_build_args = get_build_args(
+                ot3_firmware_repo,
                 self._ot3.source_location,
-                self._global_settings.get_repo_commit(repo),
-                self._global_settings.get_repo_head(repo),
+                self._global_settings.get_repo_commit(ot3_firmware_repo),
+                self._global_settings.get_repo_head(ot3_firmware_repo),
             )
-            # TODO: Add monorepo for OT-3 State Manager Compatibility
-
+            build_args.update(ot3_firmware_build_args)
+        if self._ot3.opentrons_hardware_source_type == SourceType.REMOTE:
+            monorepo_build_args = get_build_args(
+                monorepo,
+                self._ot3.opentrons_hardware_source_location,
+                self._global_settings.get_repo_commit(monorepo),
+                self._global_settings.get_repo_head(monorepo),
+            )
+            build_args.update(monorepo_build_args)
         else:
             build_args = None
         self._logging_client.log_build_args(build_args)
@@ -113,10 +125,17 @@ class ConcreteOT3ServiceBuilder(AbstractServiceBuilder):
 
     def generate_volumes(self) -> Optional[IntermediateVolumes]:
         """Generates value for volumes parameter."""
-        if self._ot3.source_type == SourceType.LOCAL:
-            volumes = [self.ENTRYPOINT_MOUNT_STRING]
+        volumes: Optional[IntermediateVolumes] = []
+        if SourceType.LOCAL in [self._ot3.source_type, self._ot3.opentrons_hardware_source_type]:
+            volumes.append(self.ENTRYPOINT_MOUNT_STRING)
             volumes.extend(self._ot3.get_mount_strings())
-            add_ot3_firmware_named_volumes(volumes)
+
+            if self._ot3.source_type == SourceType.LOCAL:
+                add_ot3_firmware_named_volumes(volumes)
+
+            if self._ot3.opentrons_hardware_source_type == SourceType.LOCAL:
+                add_opentrons_named_volumes(volumes)
+
         else:
             volumes = None
         self._logging_client.log_volumes(volumes)

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot3_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot3_model.py
@@ -1,10 +1,7 @@
 """OT-3 Module and it's attributes."""
 import os
 import pathlib
-from typing import (
-    List,
-    Optional,
-)
+from typing import List, Optional
 
 from pydantic import Field
 from typing_extensions import Literal
@@ -22,13 +19,12 @@ from emulation_system.compose_file_creator.config_file_settings import (
 from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediatePorts,
 )
-from emulation_system.consts import (
-    CAN_SERVER_MOUNT_NAME,
-    SOURCE_CODE_MOUNT_NAME,
-)
+from emulation_system.consts import CAN_SERVER_MOUNT_NAME, SOURCE_CODE_MOUNT_NAME
+
+from ..hardware_specific_attributes import HardwareSpecificAttributes
+
 # cannot import from . because of circular import issue
 from .robot_model import RobotInputModel
-from ..hardware_specific_attributes import HardwareSpecificAttributes
 
 
 class OT3Attributes(HardwareSpecificAttributes):
@@ -58,8 +54,12 @@ class OT3InputModel(RobotInputModel):
     can_server_source_type: SourceType = Field(alias="can-server-source-type")
     can_server_source_location: str = Field(alias="can-server-source-location")
 
-    opentrons_hardware_source_type: SourceType = Field(alias="opentrons-hardware-source-type")
-    opentrons_hardware_source_location: str = Field(alias="opentrons-hardware-source-location")
+    opentrons_hardware_source_type: SourceType = Field(
+        alias="opentrons-hardware-source-type"
+    )
+    opentrons_hardware_source_location: str = Field(
+        alias="opentrons-hardware-source-location"
+    )
 
     hardware_specific_attributes: OT3Attributes = Field(
         alias="hardware-specific-attributes", default=OT3Attributes()
@@ -101,9 +101,13 @@ class OT3InputModel(RobotInputModel):
         return super().is_remote and self.can_server_source_type == SourceType.REMOTE
 
     def get_mount_strings(self) -> List[str]:
+        """Returns list of mount strings for OT-3"""
         mount_strings = []
+
         if self.source_type == SourceType.LOCAL:
-            service_mount_path = os.path.basename(os.path.normpath(self.source_location))
+            service_mount_path = os.path.basename(
+                os.path.normpath(self.source_location)
+            )
             firmware_mount = DirectoryMount(
                 name=SOURCE_CODE_MOUNT_NAME,
                 type=MountTypes.DIRECTORY,
@@ -113,7 +117,9 @@ class OT3InputModel(RobotInputModel):
             mount_strings.append(firmware_mount.get_bind_mount_string())
 
         if self.opentrons_hardware_source_type == SourceType.LOCAL:
-            service_mount_path = os.path.basename(os.path.normpath(self.opentrons_hardware_source_location))
+            service_mount_path = os.path.basename(
+                os.path.normpath(self.opentrons_hardware_source_location)
+            )
             monorepo_mount = DirectoryMount(
                 name=SOURCE_CODE_MOUNT_NAME,
                 type=MountTypes.DIRECTORY,

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot3_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot3_model.py
@@ -1,7 +1,10 @@
 """OT-3 Module and it's attributes."""
 import os
 import pathlib
-from typing import List, Optional
+from typing import (
+    List,
+    Optional,
+)
 
 from pydantic import Field
 from typing_extensions import Literal
@@ -19,12 +22,13 @@ from emulation_system.compose_file_creator.config_file_settings import (
 from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediatePorts,
 )
-from emulation_system.consts import CAN_SERVER_MOUNT_NAME
-
-from ..hardware_specific_attributes import HardwareSpecificAttributes
-
+from emulation_system.consts import (
+    CAN_SERVER_MOUNT_NAME,
+    SOURCE_CODE_MOUNT_NAME,
+)
 # cannot import from . because of circular import issue
 from .robot_model import RobotInputModel
+from ..hardware_specific_attributes import HardwareSpecificAttributes
 
 
 class OT3Attributes(HardwareSpecificAttributes):
@@ -53,6 +57,9 @@ class OT3InputModel(RobotInputModel):
     )
     can_server_source_type: SourceType = Field(alias="can-server-source-type")
     can_server_source_location: str = Field(alias="can-server-source-location")
+
+    opentrons_hardware_source_type: SourceType = Field(alias="opentrons-hardware-source-type")
+    opentrons_hardware_source_location: str = Field(alias="opentrons-hardware-source-location")
 
     hardware_specific_attributes: OT3Attributes = Field(
         alias="hardware-specific-attributes", default=OT3Attributes()
@@ -92,3 +99,27 @@ class OT3InputModel(RobotInputModel):
     def is_remote(self) -> bool:
         """Check if all source-types are remote."""
         return super().is_remote and self.can_server_source_type == SourceType.REMOTE
+
+    def get_mount_strings(self) -> List[str]:
+        mount_strings = []
+        if self.source_type == SourceType.LOCAL:
+            service_mount_path = os.path.basename(os.path.normpath(self.source_location))
+            firmware_mount = DirectoryMount(
+                name=SOURCE_CODE_MOUNT_NAME,
+                type=MountTypes.DIRECTORY,
+                source_path=pathlib.Path(self.source_location),
+                mount_path=f"/{service_mount_path}",
+            )
+            mount_strings.append(firmware_mount.get_bind_mount_string())
+
+        if self.opentrons_hardware_source_type == SourceType.LOCAL:
+            service_mount_path = os.path.basename(os.path.normpath(self.opentrons_hardware_source_location))
+            monorepo_mount = DirectoryMount(
+                name=SOURCE_CODE_MOUNT_NAME,
+                type=MountTypes.DIRECTORY,
+                source_path=pathlib.Path(self.opentrons_hardware_source_location),
+                mount_path=f"/{service_mount_path}",
+            )
+            mount_strings.append(monorepo_mount.get_bind_mount_string())
+
+        return mount_strings

--- a/emulation_system/emulation_system/compose_file_creator/logging/ot3_logging_client.py
+++ b/emulation_system/emulation_system/compose_file_creator/logging/ot3_logging_client.py
@@ -2,7 +2,6 @@
 
 from typing import Optional
 
-from .abstract_logging_client import AbstractLoggingClient
 from ..types.intermediate_types import (
     IntermediateBuildArgs,
     IntermediateCommand,
@@ -11,6 +10,7 @@ from ..types.intermediate_types import (
     IntermediatePorts,
     IntermediateVolumes,
 )
+from .abstract_logging_client import AbstractLoggingClient
 
 
 class OT3LoggingClient(AbstractLoggingClient):

--- a/emulation_system/emulation_system/compose_file_creator/logging/ot3_logging_client.py
+++ b/emulation_system/emulation_system/compose_file_creator/logging/ot3_logging_client.py
@@ -2,6 +2,7 @@
 
 from typing import Optional
 
+from .abstract_logging_client import AbstractLoggingClient
 from ..types.intermediate_types import (
     IntermediateBuildArgs,
     IntermediateCommand,
@@ -10,7 +11,6 @@ from ..types.intermediate_types import (
     IntermediatePorts,
     IntermediateVolumes,
 )
-from .abstract_logging_client import AbstractLoggingClient
 
 
 class OT3LoggingClient(AbstractLoggingClient):
@@ -41,8 +41,7 @@ class OT3LoggingClient(AbstractLoggingClient):
         else:
             tabbed_volumes = [f"\t{volume}" for volume in volumes]
             output = [
-                'Since "source-type" is "remote",'
-                "adding the following volumes and bind mounts:",
+                "Adding the following volumes and bind mounts:",
                 *tabbed_volumes,
             ]
         self._logging_console.h2_print("volumes")

--- a/emulation_system/tests/compose_file_creator/conftest.py
+++ b/emulation_system/tests/compose_file_creator/conftest.py
@@ -136,6 +136,8 @@ def ot3_default(opentrons_dir: str) -> Dict[str, Any]:
         "robot-server-source-location": "latest",
         "can-server-source-type": "remote",
         "can-server-source-location": "latest",
+        "opentrons-hardware-source-type": "remote",
+        "opentrons-hardware-source-location": "latest",
         "exposed-port": 5000,
         "hardware-specific-attributes": {},
     }

--- a/emulation_system/tests/compose_file_creator/utilities/test_substitute_yaml_values.py
+++ b/emulation_system/tests/compose_file_creator/utilities/test_substitute_yaml_values.py
@@ -27,6 +27,8 @@ def remote_only_ot3() -> str:
                 "source-location": "latest",
                 "robot-server-source-type": "remote",
                 "robot-server-source-location": "latest",
+                "opentrons-hardware-source-type": "remote",
+                "opentrons-hardware-source-location": "latest",
                 "can-server-source-type": "remote",
                 "can-server-source-location": "latest",
                 "exposed-port": 31950,

--- a/samples/ot3/ot3_remote.yaml
+++ b/samples/ot3/ot3_remote.yaml
@@ -20,6 +20,8 @@ robot:
   robot-server-source-location: latest
   can-server-source-type: remote
   can-server-source-location: latest
+  opentrons-hardware-source-type: remote
+  opentrons-hardware-source-location: latest
   emulation-level: hardware
   exposed-port: 31950
   can-server-exposed-port: 9898


### PR DESCRIPTION
# Overview

Changes to make opentrons-emulation compatible with [ot3-firmware Header Creation Script](https://github.com/Opentrons/ot3-firmware/pull/435).

# Changelog

**Header Creation Script Compatability**

* Dockerfile
  * Add monorepo installation to `ot3-firmware-source` build stage, since monorepo is now a dependency of ot3-firmware
* Add `opentrons-hardware-source-type` and `opentrons-hardware-source-location` to ot3 configuration
* Add mounting of monorepo for local ot3 containers
* Add monorepo build args for remote ot3 containers
* Add tests for local and remote ot3 containers
  * Confirming that when `opentrons-hardware-source-type` is local, monorepo bind mounts are added
  * Confirming that when `opentrons-hardware-source-type` is remote, monorepo build args are added

**Misc**

* Move creating dev dockerfile to `dev-generate-compose-file`

# Review requests

None

# Risk assessment

Low
