### PR TITLE
feat: Add healthchecks to all containers (RQA-312)

### DIFF
--- a/.github/workflows/emulation-system-lint-test.yaml
+++ b/.github/workflows/emulation-system-lint-test.yaml
@@ -33,10 +33,10 @@ jobs:
       - name: Checkout opentrons-emulation repository
         uses: actions/checkout@v3
         with:
-          ref: "ot3-firmware-header-creation-script-compatability-RQA-219"
+          ref: "fix-robot-server-not-getting-pipette-RQA-312"
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
+        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
         with:
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup-python-only

--- a/.github/workflows/emulation-system-lint-test.yaml
+++ b/.github/workflows/emulation-system-lint-test.yaml
@@ -33,10 +33,10 @@ jobs:
       - name: Checkout opentrons-emulation repository
         uses: actions/checkout@v3
         with:
-          ref: "fix-robot-server-not-getting-pipette-RQA-312"
+          ref: "add-healthchecks-RQA-312"
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
+        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
         with:
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup-python-only

--- a/.github/workflows/repo-action-validation.yaml
+++ b/.github/workflows/repo-action-validation.yaml
@@ -38,17 +38,17 @@ jobs:
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:
-          ref: "fix-robot-server-not-getting-pipette-RQA-312"
+          ref: "add-healthchecks-RQA-312"
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
+        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup
 
       - name: Run Emulation
-        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
+        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           command: run
@@ -60,7 +60,7 @@ jobs:
         run: "curl --request GET --header 'opentrons-version: *' http://localhost:31950/modules"
 
       - name: Teardown Emulation
-        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
+        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           command: teardown

--- a/.github/workflows/repo-action-validation.yaml
+++ b/.github/workflows/repo-action-validation.yaml
@@ -38,17 +38,17 @@ jobs:
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:
-          ref: "ot3-firmware-header-creation-script-compatability-RQA-219"
+          ref: "fix-robot-server-not-getting-pipette-RQA-312"
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
+        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup
 
       - name: Run Emulation
-        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
+        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           command: run
@@ -60,7 +60,7 @@ jobs:
         run: "curl --request GET --header 'opentrons-version: *' http://localhost:31950/modules"
 
       - name: Teardown Emulation
-        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
+        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           command: teardown

--- a/.github/workflows/run-hardware-tests.yaml
+++ b/.github/workflows/run-hardware-tests.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout opentrons-emulation repository
         uses: actions/checkout@v3
         with:
-          ref: "ot3-firmware-header-creation-script-compatability-RQA-219"
+          ref: "fix-robot-server-not-getting-pipette-RQA-312"
 
       - name: Checkout monorepo
         uses: actions/checkout@v3
@@ -59,14 +59,14 @@ jobs:
         working-directory: ./opentrons/hardware
 
       - name: Setup opentrons-emulation project
-        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
+        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup
 
       - name: Run emulated system
-        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
+        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           command: run
@@ -78,7 +78,7 @@ jobs:
         working-directory: ./opentrons/hardware
 
       - name: Teardown emulation
-        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
+        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           command: teardown

--- a/.github/workflows/run-hardware-tests.yaml
+++ b/.github/workflows/run-hardware-tests.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout opentrons-emulation repository
         uses: actions/checkout@v3
         with:
-          ref: "fix-robot-server-not-getting-pipette-RQA-312"
+          ref: "add-healthchecks-RQA-312"
 
       - name: Checkout monorepo
         uses: actions/checkout@v3
@@ -59,14 +59,14 @@ jobs:
         working-directory: ./opentrons/hardware
 
       - name: Setup opentrons-emulation project
-        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
+        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup
 
       - name: Run emulated system
-        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
+        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           command: run
@@ -78,7 +78,7 @@ jobs:
         working-directory: ./opentrons/hardware
 
       - name: Teardown emulation
-        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
+        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           command: teardown

--- a/.github/workflows/yaml-sub-sanity-check.yaml
+++ b/.github/workflows/yaml-sub-sanity-check.yaml
@@ -31,16 +31,16 @@ jobs:
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:
-          ref: "ot3-firmware-header-creation-script-compatability-RQA-219"
+          ref: "fix-robot-server-not-getting-pipette-RQA-312"
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
+        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
         with:
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup-python-only
 
       - name: YAML Substitution
-        uses: Opentrons/opentrons-emulation@ot3-firmware-header-creation-script-compatability-RQA-219
+        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
         with:
           command: yaml-sub
           substitutions: >-

--- a/.github/workflows/yaml-sub-sanity-check.yaml
+++ b/.github/workflows/yaml-sub-sanity-check.yaml
@@ -31,16 +31,16 @@ jobs:
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:
-          ref: "fix-robot-server-not-getting-pipette-RQA-312"
+          ref: "add-healthchecks-RQA-312"
 
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
+        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
         with:
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup-python-only
 
       - name: YAML Substitution
-        uses: Opentrons/opentrons-emulation@fix-robot-server-not-getting-pipette-RQA-312
+        uses: Opentrons/opentrons-emulation@add-healthchecks-RQA-312
         with:
           command: yaml-sub
           substitutions: >-

--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ A [devcontainer](https://containers.dev/) specification is provided and cached f
 
 ![Still building](https://user-images.githubusercontent.com/502770/194160391-b4113217-1357-44a5-adf2-82c46abb1bbb.png)
 
-
 #### Done!
 
 ![Done building](https://user-images.githubusercontent.com/502770/194160726-8e2063b2-124d-4029-ab48-600cf845d175.png)
@@ -125,7 +124,7 @@ A [devcontainer](https://containers.dev/) specification is provided and cached f
 1. Wait until the emulator is up
 1. Open a new terminal
 1. Enter the command `make check-robot` to validate the robot is reachable
-1. To shut down the emulated robot go back to the terminal where you entered  `make ot2` or `make ot3` 
+1. To shut down the emulated robot go back to the terminal where you entered  `make ot2` or `make ot3`
    1. Click where logs are scrolling and press `ctrl` and `c` at the same time.
 
 #### Video of the preceding 6 steps

--- a/docker/bases_Dockerfile
+++ b/docker/bases_Dockerfile
@@ -61,6 +61,7 @@ RUN apt-get update \
       curl \
       git \
       libssl-dev \
+      net-tools \
       python3-dev \
       && rm -rf /var/lib/apt/lists/*
 RUN add-apt-repository ppa:deadsnakes/ppa && \

--- a/emulation_system/emulation_system/compose_file_creator/conversion/conversion_functions.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/conversion_functions.py
@@ -40,7 +40,6 @@ def _convert(
     ).build_services()
     return RuntimeComposeFileModel(
         is_remote=config_model.is_remote,
-        version=config_model.compose_file_version,
         services=services,
         networks={
             network_name: Network() for network_name in config_model.required_networks

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/abstract_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/abstract_service_builder.py
@@ -3,11 +3,24 @@
 from __future__ import annotations
 
 import pathlib
-from abc import ABC, abstractmethod
-from typing import Optional, Type, cast
+from abc import (
+    ABC,
+    abstractmethod,
+)
+from typing import (
+    Optional,
+    Type,
+    cast,
+)
 
-from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
-from emulation_system.compose_file_creator import BuildItem, Service
+from emulation_system import (
+    OpentronsEmulationConfiguration,
+    SystemConfigurationModel,
+)
+from emulation_system.compose_file_creator import (
+    BuildItem,
+    Service,
+)
 from emulation_system.compose_file_creator.config_file_settings import (
     FileMount,
     Hardware,
@@ -27,6 +40,7 @@ from emulation_system.compose_file_creator.types.final_types import (
     ServiceCommand,
     ServiceContainerName,
     ServiceEnvironment,
+    ServiceHealthcheck,
     ServiceImage,
     ServicePorts,
     ServiceTTY,
@@ -38,6 +52,7 @@ from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediateCommand,
     IntermediateDependsOn,
     IntermediateEnvironmentVariables,
+    IntermediateHealthcheck,
     IntermediateNetworks,
     IntermediatePorts,
     IntermediateVolumes,
@@ -147,6 +162,11 @@ class AbstractServiceBuilder(ABC):
         """Method to generate value for networks parameter for Service."""
         ...
 
+    @abstractmethod
+    def generate_healthcheck(self) -> IntermediateHealthcheck:
+        """Method to generate value for healthcheck parameter on Service."""
+        ...
+
     #############################################################
     # The following generate_* methods optionally return values #
     #############################################################
@@ -192,6 +212,8 @@ class AbstractServiceBuilder(ABC):
 
     def build_service(self) -> Service:
         """Method calling all generate* methods to build Service object."""
+        intermediate_healthcheck = self.generate_healthcheck()
+
         return Service(
             container_name=cast(ServiceContainerName, self.generate_container_name()),
             image=cast(ServiceImage, self.generate_image()),
@@ -203,4 +225,10 @@ class AbstractServiceBuilder(ABC):
             command=cast(ServiceCommand, self.generate_command()),
             networks=self.generate_networks(),
             depends_on=self.generate_depends_on(),
+            healthcheck=ServiceHealthcheck(
+                interval=f"{intermediate_healthcheck.interval}s",
+                retries=intermediate_healthcheck.retries,
+                timeout=f"{intermediate_healthcheck.timeout}s",
+                test=intermediate_healthcheck.command,
+            ),
         )

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/abstract_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/abstract_service_builder.py
@@ -3,24 +3,11 @@
 from __future__ import annotations
 
 import pathlib
-from abc import (
-    ABC,
-    abstractmethod,
-)
-from typing import (
-    Optional,
-    Type,
-    cast,
-)
+from abc import ABC, abstractmethod
+from typing import Optional, Type, cast
 
-from emulation_system import (
-    OpentronsEmulationConfiguration,
-    SystemConfigurationModel,
-)
-from emulation_system.compose_file_creator import (
-    BuildItem,
-    Service,
-)
+from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
+from emulation_system.compose_file_creator import BuildItem, Service
 from emulation_system.compose_file_creator.config_file_settings import (
     FileMount,
     Hardware,

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_can_server_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_can_server_service_builder.py
@@ -96,11 +96,12 @@ class ConcreteCANServerServiceBuilder(AbstractServiceBuilder):
 
     def generate_healthcheck(self) -> IntermediateHealthcheck:
         """Check to see if CAN service has established connections to ot3-services."""
+        port = self._ot3.can_server_bound_port
         return IntermediateHealthcheck(
             interval=10,
             retries=6,
             timeout=10,
-            command="netstat -nputw | grep -E '9898.*ESTABLISHED'",
+            command=f"netstat -nputw | grep -E '{port}.*ESTABLISHED'",
         )
 
     def generate_build_args(self) -> Optional[IntermediateBuildArgs]:

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_can_server_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_can_server_service_builder.py
@@ -13,6 +13,7 @@ from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediateCommand,
     IntermediateDependsOn,
     IntermediateEnvironmentVariables,
+    IntermediateHealthcheck,
     IntermediateNetworks,
     IntermediatePorts,
     IntermediateVolumes,
@@ -92,6 +93,15 @@ class ConcreteCANServerServiceBuilder(AbstractServiceBuilder):
         networks = self._config_model.required_networks
         self._logging_client.log_networks(networks)
         return networks
+
+    def generate_healthcheck(self) -> IntermediateHealthcheck:
+        """Check to see if CAN service has established connections to ot3-services."""
+        return IntermediateHealthcheck(
+            interval=10,
+            retries=6,
+            timeout=10,
+            command="netstat -nputw | grep -E '9898.*ESTABLISHED'",
+        )
 
     def generate_build_args(self) -> Optional[IntermediateBuildArgs]:
         """Generates value for build parameter."""

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_emulator_proxy_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_emulator_proxy_service_builder.py
@@ -18,6 +18,7 @@ from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediateCommand,
     IntermediateDependsOn,
     IntermediateEnvironmentVariables,
+    IntermediateHealthcheck,
     IntermediateNetworks,
     IntermediatePorts,
     IntermediateVolumes,
@@ -99,6 +100,15 @@ class ConcreteEmulatorProxyServiceBuilder(AbstractServiceBuilder):
         networks = self._config_model.required_networks
         self._logging_client.log_networks(networks)
         return networks
+
+    def generate_healthcheck(self) -> IntermediateHealthcheck:
+        """Check to see if emulator proxy service has started it's python service."""
+        return IntermediateHealthcheck(
+            interval=10,
+            retries=6,
+            timeout=10,
+            command="ps -eaf | grep 'python -m opentrons.hardware_control.emulation.app' | grep -v 'grep'",
+        )
 
     def generate_build_args(self) -> Optional[IntermediateBuildArgs]:
         """Generates value for build parameter."""

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_input_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_input_service_builder.py
@@ -1,15 +1,7 @@
 """Module containing ConcreteInputServiceBuilder."""
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-)
+from typing import Any, Dict, List, Optional
 
-from emulation_system import (
-    OpentronsEmulationConfiguration,
-    SystemConfigurationModel,
-)
+from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
 from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediateBuildArgs,
     IntermediateCommand,
@@ -26,7 +18,7 @@ from emulation_system.compose_file_creator.utilities.shared_functions import (
     add_ot3_firmware_named_volumes,
     get_build_args,
 )
-from .abstract_service_builder import AbstractServiceBuilder
+
 from ...config_file_settings import OpentronsRepository
 from ...errors import HardwareDoesNotExistError
 from ...input.hardware_models import (
@@ -50,6 +42,7 @@ from ...utilities.hardware_utils import (
     is_temperature_module,
     is_thermocycler_module,
 )
+from .abstract_service_builder import AbstractServiceBuilder
 
 
 class ConcreteInputServiceBuilder(AbstractServiceBuilder):

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_input_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_input_service_builder.py
@@ -1,15 +1,7 @@
 """Module containing ConcreteInputServiceBuilder."""
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-)
+from typing import Any, Dict, List, Optional
 
-from emulation_system import (
-    OpentronsEmulationConfiguration,
-    SystemConfigurationModel,
-)
+from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
 from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediateBuildArgs,
     IntermediateCommand,
@@ -26,7 +18,7 @@ from emulation_system.compose_file_creator.utilities.shared_functions import (
     add_ot3_firmware_named_volumes,
     get_build_args,
 )
-from .abstract_service_builder import AbstractServiceBuilder
+
 from ...config_file_settings import OpentronsRepository
 from ...errors import HardwareDoesNotExistError
 from ...input.hardware_models import (
@@ -50,6 +42,7 @@ from ...utilities.hardware_utils import (
     is_temperature_module,
     is_thermocycler_module,
 )
+from .abstract_service_builder import AbstractServiceBuilder
 
 
 class ConcreteInputServiceBuilder(AbstractServiceBuilder):
@@ -251,7 +244,9 @@ class ConcreteInputServiceBuilder(AbstractServiceBuilder):
             temp_vars["OT_API_FF_enableOT3HardwareController"] = True
             temp_vars["OT3_CAN_DRIVER_interface"] = "opentrons_sock"
             temp_vars["OT3_CAN_DRIVER_host"] = self._can_server_service_name
-            temp_vars["OT3_CAN_DRIVER_port"] = self.get_ot3(self._config_model).can_server_bound_port
+            temp_vars["OT3_CAN_DRIVER_port"] = self.get_ot3(
+                self._config_model
+            ).can_server_bound_port
 
         if is_module(self._container):
             temp_vars.update(self._container.get_serial_number_env_var())

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_input_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_input_service_builder.py
@@ -1,7 +1,15 @@
 """Module containing ConcreteInputServiceBuilder."""
-from typing import Any, Dict, List, Optional
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
 
-from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
+from emulation_system import (
+    OpentronsEmulationConfiguration,
+    SystemConfigurationModel,
+)
 from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediateBuildArgs,
     IntermediateCommand,
@@ -18,7 +26,7 @@ from emulation_system.compose_file_creator.utilities.shared_functions import (
     add_ot3_firmware_named_volumes,
     get_build_args,
 )
-
+from .abstract_service_builder import AbstractServiceBuilder
 from ...config_file_settings import OpentronsRepository
 from ...errors import HardwareDoesNotExistError
 from ...input.hardware_models import (
@@ -42,7 +50,6 @@ from ...utilities.hardware_utils import (
     is_temperature_module,
     is_thermocycler_module,
 )
-from .abstract_service_builder import AbstractServiceBuilder
 
 
 class ConcreteInputServiceBuilder(AbstractServiceBuilder):
@@ -244,7 +251,7 @@ class ConcreteInputServiceBuilder(AbstractServiceBuilder):
             temp_vars["OT_API_FF_enableOT3HardwareController"] = True
             temp_vars["OT3_CAN_DRIVER_interface"] = "opentrons_sock"
             temp_vars["OT3_CAN_DRIVER_host"] = self._can_server_service_name
-            temp_vars["OT3_CAN_DRIVER_port"] = 9898
+            temp_vars["OT3_CAN_DRIVER_port"] = self.get_ot3(self._config_model).can_server_bound_port
 
         if is_module(self._container):
             temp_vars.update(self._container.get_serial_number_env_var())

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_service_builder.py
@@ -11,6 +11,7 @@ from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediateCommand,
     IntermediateDependsOn,
     IntermediateEnvironmentVariables,
+    IntermediateHealthcheck,
     IntermediateNetworks,
     IntermediatePorts,
     IntermediateVolumes,
@@ -94,6 +95,15 @@ class ConcreteOT3ServiceBuilder(AbstractServiceBuilder):
         networks = self._config_model.required_networks
         self._logging_client.log_networks(networks)
         return networks
+
+    def generate_healthcheck(self) -> IntermediateHealthcheck:
+        """Check to see if OT-3 service has established connection to CAN Service."""
+        return IntermediateHealthcheck(
+            interval=10,
+            retries=6,
+            timeout=10,
+            command="netstat -nputw | grep -E '9898.*ESTABLISHED'",
+        )
 
     def generate_build_args(self) -> Optional[IntermediateBuildArgs]:
         """Generates value for build parameter."""

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_service_builder.py
@@ -98,11 +98,12 @@ class ConcreteOT3ServiceBuilder(AbstractServiceBuilder):
 
     def generate_healthcheck(self) -> IntermediateHealthcheck:
         """Check to see if OT-3 service has established connection to CAN Service."""
+        port = self._ot3.can_server_bound_port
         return IntermediateHealthcheck(
             interval=10,
             retries=6,
             timeout=10,
-            command="netstat -nputw | grep -E '9898.*ESTABLISHED'",
+            command=f"netstat -nputw | grep -E '{port}.*ESTABLISHED'",
         )
 
     def generate_build_args(self) -> Optional[IntermediateBuildArgs]:

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_smoothie_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_smoothie_service_builder.py
@@ -2,10 +2,7 @@
 import json
 from typing import Optional
 
-from emulation_system import (
-    OpentronsEmulationConfiguration,
-    SystemConfigurationModel,
-)
+from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
 from emulation_system.compose_file_creator.config_file_settings import (
     OpentronsRepository,
     SourceType,
@@ -25,8 +22,9 @@ from emulation_system.compose_file_creator.utilities.shared_functions import (
     add_opentrons_named_volumes,
     get_build_args,
 )
-from .abstract_service_builder import AbstractServiceBuilder
+
 from ...logging import SmoothieLoggingClient
+from .abstract_service_builder import AbstractServiceBuilder
 
 
 class ConcreteSmoothieServiceBuilder(AbstractServiceBuilder):

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_smoothie_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_smoothie_service_builder.py
@@ -2,7 +2,10 @@
 import json
 from typing import Optional
 
-from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
+from emulation_system import (
+    OpentronsEmulationConfiguration,
+    SystemConfigurationModel,
+)
 from emulation_system.compose_file_creator.config_file_settings import (
     OpentronsRepository,
     SourceType,
@@ -22,15 +25,15 @@ from emulation_system.compose_file_creator.utilities.shared_functions import (
     add_opentrons_named_volumes,
     get_build_args,
 )
-
-from ...logging import SmoothieLoggingClient
 from .abstract_service_builder import AbstractServiceBuilder
+from ...logging import SmoothieLoggingClient
 
 
 class ConcreteSmoothieServiceBuilder(AbstractServiceBuilder):
     """Concrete implementation of AbstractServiceBuilder for building a Smoothie Service."""
 
     SMOOTHIE_NAME = "smoothie"
+    SMOOTHIE_DEFAULT_PORT = 11000
 
     def __init__(
         self,
@@ -99,7 +102,7 @@ class ConcreteSmoothieServiceBuilder(AbstractServiceBuilder):
             interval=10,
             retries=6,
             timeout=10,
-            command="netstat -nputw | grep -E '11000.*ESTABLISHED'",
+            command=f"netstat -nputw | grep -E '{self.SMOOTHIE_DEFAULT_PORT}.*ESTABLISHED'",
         )
 
     def generate_build_args(self) -> Optional[IntermediateBuildArgs]:
@@ -150,7 +153,7 @@ class ConcreteSmoothieServiceBuilder(AbstractServiceBuilder):
     def generate_env_vars(self) -> Optional[IntermediateEnvironmentVariables]:
         """Generates value for environment parameter."""
         inner_env_vars = self._ot2.hardware_specific_attributes.dict()
-        inner_env_vars["port"] = 11000
+        inner_env_vars["port"] = self.SMOOTHIE_DEFAULT_PORT
         env_vars = {"OT_EMULATOR_smoothie": json.dumps(inner_env_vars)}
         self._logging_client.log_env_vars(env_vars)
         return env_vars

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_smoothie_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_smoothie_service_builder.py
@@ -2,7 +2,10 @@
 import json
 from typing import Optional
 
-from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
+from emulation_system import (
+    OpentronsEmulationConfiguration,
+    SystemConfigurationModel,
+)
 from emulation_system.compose_file_creator.config_file_settings import (
     OpentronsRepository,
     SourceType,
@@ -13,6 +16,7 @@ from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediateCommand,
     IntermediateDependsOn,
     IntermediateEnvironmentVariables,
+    IntermediateHealthcheck,
     IntermediateNetworks,
     IntermediatePorts,
     IntermediateVolumes,
@@ -21,9 +25,8 @@ from emulation_system.compose_file_creator.utilities.shared_functions import (
     add_opentrons_named_volumes,
     get_build_args,
 )
-
-from ...logging import SmoothieLoggingClient
 from .abstract_service_builder import AbstractServiceBuilder
+from ...logging import SmoothieLoggingClient
 
 
 class ConcreteSmoothieServiceBuilder(AbstractServiceBuilder):
@@ -91,6 +94,15 @@ class ConcreteSmoothieServiceBuilder(AbstractServiceBuilder):
         networks = self._config_model.required_networks
         self._logging_client.log_networks(networks)
         return networks
+
+    def generate_healthcheck(self) -> IntermediateHealthcheck:
+        """Check to see if smoothie service has established connection to the emulator proxy."""
+        return IntermediateHealthcheck(
+            interval=10,
+            retries=6,
+            timeout=10,
+            command="netstat -nputw | grep -E '11000.*ESTABLISHED'",
+        )
 
     def generate_build_args(self) -> Optional[IntermediateBuildArgs]:
         """Generates value for build parameter."""

--- a/emulation_system/emulation_system/compose_file_creator/errors.py
+++ b/emulation_system/emulation_system/compose_file_creator/errors.py
@@ -86,7 +86,7 @@ class IncorrectHardwareError(Exception):
 class HardwareDoesNotExistError(Exception):
     """Exception thrown when hardware does not exist."""
 
-    def __init__(self, specified_hardware: Hardware) -> None:
+    def __init__(self, specified_hardware: str) -> None:
         super().__init__(f"{specified_hardware} not defined.")
 
 

--- a/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
@@ -4,16 +4,9 @@ from __future__ import annotations
 from collections import Counter
 from typing import Dict, List, Mapping, Optional, cast
 
-from pydantic import (
-    BaseModel,
-    Field,
-    parse_file_as,
-    parse_obj_as,
-    root_validator,
-    validator,
-)
+from pydantic import BaseModel, Field, parse_file_as, parse_obj_as, root_validator
 
-from emulation_system.consts import DEFAULT_DOCKER_COMPOSE_VERSION, DEFAULT_NETWORK_NAME
+from emulation_system.consts import DEFAULT_NETWORK_NAME
 
 from ..config_file_settings import Hardware
 from ..errors import DuplicateHardwareNameError
@@ -28,7 +21,6 @@ class SystemConfigurationModel(BaseModel):
     Represents an entire system to be brought up.
     """
 
-    compose_file_version: Optional[str] = Field(alias="compose-file-version")
     system_unique_id: Optional[str] = Field(
         alias="system-unique-id", regex=r"^[A-Za-z0-9-]+$", min_length=1
     )
@@ -79,11 +71,6 @@ class SystemConfigurationModel(BaseModel):
             raise DuplicateHardwareNameError(duplicates)
 
         return values
-
-    @validator("compose_file_version", pre=True, always=True)
-    def set_default_version(cls, v: str) -> str:
-        """Sets default version if nothing is specified."""
-        return v or DEFAULT_DOCKER_COMPOSE_VERSION
 
     @property
     def modules_exist(self) -> bool:

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/magnetic_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/magnetic_module.py
@@ -37,7 +37,7 @@ class MagneticModuleInputModel(ModuleInputModel):
         model="mag_deck_v20", version="2.0.0", env_var_name="OT_EMULATOR_magdeck"
     )
     proxy_info: ClassVar[ProxyInfoModel] = ProxyInfoModel(
-        env_var_name="OT_EMULATOR_magnetic_proxy",
+        env_var_name="OT_EMULATOR_magdeck_proxy",
         emulator_port=10002,
         driver_port=11002,
     )

--- a/emulation_system/emulation_system/compose_file_creator/output/compose_file_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/output/compose_file_model.py
@@ -5,9 +5,20 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Union,
+)
 
-from pydantic import BaseModel, Extra, Field, constr
+from pydantic import (
+    BaseModel,
+    Extra,
+    Field,
+    constr,
+)
 
 
 class Config1(BaseModel):
@@ -149,7 +160,7 @@ class Healthcheck(BaseModel):
 
     disable: Optional[bool]
     interval: Optional[str]
-    retries: Optional[float]
+    retries: Optional[int]
     test: Optional[Union[str, List[str]]]
     timeout: Optional[str]
     start_period: Optional[str]
@@ -285,7 +296,8 @@ class External3(BaseModel):
 
 
 class ListOrDict(BaseModel):
-    __root__: Union[Dict[constr(regex=r'.+'), Optional[Union[str, float, bool]]], List[str]]  # type: ignore [valid-type]
+    __root__: Union[
+        Dict[constr(regex=r'.+'), Optional[Union[str, float, bool]]], List[str]]  # type: ignore [valid-type]
 
 
 class BlkioLimit(BaseModel):
@@ -472,7 +484,8 @@ class Service(BaseModel):
     cpus: Optional[Union[float, str]]
     cpuset: Optional[str]
     credential_spec: Optional[CredentialSpec]
-    depends_on: Optional[Union[List[str], Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), DependsOn]]]  # type: ignore [valid-type]
+    depends_on: Optional[
+        Union[List[str], Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), DependsOn]]]  # type: ignore [valid-type]
     device_cgroup_rules: Optional[List[str]]
     devices: Optional[List[str]]
     dns: Optional[StringOrList]
@@ -502,7 +515,8 @@ class Service(BaseModel):
     mem_swappiness: Optional[int]
     memswap_limit: Optional[Union[float, str]]
     network_mode: Optional[str]
-    networks: Optional[Union[List[str], Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Optional[Network1]]]]  # type: ignore [valid-type]
+    networks: Optional[
+        Union[List[str], Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Optional[Network1]]]]  # type: ignore [valid-type]
     oom_kill_disable: Optional[bool]
     oom_score_adj: Optional[int] = Field(None, ge=-1000.0, le=1000.0)
     pid: Optional[Optional[str]]
@@ -538,7 +552,10 @@ class ComposeSpecification(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    version: Optional[str] = Field(None, description='Version of the Compose specification used. Tools not implementing required version MUST reject the configuration file.')
+    version: Optional[str] = Field(
+        None,
+        description='Version of the Compose specification used. Tools not implementing required version MUST reject the configuration file.'
+        )
     services: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Service]]  # type: ignore [valid-type]
     networks: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Network]]  # type: ignore [valid-type]
     volumes: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Volume]]  # type: ignore [valid-type]

--- a/emulation_system/emulation_system/compose_file_creator/types/final_types.py
+++ b/emulation_system/emulation_system/compose_file_creator/types/final_types.py
@@ -9,7 +9,7 @@ mypy hate everything you have ever done.
 from typing import List, Optional, Union
 
 from .. import BuildItem
-from ..output.compose_file_model import ListOrDict, Port, Volume1
+from ..output.compose_file_model import Healthcheck, ListOrDict, Port, Volume1
 
 # TODO: Need to figure out what to do with DependsOn and Networks
 #       In compose_file_model.py they implement constr which mypy does not like.
@@ -23,3 +23,4 @@ ServiceImage = Optional[str]
 ServiceBuild = Optional[Union[str, BuildItem]]
 ServiceTTY = Optional[bool]
 ServiceCommand = Optional[Union[str, List[str]]]
+ServiceHealthcheck = Healthcheck

--- a/emulation_system/emulation_system/compose_file_creator/types/intermediate_types.py
+++ b/emulation_system/emulation_system/compose_file_creator/types/intermediate_types.py
@@ -1,5 +1,7 @@
 """Intermediate types that will be used for composing RuntimeComposeModel."""
 
+from dataclasses import dataclass
+
 from emulation_system.compose_file_creator import Service
 
 DockerServices = dict[str, Service]
@@ -10,3 +12,13 @@ IntermediateEnvironmentVariables = dict[str, str]
 IntermediateDependsOn = list[str]
 IntermediateCommand = list[str]
 IntermediateBuildArgs = dict[str, str]
+
+
+@dataclass
+class IntermediateHealthcheck:
+    """All values necessary for healthcheck."""
+
+    interval: int
+    retries: int
+    timeout: int
+    command: str

--- a/emulation_system/emulation_system/compose_file_creator/utilities/hardware_utils.py
+++ b/emulation_system/emulation_system/compose_file_creator/utilities/hardware_utils.py
@@ -6,10 +6,14 @@ from emulation_system.compose_file_creator.config_file_settings import (
     SourceType,
 )
 from emulation_system.compose_file_creator.input.hardware_models import (
+    HeaterShakerModuleInputModel,
+    MagneticModuleInputModel,
     ModuleInputModel,
     OT2InputModel,
     OT3InputModel,
     RobotInputModel,
+    TemperatureModuleInputModel,
+    ThermocyclerModuleInputModel,
 )
 from emulation_system.compose_file_creator.input.hardware_models.hardware_model import (
     HardwareModel,
@@ -34,6 +38,32 @@ def is_ot2(hardware: HardwareModel) -> TypeGuard[OT2InputModel]:
 def is_ot3(hardware: HardwareModel) -> TypeGuard[OT3InputModel]:
     """Whether hardware is an OT-3"""
     return isinstance(hardware, OT3InputModel)
+
+
+def is_heater_shaker_module(
+    hardware: HardwareModel,
+) -> TypeGuard[HeaterShakerModuleInputModel]:
+    """Whether hardware is a heater-shaker module."""
+    return isinstance(hardware, HeaterShakerModuleInputModel)
+
+
+def is_magnetic_module(hardware: HardwareModel) -> TypeGuard[MagneticModuleInputModel]:
+    """Whether hardware is a magnetic module."""
+    return isinstance(hardware, MagneticModuleInputModel)
+
+
+def is_temperature_module(
+    hardware: HardwareModel,
+) -> TypeGuard[TemperatureModuleInputModel]:
+    """Whether hardware is a temperature module."""
+    return isinstance(hardware, TemperatureModuleInputModel)
+
+
+def is_thermocycler_module(
+    hardware: HardwareModel,
+) -> TypeGuard[ThermocyclerModuleInputModel]:
+    """Whether hardware is a thermocycler module."""
+    return isinstance(hardware, ThermocyclerModuleInputModel)
 
 
 def is_remote_robot(hardware: HardwareModel) -> TypeGuard[RobotInputModel]:

--- a/emulation_system/tests/command_creators/test_emulation_system.py
+++ b/emulation_system/tests/command_creators/test_emulation_system.py
@@ -41,14 +41,18 @@ EXPECTED_YAML = convert_yaml(
         container_name: derek-emulator-proxy
         environment:
           OT_EMULATOR_heatershaker_proxy: '{"emulator_port": 10004, "driver_port": 11004}'
-          OT_EMULATOR_magnetic_proxy: '{"emulator_port": 10002, "driver_port": 11002}'
+          OT_EMULATOR_magdeck_proxy: '{"emulator_port": 10002, "driver_port": 11002}'
           OT_EMULATOR_temperature_proxy: '{"emulator_port": 10001, "driver_port": 11001}'
           OT_EMULATOR_thermocycler_proxy: '{"emulator_port": 10003, "driver_port": 11003}'
+        healthcheck:
+          interval: 10s
+          retries: 6
+          test: "ps -eaf | grep 'python -m opentrons.hardware_control.emulation.app' | grep -v 'grep'"
+          timeout: 10s
         image: emulator-proxy-remote:latest
         networks:
         - derek-local-network
         tty: true
-    version: '3.8'
     """
 )
 

--- a/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_emulator_proxy_service_builder.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_emulator_proxy_service_builder.py
@@ -72,7 +72,7 @@ def test_simple_can_server_values(
     assert env_root is not None
     assert len(env_root.values()) == 4
     assert "OT_EMULATOR_heatershaker_proxy" in env_root
-    assert "OT_EMULATOR_magnetic_proxy" in env_root
+    assert "OT_EMULATOR_magdeck_proxy" in env_root
     assert "OT_EMULATOR_temperature_proxy" in env_root
     assert "OT_EMULATOR_thermocycler_proxy" in env_root
 
@@ -81,7 +81,7 @@ def test_simple_can_server_values(
         == '{"emulator_port": 10004, "driver_port": 11004}'
     )
     assert (
-        env_root["OT_EMULATOR_magnetic_proxy"]
+        env_root["OT_EMULATOR_magdeck_proxy"]
         == '{"emulator_port": 10002, "driver_port": 11002}'
     )
     assert (

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_conversion_logic.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_conversion_logic.py
@@ -24,25 +24,8 @@ from tests.compose_file_creator.conversion_logic.conftest import (
     SERVICE_NAMES,
 )
 
-
-@pytest.fixture
-def version_only() -> Dict[str, Any]:
-    """Input file with only a compose-file-version specified."""
-    return {"compose-file-version": "4.0"}
-
-
 # TODO: Add following tests:
 #   - CAN network is created on OT3 breakout
-
-
-def test_version(
-    version_only: Dict[str, str],
-    testing_global_em_config: OpentronsEmulationConfiguration,
-) -> None:
-    """Confirms that version is set correctly on compose file."""
-    assert (
-        convert_from_obj(version_only, testing_global_em_config, False).version == "4.0"
-    )
 
 
 def test_service_keys(

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_healthcheck.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_healthcheck.py
@@ -1,0 +1,170 @@
+"""Test docker-compose healthcheck fields for all emulators."""
+
+from typing import Any, Dict
+
+import pytest
+from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
+
+from emulation_system import OpentronsEmulationConfiguration
+from emulation_system.compose_file_creator.conversion.conversion_functions import (
+    convert_from_obj,
+)
+from emulation_system.compose_file_creator.images import (
+    HeaterShakerModuleImages,
+    MagneticModuleImages,
+    TemperatureModuleImages,
+    ThermocyclerModuleImages,
+)
+from emulation_system.compose_file_creator.input.hardware_models import (
+    HeaterShakerModuleInputModel,
+    MagneticModuleInputModel,
+    TemperatureModuleInputModel,
+    ThermocyclerModuleInputModel,
+)
+
+MODULE_IMAGE_NAMES = (
+    HeaterShakerModuleImages().get_image_names()
+    + MagneticModuleImages().get_image_names()
+    + TemperatureModuleImages().get_image_names()
+    + ThermocyclerModuleImages().get_image_names()
+)
+
+
+def test_ot3_services_heathcheck(
+    ot3_only: Dict[str, Any], testing_global_em_config: OpentronsEmulationConfiguration
+) -> None:
+    """Confirm all ot3 firmware service and can-server healthchecks are correct."""
+    services = convert_from_obj(ot3_only, testing_global_em_config, False).services
+    assert services is not None
+    services_to_check = [
+        service
+        for service in services.values()
+        if service.image is not None
+        and ("ot3" in service.image or "can-server" in service.image)
+    ]
+    assert len(services_to_check) == 7
+    for service in services_to_check:
+        healthcheck = service.healthcheck
+        assert healthcheck is not None
+        assert healthcheck.interval == "10s"
+        assert healthcheck.timeout == "10s"
+        assert healthcheck.test == "netstat -nputw | grep -E '9898.*ESTABLISHED'"
+        assert healthcheck.start_period is None
+        assert healthcheck.disable is None
+
+
+def test_emulator_proxy_heathcheck(
+    ot3_only: Dict[str, Any], testing_global_em_config: OpentronsEmulationConfiguration
+) -> None:
+    """Confirm emulator proxy healthcheck is configured correctly."""
+    services = convert_from_obj(ot3_only, testing_global_em_config, False).services
+    assert services is not None
+    services_to_check = [
+        service
+        for service in services.values()
+        if service.image is not None and "emulator-proxy" in service.image
+    ]
+    assert len(services_to_check) == 1
+    for service in services_to_check:
+        healthcheck = service.healthcheck
+        assert healthcheck is not None
+        assert healthcheck.interval == "10s"
+        assert healthcheck.timeout == "10s"
+        assert (
+            healthcheck.test
+            == "ps -eaf | grep 'python -m opentrons.hardware_control.emulation.app' | grep -v 'grep'"
+        )
+        assert healthcheck.start_period is None
+        assert healthcheck.disable is None
+
+
+def test_smoothie_heathcheck(
+    ot2_only: Dict[str, Any], testing_global_em_config: OpentronsEmulationConfiguration
+) -> None:
+    """Confirm smoothie healthcheck is configured correctly."""
+    services = convert_from_obj(ot2_only, testing_global_em_config, False).services
+    assert services is not None
+    services_to_check = [
+        service
+        for service in services.values()
+        if service.image is not None and "smoothie" in service.image
+    ]
+    assert len(services_to_check) == 1
+    for service in services_to_check:
+        healthcheck = service.healthcheck
+        assert healthcheck is not None
+        assert healthcheck.interval == "10s"
+        assert healthcheck.timeout == "10s"
+        assert healthcheck.test == "netstat -nputw | grep -E '11000.*ESTABLISHED'"
+        assert healthcheck.start_period is None
+        assert healthcheck.disable is None
+
+
+@pytest.mark.parametrize("config", [lazy_fixture("ot2_only"), lazy_fixture("ot3_only")])
+def test_robot_server_healthcheck(
+    config: Dict[str, Any], testing_global_em_config: OpentronsEmulationConfiguration
+) -> None:
+    """Confirm healthcheck for robot-server on both OT-2 and OT-3 is correct."""
+    services = convert_from_obj(config, testing_global_em_config, False).services
+    assert services is not None
+    services_to_check = [
+        service
+        for service in services.values()
+        if service.image is not None and "robot-server" in service.image
+    ]
+    assert len(services_to_check) == 1
+    for service in services_to_check:
+        healthcheck = service.healthcheck
+        assert healthcheck is not None
+        assert healthcheck.interval == "10s"
+        assert healthcheck.timeout == "10s"
+        assert (
+            healthcheck.test
+            == "curl -s --location --request GET 'http://127.0.0.1:31950/modules' --header 'opentrons-version: *' || exit 1"
+        )
+        assert healthcheck.start_period is None
+        assert healthcheck.disable is None
+
+
+def __lookup_module_port(module_image: str) -> int:
+    module_image = module_image.replace(":latest", "")
+    if module_image in HeaterShakerModuleImages().get_image_names():
+        port = HeaterShakerModuleInputModel.proxy_info.emulator_port
+    elif module_image in MagneticModuleImages().get_image_names():
+        port = MagneticModuleInputModel.proxy_info.emulator_port
+    elif module_image in ThermocyclerModuleImages().get_image_names():
+        port = ThermocyclerModuleInputModel.proxy_info.emulator_port
+    elif module_image in TemperatureModuleImages().get_image_names():
+        port = TemperatureModuleInputModel.proxy_info.emulator_port
+    else:
+        raise Exception("You passed a bad module image")
+    return port
+
+
+def test_modules_healthcheck(
+    ot2_and_modules: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
+    """Confirm all 4 module's healthcheck is correct."""
+    services = convert_from_obj(
+        ot2_and_modules, testing_global_em_config, False
+    ).services
+    assert services is not None
+    services_to_check = [
+        service
+        for service in services.values()
+        if service.image is not None
+        and service.image.replace(":latest", "") in MODULE_IMAGE_NAMES
+    ]
+    assert len(services_to_check) == 4
+
+    for service in services_to_check:
+        assert service.image is not None
+        port = __lookup_module_port(service.image)
+        healthcheck = service.healthcheck
+        assert healthcheck is not None
+        assert healthcheck.interval == "10s"
+        assert healthcheck.timeout == "10s"
+        assert healthcheck.test == f"netstat -nputw | grep -E '{port}.*ESTABLISHED'"
+        assert healthcheck.start_period is None
+        assert healthcheck.disable is None

--- a/emulation_system/tests/compose_file_creator/input/test_configuration_file.py
+++ b/emulation_system/tests/compose_file_creator/input/test_configuration_file.py
@@ -19,7 +19,6 @@ from emulation_system.compose_file_creator.input.hardware_models import (
     TemperatureModuleInputModel,
     ThermocyclerModuleInputModel,
 )
-from emulation_system.consts import DEFAULT_DOCKER_COMPOSE_VERSION
 from tests.compose_file_creator.conftest import (
     HEATER_SHAKER_MODULE_ID,
     MAGNETIC_MODULE_ID,
@@ -50,13 +49,6 @@ def invalid_ot2_name(ot2_default: Dict[str, Any]) -> Dict[str, Any]:
     """Dict with ot2 that has invalid name."""
     ot2_default["id"] = "Invalid Name"
     return {"robot": ot2_default}
-
-
-@pytest.fixture
-def version_defined(ot2_and_modules: Dict[str, Any]) -> Dict[str, Any]:
-    """Structure of SystemConfigurationModel with robot, modules, and version."""
-    ot2_and_modules["compose-file-version"] = "3.7"
-    return ot2_and_modules
 
 
 @pytest.fixture
@@ -230,21 +222,6 @@ def test_get_by_id(ot2_and_modules: Dict[str, Any]) -> None:
     assert isinstance(
         system_config.get_by_id(THERMOCYCLER_MODULE_ID), ThermocyclerModuleInputModel
     )
-
-
-@pytest.mark.parametrize(
-    "config", [lazy_fixture("ot2_and_modules"), lazy_fixture("null_everything")]
-)
-def test_default_version(config: Dict[str, Any]) -> None:
-    """Test that version is set to default when not specified."""
-    system_config = create_system_configuration(config)
-    assert system_config.compose_file_version == DEFAULT_DOCKER_COMPOSE_VERSION
-
-
-def test_overriding_version(version_defined: Dict[str, Any]) -> None:
-    """Test that version is overridden correctly."""
-    system_config = create_system_configuration(version_defined)
-    assert system_config.compose_file_version == "3.7"
 
 
 @pytest.mark.parametrize(

--- a/emulation_system/tests/compose_file_creator/input/test_configuration_file.py
+++ b/emulation_system/tests/compose_file_creator/input/test_configuration_file.py
@@ -55,7 +55,6 @@ def invalid_ot2_name(ot2_default: Dict[str, Any]) -> Dict[str, Any]:
 def null_robot_with_modules(modules_only: Dict[str, Any]) -> Dict[str, Any]:
     """Structure of SystemConfigurationModel with modules and null robot."""
     modules_only["robot"] = None
-    modules_only["compose-file-version"] = None
     modules_only["system-unique-id"] = None
     return modules_only
 
@@ -64,7 +63,6 @@ def null_robot_with_modules(modules_only: Dict[str, Any]) -> Dict[str, Any]:
 def null_module_with_robot(ot2_only: Dict[str, Any]) -> Dict[str, Any]:
     """Structure of SystemConfigurationModel with modules and null robot."""
     ot2_only["modules"] = None
-    ot2_only["compose-file-version"] = None
     ot2_only["system-unique-id"] = None
     return ot2_only
 
@@ -73,7 +71,6 @@ def null_module_with_robot(ot2_only: Dict[str, Any]) -> Dict[str, Any]:
 def null_everything() -> Dict[str, None]:
     """Structure of SystemConfigurationModel with all values null."""
     return {
-        "compose-file-version": None,
         "robot": None,
         "modules": None,
         "system-unique-id": None,


### PR DESCRIPTION
# Overview

Add healthchecks to all emulator Docker containers

[Docker Healthcheck Documentation](https://docs.docker.com/compose/compose-file/#healthcheck)

# Changelog

- Add `net-tools` to ubuntu-base
- Add `generate_healthcheck` abstract method to AbstractServiceBuilder
- Implement `generate_healthcheck` for all ConcreteServiceBuilder` classes
- Remove `compose-file-version` field from input files. No longer specifying a version so that we can use [Docker Compose Specification](https://docs.docker.com/compose/compose-file/)
- Fix magdeck env variable so that it is actually used by underlying emulator
- Update existing tests to allow for healthcheck changes
- Add specific tests for healthcheck

# Review requests

None

# Risk assessment

Low
