### PR TITLE
fix: Fix ubuntu-base-arm64 being built against x86_64

### DIFF
--- a/docker/bases_Dockerfile
+++ b/docker/bases_Dockerfile
@@ -22,7 +22,7 @@
 # ubuntu-base #
 ###############
 
-FROM --platform=${BUILDPLATFORM} ubuntu:22.04 as ubuntu-base-amd64
+FROM --platform=${TARGETPLATFORM} ubuntu:22.04 as ubuntu-base-amd64
 # Only need to fill out these args, in CI builds to push images to AWS ECR.
 # Don't bother when you are doing manual builds. It will break your cache and your
 # build will take forever

--- a/samples/ot3/ot3_remote.yaml
+++ b/samples/ot3/ot3_remote.yaml
@@ -15,7 +15,7 @@ robot:
   id: otie
   hardware: ot3
   source-type: remote
-  source-location: 815fb55e80656db10e6a3ecdefe7522a034446da
+  source-location: latest
   robot-server-source-type: remote
   robot-server-source-location: latest
   can-server-source-type: remote


### PR DESCRIPTION
# Overview

Fix ubuntu-base-arm64 Docker Image being built against x86_64

# Changelog

- Change `${BUILDPLATFORM}` to `${TARGETPLATFORM}`. 
  - What was happening was the system was setup to pull down an Ubuntu image with the same architecture as what the host platform was. Since we using a Linux runner to build both the ARM and x86_64 image, it was using the x86_64 version of Ubuntu to build ubuntu-base-arm64 which is obviously incorrect
- Remove hardcoded sha in ot3_remote.yaml
- Was failing to push packages in the `Upload Docker Image Bases` Github Action due to a 403 error. Had to go in to the package settings for `ubuntu-base-amd64`, `ubuntu-base-arm64`, `cpp-base-amd64`, and `cpp-base-arm64` and change it to allow `opentrons-emulation` to read and write the packages

# Review requests

None

# Risk assessment

Low, I pulled down all the images and ran `lscpu` against them and verified that the CPU architecture was correct. Also triggered `Upload Docker Image Bases` manually [here](https://github.com/Opentrons/opentrons-emulation/actions/runs/3341064888/jobs/5531873969) and verified that all images were pushed successfully.
