### PR TITLE
fix: Fix hardware emulation level Thermocycler command

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/thermocycler_module.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/thermocycler_module.py
@@ -1,5 +1,9 @@
 """Model and attributes for Thermocycler Module."""
-from typing import ClassVar, List, Optional
+from typing import (
+    ClassVar,
+    List,
+    Optional,
+)
 
 from pydantic import Field
 from typing_extensions import Literal
@@ -11,9 +15,12 @@ from emulation_system.compose_file_creator.config_file_settings import (
     SourceRepositories,
     TemperatureModelSettings,
 )
-
+from .module_model import (
+    FirmwareSerialNumberModel,
+    ModuleInputModel,
+    ProxyInfoModel,
+)
 from ..hardware_specific_attributes import HardwareSpecificAttributes
-from .module_model import FirmwareSerialNumberModel, ModuleInputModel, ProxyInfoModel
 
 
 class ThermocyclerModuleAttributes(HardwareSpecificAttributes):
@@ -64,8 +71,7 @@ class ThermocyclerModuleInputModel(ModuleInputModel):
     ) -> Optional[List[str]]:
         """Get command for heater shaker when it is being emulated at hardware level."""
         return [
-            "--socket",
-            f"http://{emulator_proxy_name}:{self.proxy_info.emulator_port}",
+            f"--socket http://{emulator_proxy_name}:{self.proxy_info.emulator_port}",
         ]
 
     def get_firmware_level_command(

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_conversion_logic.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_conversion_logic.py
@@ -1,15 +1,26 @@
 """Tests for converting input file to DockerComposeFile."""
-from typing import Any, Dict, List, cast
+from typing import (
+    Any,
+    Dict,
+    List,
+    cast,
+)
 
 import pytest
 
 from emulation_system import OpentronsEmulationConfiguration
-from emulation_system.compose_file_creator import BuildItem, Service
+from emulation_system.compose_file_creator import (
+    BuildItem,
+    Service,
+)
 from emulation_system.compose_file_creator.conversion.conversion_functions import (
     convert_from_obj,
 )
 from emulation_system.compose_file_creator.output.compose_file_model import Network
-from emulation_system.consts import DEFAULT_NETWORK_NAME, DOCKERFILE_DIR_LOCATION
+from emulation_system.consts import (
+    DEFAULT_NETWORK_NAME,
+    DOCKERFILE_DIR_LOCATION,
+)
 from tests.compose_file_creator.conftest import (
     EMULATOR_PROXY_ID,
     HEATER_SHAKER_MODULE_ID,
@@ -23,6 +34,7 @@ from tests.compose_file_creator.conversion_logic.conftest import (
     CONTAINER_NAME_TO_IMAGE,
     SERVICE_NAMES,
 )
+
 
 # TODO: Add following tests:
 #   - CAN network is created on OT3 breakout
@@ -57,8 +69,8 @@ def test_service_container_name(
 ) -> None:
     """Verify container name matches service name."""
     assert (
-        robot_with_mount_and_modules_services[service_name].container_name
-        == service_name
+            robot_with_mount_and_modules_services[service_name].container_name
+            == service_name
     )
 
 
@@ -68,8 +80,8 @@ def test_service_image(
 ) -> None:
     """Verify image name is correct."""
     assert (
-        robot_with_mount_and_modules_services[service_name].image
-        == f"{CONTAINER_NAME_TO_IMAGE[service_name]}:latest"
+            robot_with_mount_and_modules_services[service_name].image
+            == f"{CONTAINER_NAME_TO_IMAGE[service_name]}:latest"
     )
 
 
@@ -138,7 +150,7 @@ def test_can_server_port_not_exposed(
 @pytest.mark.parametrize(
     "service_name, expected_value",
     [
-        [THERMOCYCLER_MODULE_ID, ["--socket", f"http://{EMULATOR_PROXY_ID}:10003"]],
+        [THERMOCYCLER_MODULE_ID, ["--socket http://{EMULATOR_PROXY_ID}:10003"]],
         [TEMPERATURE_MODULE_ID, [EMULATOR_PROXY_ID]],
         [MAGNETIC_MODULE_ID, [EMULATOR_PROXY_ID]],
         [HEATER_SHAKER_MODULE_ID, ["--socket", f"http://{EMULATOR_PROXY_ID}:10004"]],


### PR DESCRIPTION
# Overview

When starting the Thermocycler in `hardware` emulation mode, it was throwing an error saying the command was bad. 

Found that the command was getting into 2 separate strings. This was telling Docker that there was 2 separate

# Changelog

- Make Thermocycler command a single string
- Update tests

# Review requests

None

# Risk assessment

Low, it's already broken