### PR TITLE
fix: Build monorepo against python3.7

### DIFF
--- a/docker/bases_Dockerfile
+++ b/docker/bases_Dockerfile
@@ -35,6 +35,8 @@ ARG URL
 ARG VENDOR
 ARG DOCKER_CMD
 ARG DESCRIPTION
+ARG MONOREPO_PYTHON="python3.7"
+ARG STATE_MANAGER_PYTHON="python3.8"
 
 LABEL opentrons-emulation.trigger=$TRIGGER
 LABEL opentrons-emulation.build_date=$BUILD_DATE
@@ -79,11 +81,20 @@ RUN apt-get update && \
 
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
-     apt-get install \
+    apt-get install \
     	--no-install-recommends \
        	-y \
+    	python3.7 \
+    	python3.7-venv \
     	python3.8 \
     	python3.8-venv
+
+RUN ( \
+    cd /usr/bin && \
+    ln -s ${STATE_MANAGER_PYTHON} state_manager_python && \
+    ln -s ${MONOREPO_PYTHON} monorepo_python \
+    )
+
 
 FROM ubuntu-base-amd64 as ubuntu-base-arm64
 
@@ -99,7 +110,6 @@ ARG TARGETARCH
 FROM ubuntu-base-${TARGETARCH} as python-base
 
 ENV NODE_VERSION 14
-ENV OT_PYTHON "/usr/bin/python3.10"
 
 RUN apt-get update && \
     apt-get install \
@@ -111,10 +121,11 @@ RUN apt-get update && \
     pkgconf \
     libpython3.10-dev \
     libpython3.8-dev \
+    libpython3.7-dev \
     python3-pip
 
-RUN pip install --upgrade pip setuptools wheel && \
-    pip install pipenv
+RUN monorepo_python -m pip install --upgrade pip setuptools wheel && \
+    monorepo_python -m pip install pipenv
 
 
 RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -144,38 +144,38 @@ case $FULL_COMMAND in
   # Firmware Level
 
   build-thermocycler-firmware|build-heater-shaker-firmware|build-magdeck-firmware|build-tempdeck-firmware|build-emulator-proxy|build-robot-server|build-common-firmware|build-smoothie|build-can-server)
-    pip uninstall --yes /dist/*
-    (cd /opentrons/shared-data/python && python3 setup.py bdist_wheel -d /dist/)
-    (cd /opentrons/api && python3 setup.py bdist_wheel -d /dist/)
-    (cd /opentrons/notify-server && python3 setup.py bdist_wheel -d /dist/)
-    (cd /opentrons/robot-server && python3 setup.py bdist_wheel -d /dist/)
-    (cd /opentrons/hardware && python3 setup.py bdist_wheel -d /dist/)
-    pip install /dist/*
+    monorepo_python -m pip uninstall --yes /dist/*
+    (cd /opentrons/shared-data/python && monorepo_python setup.py bdist_wheel -d /dist/)
+    (cd /opentrons/api && monorepo_python setup.py bdist_wheel -d /dist/)
+    (cd /opentrons/notify-server && monorepo_python setup.py bdist_wheel -d /dist/)
+    (cd /opentrons/robot-server && monorepo_python setup.py bdist_wheel -d /dist/)
+    (cd /opentrons/hardware && monorepo_python setup.py bdist_wheel -d /dist/)
+    monorepo_python -m pip install /dist/*
     ;;
 
   run-thermocycler-firmware)
-    bash -c "python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator thermocycler $OTHER_ARGS"
+    bash -c "monorepo_python -m opentrons.hardware_control.emulation.scripts.run_module_emulator thermocycler $OTHER_ARGS"
     ;;
   run-heater-shaker-firmware)
-    bash -c "python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator heatershaker $OTHER_ARGS"
+    bash -c "monorepo_python -m opentrons.hardware_control.emulation.scripts.run_module_emulator heatershaker $OTHER_ARGS"
     ;;
   run-tempdeck-firmware)
-    bash -c "python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator tempdeck $OTHER_ARGS"
+    bash -c "monorepo_python -m opentrons.hardware_control.emulation.scripts.run_module_emulator tempdeck $OTHER_ARGS"
     ;;
   run-magdeck-firmware)
-    bash -c "python3 -m opentrons.hardware_control.emulation.scripts.run_module_emulator magdeck $OTHER_ARGS"
+    bash -c "monorepo_python -m opentrons.hardware_control.emulation.scripts.run_module_emulator magdeck $OTHER_ARGS"
     ;;
   run-robot-server)
     bash -c "uvicorn "robot_server:app" --host 0.0.0.0 --port 31950 --ws wsproto"
     ;;
   run-emulator-proxy)
-    python3 -m opentrons.hardware_control.emulation.app
+    monorepo_python -m opentrons.hardware_control.emulation.app
     ;;
   run-smoothie)
-    bash -c "python3 -m opentrons.hardware_control.emulation.scripts.run_smoothie"
+    bash -c "monorepo_python -m opentrons.hardware_control.emulation.scripts.run_smoothie"
     ;;
   run-can-server)
-    bash -c "python3 -m opentrons_hardware.scripts.sim_socket_can"
+    bash -c "monorepo_python -m opentrons_hardware.scripts.sim_socket_can"
     ;;
 
   stop-thermocycler-firmware|stop-tempdeck-firmware|stop-magdeck-firmware)


### PR DESCRIPTION
# Overview

Monorepo was not building against python3.7
Now it is.

# Changelog

- Install Python 3.7 into ubuntu-base
- Symlink it as `monorepo_python`
- Symlink Python 3.8 as `state_manager_python`

# Review requests

None

# Risk assessment

Low, it's already broken
