### PR TITLE
fix: Update team spec ot3 yaml file

### DIFF
--- a/samples/ot3/ot3_local.yaml
+++ b/samples/ot3/ot3_local.yaml
@@ -21,5 +21,7 @@ robot:
   robot-server-source-location: /home/derek-maggio/Documents/repos/opentrons
   can-server-source-type: local
   can-server-source-location: /home/derek-maggio/Documents/repos/opentrons
+  opentrons-hardware-source-type: local
+  opentrons-hardware-source-location: /home/derek-maggio/Documents/repos/opentrons
   emulation-level: hardware
   exposed-port: 31950

--- a/samples/team_specific_setups/ot3_firmware_development.yaml
+++ b/samples/team_specific_setups/ot3_firmware_development.yaml
@@ -20,6 +20,8 @@ robot:
   robot-server-source-location: /home/derek-maggio/Documents/repos/opentrons
   can-server-source-type: local
   can-server-source-location: /home/derek-maggio/Documents/repos/opentrons
+  opentrons-hardware-source-type: local
+  opentrons-hardware-source-location: /home/derek-maggio/Documents/repos/opentrons 
   emulation-level: hardware
   exposed-port: 31950
   can-server-exposed-port: 9898


### PR DESCRIPTION
# Overview
This adds the opentrons-hardware source type and location to the `team_specific_setups/ot3_firmware_development.yaml`
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
