### PR TITLE
feat: Create local-ot3-firmware-builder image and build script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,9 @@
 # entrypoint.sh should also be bind-mounted in so do not copy it in either
 # Make sure to include the OPENTRONS_HARDWARE env variable
 
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as local-ot3-firmware-builder
+COPY entrypoints/local_ot3_firmware_builder.sh /build.sh
+
 ############################
 # Hardware Local Emulators #
 ############################

--- a/docker/entrypoints/local_ot3_firmware_builder.sh
+++ b/docker/entrypoints/local_ot3_firmware_builder.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+(
+  cd /ot3-firmware && \
+  cmake --preset host-gcc10 && \
+  cmake --build ./build-host -j $(expr $(nproc) - 1)
+)
+
+mkdir -p \
+  /volumes/pipettes_volume \
+  /volumes/head_volume \
+  /volumes/gantry_x_volume \
+  /volumes/gantry_y_volume \
+  /volumes/gantry_y_volume \
+  /volumes/bootloader_volume \
+  /volumes/gripper_volume
+
+cp /ot3-firmware/build-host/pipettes/simulator/pipettes-single-simulator /volumes/pipettes_volume/pipettes-simulator
+cp /ot3-firmware/build-host/head/simulator/head-simulator /volumes/head_volume/head-simulator
+cp /ot3-firmware/build-host/gantry/simulator/gantry-x-simulator /volumes/gantry_x_volume/gantry-x-simulator
+cp /ot3-firmware/build-host/gantry/simulator/gantry-y-simulator /volumes/gantry_y_volume/gantry-y-simulator
+cp /ot3-firmware/build-host/bootloader/simulator/bootloader-simulator /volumes/bootloader_volume/bootloader-simulator
+cp /ot3-firmware/build-host/gripper/simulator/gripper-simulator /volumes/gripper_volume/gripper-simulator


### PR DESCRIPTION
# Overview

- Added `local-ot3-firmware-builder` image.
- Copies local_ot3_firmware_builder.sh script into image as build.sh

# Testing

- Tested by building image, running container with it, and building ot3-firmware simulators
- Test script 
  ```shell
  docker buildx build --load --target ot3-firmware-local-builder --tag ot3-firmware-local-builder:test . && docker run --rm -it -v "${PWD}"/../../ot3-firmware:/ot3-firmware -v "${PWD}"/../../opentrons:/opentrons ot3-firmware-local-builder:test bash
  ```

# Questions for Reviewers

**Issue:** When building initially inside the container, if your bind mounted `ot3-firmware` repo already has a `build-host` or `stm32-tools` folder you will get an error about cache paths not being correct. The solution for this is to delete both of these folders and rebuild.

**Question:** I am wondering if there is some kind of handing I should add for this? Should I have an "initial build" mode that removes those folders if they exist? Should I just doc the issue and provide the steps to fix it that way? 

My thought is to let the user remove the folder themselves so someone doesn't wipe out their cache inadvertently 
