### PR TITLE
fix: Fix can-mon and can-comm commands (RQA-224)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ can-comm:
 		load-container-names \
 		file_path="${abs_path}" \
 		filter="can-server" \
-		| xargs -o -I{} docker exec -it {} poetry run python -m opentrons_hardware.scripts.can_comm --interface opentrons_sock
+		| xargs -o -I{} docker exec -it {} python -m opentrons_hardware.scripts.can_comm --interface opentrons_sock
 
 
 # Runs can monitor script against can_server
@@ -196,7 +196,7 @@ can-mon:
 		load-container-names \
 		file_path="${abs_path}" \
 		filter="can-server" \
-		| xargs -o -I{} docker exec -it {} poetry run python -m opentrons_hardware.scripts.can_mon --interface opentrons_sock
+		| xargs -o -I{} docker exec -it {} python -m opentrons_hardware.scripts.can_mon --interface opentrons_sock
 
 ###########################################
 ############### CI Commands ###############

--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,7 @@ load-container-names:
 ###########################################
 
 # Run can communication script against can_server
+# Note: uses pipenv since monorepo still uses pipenv
 .PHONY: can-comm
 can-comm:
 
@@ -185,6 +186,7 @@ can-comm:
 
 
 # Runs can monitor script against can_server
+# Note: uses pipenv since monorepo still uses pipenv
 .PHONY: can-mon
 can-mon:
 

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,6 @@ load-container-names:
 ###########################################
 
 # Run can communication script against can_server
-# Note: uses pipenv since monorepo still uses pipenv
 .PHONY: can-comm
 can-comm:
 
@@ -186,7 +185,6 @@ can-comm:
 
 
 # Runs can monitor script against can_server
-# Note: uses pipenv since monorepo still uses pipenv
 .PHONY: can-mon
 can-mon:
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -202,7 +202,7 @@ RUN /entrypoint.sh build
 FROM ghcr.io/opentrons/python-base:latest as firmware-common
 RUN mkdir /dist
 COPY --from=python-emulator-builder /dist/* /dist/
-RUN pip install /dist/*
+RUN python -m pip install /dist/*
 
 ##############################################################
 #                       REMOTE TARGETS                       #

--- a/docker/bases_Dockerfile
+++ b/docker/bases_Dockerfile
@@ -70,9 +70,11 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
        	-y \
     	python3.10 \
     	python3.10-venv && \
-    rm -f /usr/bin/python /usr/bin/python3 && \
-	(cd /usr/bin/ && ln -s /usr/bin/python3.10 python) && \
-	(cd /usr/bin/ && ln -s /usr/bin/python3.10 python3)
+    (cd /usr/bin && \
+      rm -f python python3 && \
+	  ln -s /usr/bin/python3.10 python && \
+      ln -s /usr/bin/python3.10 python3 \
+    )
 
 
 ###############

--- a/docker/bases_Dockerfile
+++ b/docker/bases_Dockerfile
@@ -47,6 +47,7 @@ LABEL opentons-emulation.description=$DESCRIPTION
 
 ENV DEBIAN_FRONTEND noninteractive
 
+SHELL ["/bin/bash", "-c"]
 RUN rm -rf /var/lib/apt/lists/*
 RUN echo "Updating apt" && apt-get update > /dev/null
 RUN apt-get update \
@@ -69,14 +70,44 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
        	-y \
     	python3.10 \
     	python3.10-venv && \
-	(cd /usr/bin/ && ln -s /usr/bin/python3.10 python)
+    rm -f /usr/bin/python /usr/bin/python3 && \
+	(cd /usr/bin/ && ln -s /usr/bin/python3.10 python) && \
+	(cd /usr/bin/ && ln -s /usr/bin/python3.10 python3)
+
+
+###############
+# python-base #
+###############
+
+FROM ubuntu-base as python-base
+
+ENV NODE_VERSION 14
+ENV OT_PYTHON "/usr/bin/python3.10"
+
+RUN apt-get update && \
+    apt-get install \
+    --no-install-recommends \
+    -y \
+    libudev-dev \
+    libsystemd-dev \
+    python3-dev \
+    pkgconf \
+    libpython3.10-dev
+
+RUN python -m ensurepip --upgrade && \
+    python -m pip install --upgrade pip setuptools wheel && \
+    python -m pip install pipenv
+
+
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -
+RUN apt-get install -y nodejs && npm install --global yarn
 
 
 ############
 # cpp-base #
 ############
 
-FROM ubuntu-base as cpp-base
+FROM python-base as cpp-base
 RUN apt-get update && \
     apt-get install \
     --no-install-recommends \
@@ -93,29 +124,3 @@ RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.2
     rm cmake-3.21.2-linux-x86_64.tar.gz && \
     mv cmake-3.21.2-linux-x86_64 cmake && \
     (cd /usr/bin/ && ln -s /cmake/bin/cmake cmake)
-
-###############
-# python-base #
-###############
-
-FROM ubuntu-base as python-base
-
-ENV NODE_VERSION 14
-ENV OT_PYTHON "/usr/bin/python3.10"
-
-RUN apt-get update && \
-    apt-get install \
-    --no-install-recommends \
-    -y \
-    pipenv \
-    libudev-dev \
-    libsystemd-dev \
-    python3-dev \
-    pkgconf \
-    libpython3.10-dev
-
-RUN python -m ensurepip --upgrade &&  \
-    python -m pip install --upgrade pip setuptools wheel
-
-RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -
-RUN apt-get install -y nodejs && npm install --global yarn

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -137,13 +137,13 @@ case $FULL_COMMAND in
   # Firmware Level
 
   build-thermocycler-firmware|build-heater-shaker-firmware|build-magdeck-firmware|build-tempdeck-firmware|build-emulator-proxy|build-robot-server|build-common-firmware|build-smoothie|build-can-server)
-    pip uninstall --yes /dist/*
+    python -m pip uninstall --yes /dist/*
     (cd /opentrons/shared-data/python && python setup.py bdist_wheel -d /dist/)
     (cd /opentrons/api && python setup.py bdist_wheel -d /dist/)
     (cd /opentrons/notify-server && python setup.py bdist_wheel -d /dist/)
     (cd /opentrons/robot-server && python setup.py bdist_wheel -d /dist/)
     (cd /opentrons/hardware && python setup.py bdist_wheel -d /dist/)
-    pip install /dist/*
+    python -m pip install /dist/*
     ;;
 
   run-thermocycler-firmware)


### PR DESCRIPTION
# Overview

The commands `can-mon` and `can-comm` were trying to use pipenv to run. 
Inside the containers, pipenv is not used to install monorepo modules. 
Instead, the monorepo modules are installed directly using `python -m pip`. `python` is mapped to the version of python installed by `opentron-emulation`.

So instead of using `pipenv run python` just call `python` directly to run the internal commands

**Misc Changes**

* Edit and `pip` calls to use `python -m pip`
* Default shell to bash
* Remove symlink binding `python` and `python3` to system versions of python and bind them to installed version of python
* Install pipenv against installed version of python
* Change cpp-base to be built from python-base instead of ubuntu-base

# Testing

1. Started an emulated OT-3 using `make dev-build` and `make dev-run-detached`.
  1. Using the dev commands ensured that all changes in both `bases_Dockerfile` and `Dockerfile` were used. 
2. Opened 2 terminals
3. On 1 terminal ran `can-mon`
4. On the other ran `can-comm` and send a pipette information message.
5. Verified can message came through on `can-mon` terminal


