### PR TITLE
chore: Parameterize Github Action Refs

### DIFF
--- a/.github/workflows/emulation-system-lint-test.yaml
+++ b/.github/workflows/emulation-system-lint-test.yaml
@@ -34,8 +34,10 @@ jobs:
       - name: Checkout opentrons-emulation repository
         uses: actions/checkout@v3
         with:
-          ref: multi-arch-builds-RQA-335
+          ref: ${{ github.sha }}
 
+      # Only change `main` in Opentrons/opentrons-emulation@main
+      # if making changes to .github/actions or action.yaml
       - name: Setup Emulation
         uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
         with:

--- a/.github/workflows/emulation-system-lint-test.yaml
+++ b/.github/workflows/emulation-system-lint-test.yaml
@@ -39,7 +39,7 @@ jobs:
       # Only change `main` in Opentrons/opentrons-emulation@main
       # if making changes to .github/actions or action.yaml
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
+        uses: Opentrons/opentrons-emulation@main
         with:
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup-python-only

--- a/.github/workflows/repo-action-validation.yaml
+++ b/.github/workflows/repo-action-validation.yaml
@@ -38,8 +38,10 @@ jobs:
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:
-          ref: "multi-arch-builds-RQA-335"
+          ref: ${{ github.sha }}
 
+      # Only change `main` in Opentrons/opentrons-emulation@main
+      # if making changes to .github/actions or action.yaml
       - name: Setup Emulation
         uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
         with:
@@ -47,6 +49,8 @@ jobs:
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup
 
+      # Only change `main` in Opentrons/opentrons-emulation@main
+      # if making changes to .github/actions or action.yaml
       - name: Run Emulation
         uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
         with:
@@ -59,6 +63,8 @@ jobs:
       - name: Test Emulation
         run: "curl --request GET --header 'opentrons-version: *' http://localhost:31950/modules"
 
+      # Only change `main` in Opentrons/opentrons-emulation@main
+      # if making changes to .github/actions or action.yaml
       - name: Teardown Emulation
         uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
         with:

--- a/.github/workflows/repo-action-validation.yaml
+++ b/.github/workflows/repo-action-validation.yaml
@@ -43,7 +43,7 @@ jobs:
       # Only change `main` in Opentrons/opentrons-emulation@main
       # if making changes to .github/actions or action.yaml
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
+        uses: Opentrons/opentrons-emulation@main
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           cache-break: ${{ github.event.inputs.cache-break }}
@@ -52,7 +52,7 @@ jobs:
       # Only change `main` in Opentrons/opentrons-emulation@main
       # if making changes to .github/actions or action.yaml
       - name: Run Emulation
-        uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
+        uses: Opentrons/opentrons-emulation@main
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           command: run
@@ -66,7 +66,7 @@ jobs:
       # Only change `main` in Opentrons/opentrons-emulation@main
       # if making changes to .github/actions or action.yaml
       - name: Teardown Emulation
-        uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
+        uses: Opentrons/opentrons-emulation@main
         with:
           input-file: ${PWD}/samples/${{ matrix.file }}
           command: teardown

--- a/.github/workflows/run-hardware-tests.yaml
+++ b/.github/workflows/run-hardware-tests.yaml
@@ -54,7 +54,7 @@ jobs:
       # Only change `main` in Opentrons/opentrons-emulation@main
       # if making changes to .github/actions or action.yaml
       - name: Setup opentrons-emulation project
-        uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
+        uses: Opentrons/opentrons-emulation@main
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           cache-break: ${{ github.event.inputs.cache-break }}
@@ -63,7 +63,7 @@ jobs:
       # Only change `main` in Opentrons/opentrons-emulation@main
       # if making changes to .github/actions or action.yaml
       - name: Run emulated system
-        uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
+        uses: Opentrons/opentrons-emulation@main
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           command: run
@@ -77,7 +77,7 @@ jobs:
       # Only change `main` in Opentrons/opentrons-emulation@main
       # if making changes to .github/actions or action.yaml
       - name: Teardown emulation
-        uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
+        uses: Opentrons/opentrons-emulation@main
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           command: teardown

--- a/.github/workflows/run-hardware-tests.yaml
+++ b/.github/workflows/run-hardware-tests.yaml
@@ -3,18 +3,11 @@
 name: "Run Hardware Tests"
 
 on:
-  push:
-    branches:
-      - 'main'
-      - 'release-*'
   pull_request:
     paths:
       - '.github/workflows/run-hardware-tests.yaml'
       - '.github/actions/**'
       - 'action.yaml'
-      - 'docker/**'
-      - './Makefile'
-      - 'emulation_system/**'
   schedule:
     # Running at 1:37 AM, so we don't get delays from so many people running nightly actions at midnight/top of hour
     - cron: '37 1 * * 1-5'
@@ -34,7 +27,7 @@ jobs:
       - name: Checkout opentrons-emulation repository
         uses: actions/checkout@v3
         with:
-          ref: "multi-arch-builds-RQA-335"
+          ref: ${{ github.sha }}
 
       - name: Checkout monorepo
         uses: actions/checkout@v3
@@ -58,6 +51,8 @@ jobs:
         run: make setup
         working-directory: ./opentrons/hardware
 
+      # Only change `main` in Opentrons/opentrons-emulation@main
+      # if making changes to .github/actions or action.yaml
       - name: Setup opentrons-emulation project
         uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
         with:
@@ -65,6 +60,8 @@ jobs:
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup
 
+      # Only change `main` in Opentrons/opentrons-emulation@main
+      # if making changes to .github/actions or action.yaml
       - name: Run emulated system
         uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
         with:
@@ -77,19 +74,21 @@ jobs:
           OT3_CAN_DRIVER_INTERFACE: opentrons_sock
         working-directory: ./opentrons/hardware
 
+      # Only change `main` in Opentrons/opentrons-emulation@main
+      # if making changes to .github/actions or action.yaml
       - name: Teardown emulation
         uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
         with:
           input-file: ${PWD}/samples/ot3/ot3_remote.yaml
           command: teardown
-#
-#      - name: Send results notification
-#        if: ${{ failure() }}
-#        uses: rtCamp/action-slack-notify@v2
-#        env:
-#          SLACK_WEBHOOK: ${{ secrets.EMULATION_NIGHTLY_TESTING_SLACK_WEBHOOK }}
-#          SLACK_USERNAME: "OT-3 Integration Tests Results"
-#          SLACK_TITLE: Test Run Results
-#          SLACK_MESSAGE: ${{ job.status }}
-#          SLACK_COLOR: ${{ job.status }}
-#          SLACK_ICON_EMOJI: ':rocket:'
+
+      - name: Send results notification
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.EMULATION_NIGHTLY_TESTING_SLACK_WEBHOOK }}
+          SLACK_USERNAME: "OT-3 Integration Tests Results"
+          SLACK_TITLE: Test Run Results
+          SLACK_MESSAGE: ${{ job.status }}
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_ICON_EMOJI: ':rocket:'

--- a/.github/workflows/test-samples-files.yaml
+++ b/.github/workflows/test-samples-files.yaml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: opentrons-emulation
+          ref: ${{ github.sha }}
 
       - name: Checkout Monorepo
         uses: actions/checkout@v3

--- a/.github/workflows/yaml-sub-sanity-check.yaml
+++ b/.github/workflows/yaml-sub-sanity-check.yaml
@@ -31,14 +31,18 @@ jobs:
       - name: Checkout opentrons-emulation
         uses: actions/checkout@v3
         with:
-          ref: "multi-arch-builds-RQA-335"
+          ref: ${{ github.sha }}
 
+      # Only change `main` in Opentrons/opentrons-emulation@main
+      # if making changes to .github/actions or action.yaml
       - name: Setup Emulation
         uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
         with:
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup-python-only
 
+      # Only change `main` in Opentrons/opentrons-emulation@main
+      # if making changes to .github/actions or action.yaml
       - name: YAML Substitution
         uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
         with:

--- a/.github/workflows/yaml-sub-sanity-check.yaml
+++ b/.github/workflows/yaml-sub-sanity-check.yaml
@@ -36,7 +36,7 @@ jobs:
       # Only change `main` in Opentrons/opentrons-emulation@main
       # if making changes to .github/actions or action.yaml
       - name: Setup Emulation
-        uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
+        uses: Opentrons/opentrons-emulation@main
         with:
           cache-break: ${{ github.event.inputs.cache-break }}
           command: setup-python-only
@@ -44,7 +44,7 @@ jobs:
       # Only change `main` in Opentrons/opentrons-emulation@main
       # if making changes to .github/actions or action.yaml
       - name: YAML Substitution
-        uses: Opentrons/opentrons-emulation@multi-arch-builds-RQA-335
+        uses: Opentrons/opentrons-emulation@main
         with:
           command: yaml-sub
           substitutions: >-


### PR DESCRIPTION
# Overview

Fixing ref logic in Github Actions so it won't be necessary to be updating the refs for every PR.

# Changelog

- Any checkout of `opentrons-emulation` has been changed to `${{ github.sha }}` to pull the latest commit for the current branch.
- Any call to the `opentrons-emulation` Github Action will reference `main` unless editing `action.yaml` or any files in `.github/actions`. 
- Change run conditions for `Run Hardware Tests` Github action. Only run if action anything related to actions is being changed and on schedule. Not gaining anything by running it otherwise. 
- Turn Slack notifications for `Run Hardware Tests` back on
- Change committing model to merge to `main` and any releases will just be a tagged commit on `main`

# Review requests

None

# Risk assessment

Low
