### PR TITLE
fix(devcontainer): always root in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
             "USERNAME": "root"
         }
     },
+    "remoteUser": "root",
     "mounts": [
         "source=commandhistory-oe,target=/commandhistory,type=volume",
         "source=extensions-oe,target=/root/.vscode-server/extensions,type=volume",


### PR DESCRIPTION
# Overview

Forgot to add this.  Without it when VSCode opens the container it will use the user `vscode` and then lots of things don't work.

# Risk assessment

None, devcontainer only.
