### PR TITLE
fix: Make containers wait for emulator-proxy to be healthy before starting (RQA-340)

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/abstract_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/abstract_service_builder.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pathlib
 from abc import ABC, abstractmethod
-from typing import Optional, Type, cast
+from typing import Dict, Optional, Type, cast, overload
 
 from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
 from emulation_system.compose_file_creator import BuildItem, Service
@@ -36,6 +36,7 @@ from emulation_system.compose_file_creator.types.final_types import (
 )
 from emulation_system.compose_file_creator.types.input_types import Robots
 from emulation_system.compose_file_creator.types.intermediate_types import (
+    DependsOnConditions,
     IntermediateBuildArgs,
     IntermediateCommand,
     IntermediateDependsOn,
@@ -130,8 +131,21 @@ class AbstractServiceBuilder(ABC):
         )
         return container_name
 
+    @overload
+    @staticmethod
     def _cast_depends_on(
-        self, depends_on: Optional[IntermediateDependsOn]
+        depends_on: Dict[str, DependsOnConditions]
+    ) -> ServiceDependsOn:
+        ...
+
+    @overload
+    @staticmethod
+    def _cast_depends_on(depends_on: None) -> None:
+        ...
+
+    @staticmethod
+    def _cast_depends_on(
+        depends_on: Dict[str, DependsOnConditions] | None
     ) -> Optional[ServiceDependsOn]:
         final_val: Optional[ServiceDependsOn] = None
         if depends_on is not None:
@@ -223,7 +237,12 @@ class AbstractServiceBuilder(ABC):
             environment=cast(ServiceEnvironment, self.generate_env_vars()),
             command=cast(ServiceCommand, self.generate_command()),
             networks=self.generate_networks(),
-            depends_on=self._cast_depends_on(self.generate_depends_on()),
+            # Have to call with AbstractServiceBuilder instead of self due to
+            # https://github.com/python/mypy/issues/7781
+            # It seems like the issue is fixed, just hasn't made it into a mypy release yet
+            depends_on=AbstractServiceBuilder._cast_depends_on(
+                self.generate_depends_on()
+            ),
             healthcheck=ServiceHealthcheck(
                 interval=f"{intermediate_healthcheck.interval}s",
                 retries=intermediate_healthcheck.retries,

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_input_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_input_service_builder.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 
 from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
 from emulation_system.compose_file_creator.types.intermediate_types import (
+    DependsOnConditions,
     IntermediateBuildArgs,
     IntermediateCommand,
     IntermediateDependsOn,
@@ -213,12 +214,12 @@ class ConcreteInputServiceBuilder(AbstractServiceBuilder):
 
     def generate_depends_on(self) -> Optional[IntermediateDependsOn]:
         """Generates value for depends_on parameter."""
-        dependencies = []
+        dependencies = IntermediateDependsOn()
         if self._emulator_proxy_name is not None:
-            dependencies.append(self._emulator_proxy_name)
+            dependencies[self._emulator_proxy_name] = DependsOnConditions.HEALTHY
 
         if self._smoothie_name is not None and is_ot2(self._container):
-            dependencies.append(self._smoothie_name)
+            dependencies[self._smoothie_name] = DependsOnConditions.STARTED
 
         deps = dependencies if len(dependencies) != 0 else None
         self._logging_client.log_depends_on(deps)

--- a/emulation_system/emulation_system/compose_file_creator/logging/input_logging_client.py
+++ b/emulation_system/emulation_system/compose_file_creator/logging/input_logging_client.py
@@ -75,7 +75,7 @@ class InputLoggingClient(AbstractLoggingClient):
         if depends_on is None:
             output = ["No depends_on will be added."]
         else:
-            tabbed_depends_on = [f'\t"{depends_on}"' for depends_on in depends_on]
+            tabbed_depends_on = [f'\t"{name}"' for name in depends_on.keys()]
             output = [
                 "Adding the following depends_on:",
                 *tabbed_depends_on,

--- a/emulation_system/emulation_system/compose_file_creator/output/compose_file_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/output/compose_file_model.py
@@ -51,7 +51,7 @@ class DependsOn(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    condition: Condition
+    condition: str
 
 
 class Extend(BaseModel):
@@ -555,7 +555,7 @@ class ComposeSpecification(BaseModel):
     version: Optional[str] = Field(
         None,
         description='Version of the Compose specification used. Tools not implementing required version MUST reject the configuration file.'
-        )
+    )
     services: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Service]]  # type: ignore [valid-type]
     networks: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Network]]  # type: ignore [valid-type]
     volumes: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Volume]]  # type: ignore [valid-type]

--- a/emulation_system/emulation_system/compose_file_creator/types/final_types.py
+++ b/emulation_system/emulation_system/compose_file_creator/types/final_types.py
@@ -6,14 +6,19 @@ Do not use these types when implementing business logic, they suck, and it makes
 mypy hate everything you have ever done.
 """
 
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from .. import BuildItem
-from ..output.compose_file_model import Healthcheck, ListOrDict, Port, Volume1
+from ..output.compose_file_model import (
+    DependsOn,
+    Healthcheck,
+    ListOrDict,
+    Port,
+    Volume1,
+)
 
 # TODO: Need to figure out what to do with DependsOn and Networks
 #       In compose_file_model.py they implement constr which mypy does not like.
-
 
 ServiceVolumes = Optional[List[Union[str, Volume1]]]
 ServicePorts = Optional[List[Union[float, str, Port]]]
@@ -24,3 +29,4 @@ ServiceBuild = Optional[Union[str, BuildItem]]
 ServiceTTY = Optional[bool]
 ServiceCommand = Optional[Union[str, List[str]]]
 ServiceHealthcheck = Healthcheck
+ServiceDependsOn = Optional[Dict[str, DependsOn]]

--- a/emulation_system/emulation_system/compose_file_creator/types/final_types.py
+++ b/emulation_system/emulation_system/compose_file_creator/types/final_types.py
@@ -6,7 +6,7 @@ Do not use these types when implementing business logic, they suck, and it makes
 mypy hate everything you have ever done.
 """
 
-from typing import Dict, List, Optional, Union
+from typing import List, TypeAlias
 
 from .. import BuildItem
 from ..output.compose_file_model import (
@@ -20,13 +20,13 @@ from ..output.compose_file_model import (
 # TODO: Need to figure out what to do with DependsOn and Networks
 #       In compose_file_model.py they implement constr which mypy does not like.
 
-ServiceVolumes = Optional[List[Union[str, Volume1]]]
-ServicePorts = Optional[List[Union[float, str, Port]]]
-ServiceEnvironment = Optional[ListOrDict]
-ServiceContainerName = Optional[str]
-ServiceImage = Optional[str]
-ServiceBuild = Optional[Union[str, BuildItem]]
-ServiceTTY = Optional[bool]
-ServiceCommand = Optional[Union[str, List[str]]]
-ServiceHealthcheck = Healthcheck
-ServiceDependsOn = Optional[Dict[str, DependsOn]]
+ServiceVolumes: TypeAlias = List[str | Volume1] | None
+ServicePorts: TypeAlias = List[float | str | Port] | None
+ServiceEnvironment: TypeAlias = ListOrDict | None
+ServiceContainerName: TypeAlias = str | None
+ServiceImage: TypeAlias = str | None
+ServiceBuild: TypeAlias = str | BuildItem | None
+ServiceTTY: TypeAlias = bool | None
+ServiceCommand: TypeAlias = str | List[str] | None
+ServiceHealthcheck: TypeAlias = Healthcheck
+ServiceDependsOn: TypeAlias = dict[str, DependsOn] | None

--- a/emulation_system/emulation_system/compose_file_creator/types/intermediate_types.py
+++ b/emulation_system/emulation_system/compose_file_creator/types/intermediate_types.py
@@ -1,18 +1,20 @@
 """Intermediate types that will be used for composing RuntimeComposeModel."""
-
 from dataclasses import dataclass
+from enum import Enum
 from typing import Union
 
 from emulation_system.compose_file_creator import Service
 
-DockerServices = dict[str, Service]
-IntermediateNetworks = list[str]
-IntermediateVolumes = list[str]
-IntermediatePorts = list[str]
-IntermediateEnvironmentVariables = dict[str, Union[str, int, float]]
-IntermediateDependsOn = list[str]
-IntermediateCommand = list[str]
-IntermediateBuildArgs = dict[str, str]
+
+class DependsOnConditions(Enum):
+    """Conditions for depends_on.
+
+    https://docs.docker.com/compose/compose-file/#long-syntax-1
+    """
+
+    STARTED = "service_started"
+    HEALTHY = "service_healthy"
+    COMPLETED_SUCCESSFULLY = "service_completed_successfully"
 
 
 @dataclass
@@ -23,3 +25,13 @@ class IntermediateHealthcheck:
     retries: int
     timeout: int
     command: str
+
+
+DockerServices = dict[str, Service]
+IntermediateNetworks = list[str]
+IntermediateVolumes = list[str]
+IntermediatePorts = list[str]
+IntermediateEnvironmentVariables = dict[str, Union[str, int, float]]
+IntermediateDependsOn = dict[str, DependsOnConditions]
+IntermediateCommand = list[str]
+IntermediateBuildArgs = dict[str, str]

--- a/emulation_system/emulation_system/compose_file_creator/types/intermediate_types.py
+++ b/emulation_system/emulation_system/compose_file_creator/types/intermediate_types.py
@@ -1,7 +1,6 @@
 """Intermediate types that will be used for composing RuntimeComposeModel."""
 from dataclasses import dataclass
 from enum import Enum
-from typing import Union
 
 from emulation_system.compose_file_creator import Service
 
@@ -31,7 +30,7 @@ DockerServices = dict[str, Service]
 IntermediateNetworks = list[str]
 IntermediateVolumes = list[str]
 IntermediatePorts = list[str]
-IntermediateEnvironmentVariables = dict[str, Union[str, int, float]]
+IntermediateEnvironmentVariables = dict[str, str | int | float]
 IntermediateDependsOn = dict[str, DependsOnConditions]
 IntermediateCommand = list[str]
 IntermediateBuildArgs = dict[str, str]

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_depends_on.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_depends_on.py
@@ -1,6 +1,9 @@
 """Tests related to depends_on property of services."""
 
-from typing import Any, Dict
+from typing import (
+    Any,
+    Dict,
+)
 
 import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
@@ -35,8 +38,8 @@ def test_emulator_proxy_in_depends_on(
 ) -> None:
     """Confirm that modules depend on emulator proxy."""
     assert (
-        EMULATOR_PROXY_ID
-        in robot_with_mount_and_modules_services[service_name].depends_on
+            EMULATOR_PROXY_ID
+            in robot_with_mount_and_modules_services[service_name].depends_on
     )
 
 
@@ -60,5 +63,5 @@ def test_robots_only_emulator_proxy_in_depends_on(
     services = convert_from_obj(config, testing_global_em_config, dev=False).services
     assert services is not None
     depends_on = services[service_id].depends_on
-    assert isinstance(depends_on, list)
+    assert isinstance(depends_on, dict)
     assert EMULATOR_PROXY_ID in depends_on

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_depends_on.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_depends_on.py
@@ -1,9 +1,6 @@
 """Tests related to depends_on property of services."""
 
-from typing import (
-    Any,
-    Dict,
-)
+from typing import Any, Dict
 
 import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
@@ -38,8 +35,8 @@ def test_emulator_proxy_in_depends_on(
 ) -> None:
     """Confirm that modules depend on emulator proxy."""
     assert (
-            EMULATOR_PROXY_ID
-            in robot_with_mount_and_modules_services[service_name].depends_on
+        EMULATOR_PROXY_ID
+        in robot_with_mount_and_modules_services[service_name].depends_on
     )
 
 


### PR DESCRIPTION
# Overview

Containers that depend on emulator-proxy now wait for it to be healthy before starting

# Changelog

- Update depends_on logic to include conditions
- Update tests

# Review requests

None

# Risk assessment

Low, it was already broken
