### PR TITLE
chore: Add gripper EEPROM_FILENAME environment variable

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_service_builder.py
@@ -22,7 +22,7 @@ from emulation_system.compose_file_creator.utilities.shared_functions import (
     get_build_args,
 )
 
-from ...images import OT3PipettesImages
+from ...images import OT3GripperImages, OT3PipettesImages
 from ...logging import OT3LoggingClient
 from .abstract_service_builder import AbstractServiceBuilder
 from .service_info import ServiceInfo
@@ -177,7 +177,7 @@ class ConcreteOT3ServiceBuilder(AbstractServiceBuilder):
         """Generates value for environment parameter."""
         env_vars = {"CAN_SERVER_HOST": self._can_server_service_name}
 
-        if isinstance(self._service_info.image, OT3PipettesImages):
+        if isinstance(self._service_info.image, (OT3PipettesImages, OT3GripperImages)):
             env_vars["EEPROM_FILENAME"] = "eeprom.bin"
 
         self._logging_client.log_env_vars(env_vars)

--- a/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_ot3_service_builder.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_ot3_service_builder.py
@@ -185,9 +185,9 @@ def test_ot3_service_environment_variables(
     gripper = get_ot3_service(services, OT3Hardware.GRIPPER)
     pipettes = get_ot3_service(services, OT3Hardware.PIPETTES)
 
-    not_pipette_services = [head, gantry_x, gantry_y, bootloader, gripper]
+    not_pipette_or_gripper_services = [head, gantry_x, gantry_y, bootloader]
 
-    for service in not_pipette_services:
+    for service in not_pipette_or_gripper_services:
         service_env = service.environment
         assert service_env is not None
         env_root = cast(Dict[str, Any], service_env.__root__)
@@ -195,13 +195,14 @@ def test_ot3_service_environment_variables(
         assert len(env_root.values()) == 1
         assert "CAN_SERVER_HOST" in env_root
 
-    pipette_service_env = pipettes.environment
-    assert pipette_service_env is not None
-    pipette_env_root = cast(Dict[str, Any], pipette_service_env.__root__)
-    assert pipette_env_root is not None
-    assert len(pipette_env_root.values()) == 2
-    assert "CAN_SERVER_HOST" in pipette_env_root
-    assert "EEPROM_FILENAME" in pipette_env_root
+    for service in [pipettes, gripper]:
+        service_env = service.environment
+        assert service_env is not None
+        env_root = cast(Dict[str, Any], service_env.__root__)
+        assert env_root is not None
+        assert len(env_root.values()) == 2
+        assert "CAN_SERVER_HOST" in env_root
+        assert "EEPROM_FILENAME" in env_root
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Overview

Added `EEPROM_FILENAME` environment variable so the gripper emulator will work with robot-server.


# Changelog

- Add `EEPROM_FILENAME` environment variable with the value of `eeprom.bin` to gripper emulator
- Update tests

# Review requests

None

# Risk assessment

Low.

Tested against code in https://github.com/Opentrons/ot3-firmware/pull/461 and the OT-3 emulator now starts up.
