### PR TITLE
fix: Fix "Test Sample Files" Github Action (RQA-311)

### DIFF
--- a/.github/workflows/emulation-system-lint-test.yaml
+++ b/.github/workflows/emulation-system-lint-test.yaml
@@ -1,7 +1,7 @@
 # This workflow runs test and lint on branch pushes that touch the
 # emulation-system project.
 
-name: 'emulation-system Lint & Test'
+name: emulation-system Lint & Test
 
 on:
   push:
@@ -27,28 +27,28 @@ defaults:
 
 jobs:
   lint-test:
-    name: 'emulation-system linting and tests'
-    runs-on: 'ubuntu-20.04'
+    name: emulation-system linting and tests
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout opentrons-emulation repository
         uses: actions/checkout@v3
         with:
-          ref: "add-healthchecks-RQA-312"
+          ref: fix-test-sample-files-RQA-311
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
+        uses: Opentrons/opentrons-emulation@fix-test-sample-files-RQA-311
         with:
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup-python-only
 
-      - name: "Lint"
+      - name: Lint
         run: make lint
 
-      - name: "Test"
+      - name: Test
         run: make test
 
-      - name: 'Upload Coverage Report'
-        uses: 'codecov/codecov-action@v2'
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v3
         with:
           files: ./g-code-testing/coverage.xml
           flags: g-code-testing

--- a/.github/workflows/repo-action-validation.yaml
+++ b/.github/workflows/repo-action-validation.yaml
@@ -38,17 +38,17 @@ jobs:
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:
-          ref: "add-healthchecks-RQA-312"
+          ref: "fix-test-sample-files-RQA-311"
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
+        uses: Opentrons/opentrons-emulation@fix-test-sample-files-RQA-311
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup
 
       - name: Run Emulation
-        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
+        uses: Opentrons/opentrons-emulation@fix-test-sample-files-RQA-311
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           command: run
@@ -60,7 +60,7 @@ jobs:
         run: "curl --request GET --header 'opentrons-version: *' http://localhost:31950/modules"
 
       - name: Teardown Emulation
-        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
+        uses: Opentrons/opentrons-emulation@fix-test-sample-files-RQA-311
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           command: teardown

--- a/.github/workflows/run-hardware-tests.yaml
+++ b/.github/workflows/run-hardware-tests.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout opentrons-emulation repository
         uses: actions/checkout@v3
         with:
-          ref: "add-healthchecks-RQA-312"
+          ref: "fix-test-sample-files-RQA-311"
 
       - name: Checkout monorepo
         uses: actions/checkout@v3
@@ -59,14 +59,14 @@ jobs:
         working-directory: ./opentrons/hardware
 
       - name: Setup opentrons-emulation project
-        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
+        uses: Opentrons/opentrons-emulation@fix-test-sample-files-RQA-311
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup
 
       - name: Run emulated system
-        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
+        uses: Opentrons/opentrons-emulation@fix-test-sample-files-RQA-311
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           command: run
@@ -78,7 +78,7 @@ jobs:
         working-directory: ./opentrons/hardware
 
       - name: Teardown emulation
-        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
+        uses: Opentrons/opentrons-emulation@fix-test-sample-files-RQA-311
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           command: teardown

--- a/.github/workflows/yaml-sub-sanity-check.yaml
+++ b/.github/workflows/yaml-sub-sanity-check.yaml
@@ -31,16 +31,16 @@ jobs:
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:
-          ref: "add-healthchecks-RQA-312"
+          ref: "fix-test-sample-files-RQA-311"
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
+        uses: Opentrons/opentrons-emulation@fix-test-sample-files-RQA-311
         with:
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup-python-only
 
       - name: YAML Substitution
-        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
+        uses: Opentrons/opentrons-emulation@fix-test-sample-files-RQA-311
         with:
           command: yaml-sub
           substitutions: >-

--- a/samples/ot3/ot3_local.yaml
+++ b/samples/ot3/ot3_local.yaml
@@ -16,12 +16,12 @@ robot:
   id: otie
   hardware: ot3
   source-type: local
-  source-location: /home/derek-maggio/Documents/repos/ot3-firmware
+  source-location: /home/runner/work/opentrons-emulation/opentrons-emulation/ot3-firmware    # Replace with path to your source code
   robot-server-source-type: local
-  robot-server-source-location: /home/derek-maggio/Documents/repos/opentrons
+  robot-server-source-location: /home/runner/work/opentrons-emulation/opentrons-emulation/opentrons  # Replace with path to your source code
   can-server-source-type: local
-  can-server-source-location: /home/derek-maggio/Documents/repos/opentrons
+  can-server-source-location: /home/runner/work/opentrons-emulation/opentrons-emulation/opentrons  # Replace with path to your source code
   opentrons-hardware-source-type: local
-  opentrons-hardware-source-location: /home/derek-maggio/Documents/repos/opentrons
+  opentrons-hardware-source-location: /home/runner/work/opentrons-emulation/opentrons-emulation/opentrons  # Replace with path to your source code
   emulation-level: hardware
   exposed-port: 31950

--- a/samples/team_specific_setups/ot3_firmware_development.yaml
+++ b/samples/team_specific_setups/ot3_firmware_development.yaml
@@ -15,13 +15,13 @@ robot:
   id: otie
   hardware: ot3
   source-type: local
-  source-location: /home/derek-maggio/Documents/repos/ot3-firmware
+  source-location: /home/runner/work/opentrons-emulation/opentrons-emulation/ot3-firmware    # Replace with path to your source code
   robot-server-source-type: local
-  robot-server-source-location: /home/derek-maggio/Documents/repos/opentrons
+  robot-server-source-location: /home/runner/work/opentrons-emulation/opentrons-emulation/opentrons  # Replace with path to your source code
   can-server-source-type: local
-  can-server-source-location: /home/derek-maggio/Documents/repos/opentrons
+  can-server-source-location: /home/runner/work/opentrons-emulation/opentrons-emulation/opentrons  # Replace with path to your source code
   opentrons-hardware-source-type: local
-  opentrons-hardware-source-location: /home/derek-maggio/Documents/repos/opentrons 
+  opentrons-hardware-source-location: /home/runner/work/opentrons-emulation/opentrons-emulation/opentrons  # Replace with path to your source code
   emulation-level: hardware
   exposed-port: 31950
   can-server-exposed-port: 9898

--- a/scripts/makefile/helper_scripts/test_samples.sh
+++ b/scripts/makefile/helper_scripts/test_samples.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-SAMPLE_PATHS=`(cd ${SCRIPT_DIR}/../ && find samples \( -name "*.json" -or -name "*.yaml" \) -and -not -path "*/team_specific_setups/*")`
 FAILURE="FALSE"
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SAMPLE_PATHS=`(cd ${SCRIPT_DIR}/../../../ && find samples \( -name "*.json" -or -name "*.yaml" \) -and -not -path "*/team_specific_setups/*")`
+
+if [ $? -ne 0 ]; then
+  FAILURE="TRUE"
+  printf "\nFinding sample folder failed failed\n\n"
+  exit 1
+fi
 
 echo "Checking the following sample files execute:"
 for sample in ${SAMPLE_PATHS}; do
@@ -9,8 +15,8 @@ for sample in ${SAMPLE_PATHS}; do
 done
 
 for val in ${SAMPLE_PATHS}; do
-    abs_path=`(cd ${SCRIPT_DIR}/../ && echo ${PWD}/${val})`
-    (cd ${SCRIPT_DIR}/../ && make generate-compose-file file_path=${abs_path}) > /dev/null
+    abs_path=`(cd ${SCRIPT_DIR}/../../../ && echo ${PWD}/${val})`
+    (cd ${SCRIPT_DIR}/../../../ && make generate-compose-file file_path=${abs_path}) > /dev/null
 
     if [ $? -ne 0 ]; then
       FAILURE="TRUE"


### PR DESCRIPTION
# Overview

The Test All Sample Files Github Action, is not able to find the samples folder, yet still passes the Github Action. 


1. Change path so samples folder can be found 
2. If for some reason samples folder cannot be found, fail the tests

# Changelog

1. Fix all `local` configuration files to have paths that will be valid in CI
2. Update test_samples.sh
   1. Fix path to `samples` folder
   2. If `samples` folder is not found, exit with exit code 1
3. Format README
 

# Review requests

Anything else I am missing in [test_samples.sh](https://github.com/Opentrons/opentrons-emulation/blob/cbc3da3621a56530f25975243a4e772f7cbf1ccc/scripts/makefile/helper_scripts/test_samples.sh)?

# Risk assessment

Super super low