### PR TITLE
fix: changed specification of state manager IP

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -133,7 +133,7 @@ case $FULL_COMMAND in
     # 9999 is the hardcoded state manager port
     (
       cd /ot3-firmware/state_manager && \
-      ../stm32-tools/poetry/bin/poetry run python3 -m state_manager.state_manager --right-pipette P1000-multi-96 localhost 9999
+      ../stm32-tools/poetry/bin/poetry run python3 -m state_manager.state_manager --right-pipette P1000-multi-96 0.0.0.0 9999
     )
     ;;
 


### PR DESCRIPTION
# Overview

Changes how the ip address for the state manager is passed from `entrypoint.sh`. This is necessary to allow the state manager to receive any UDP traffic through Docker.

Tested on a local setup. Without this, it is impossible to send a message to the state manager and get a response. With this change, I can send UDP messages and get responses.

# Changelog

* Changed the state manager IP address designation from `localhost` to `0.0.0.0`

# Review requests


# Risk assessment
Minimal, this was already broken and the state manager is disabled right now.