### PR TITLE
feat: Add builder container addition logic (RQA-372)

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/service_builder_orchestrator.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/service_builder_orchestrator.py
@@ -157,6 +157,15 @@ class ServiceBuilderOrchestrator:
             assert service.container_name is not None
             self._services[service.container_name] = service
 
+    def __add_local_ot3_builder(self) -> None:
+        print("Local ot3-firmware builder required")
+
+    def __add_local_opentrons_modules_builder(self) -> None:
+        print("Local opentrons-modules builder required")
+
+    def __add_local_monorepo_builder(self) -> None:
+        print("Local monorepo builder required")
+
     def build_services(self) -> DockerServices:
         """Build services."""
         emulator_proxy_name = self.__add_emulator_proxy_service()
@@ -169,5 +178,13 @@ class ServiceBuilderOrchestrator:
         self.__add_input_services(
             emulator_proxy_name, smoothie_name, can_server_service_name
         )
+        if self._config_model.local_ot3_builder_required:
+            self.__add_local_ot3_builder()
+
+        if self._config_model.local_opentrons_modules_builder_required:
+            self.__add_local_opentrons_modules_builder()
+
+        if self._config_model.local_monorepo_builder_required:
+            self.__add_local_monorepo_builder()
 
         return DockerServices(self._services)

--- a/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
@@ -167,12 +167,9 @@ class SystemConfigurationModel(BaseModel):
     @property
     def local_ot3_builder_required(self) -> bool:
         """Whether or not a local-ot3-firmware-builder container is required."""
-        req: bool
         if self.robot is None:
-            req = False
-        else:
-            req = is_ot3(self.robot) and self.robot.source_type == SourceType.LOCAL
-        return req
+            return False
+        return is_ot3(self.robot) and self.robot.source_type == SourceType.LOCAL
 
     @property
     def local_opentrons_modules_builder_required(self) -> bool:

--- a/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
@@ -8,10 +8,11 @@ from pydantic import BaseModel, Field, parse_file_as, parse_obj_as, root_validat
 
 from emulation_system.consts import DEFAULT_NETWORK_NAME
 
-from ..config_file_settings import Hardware
+from ..config_file_settings import EmulationLevels, Hardware, SourceType
 from ..errors import DuplicateHardwareNameError
 from ..types.input_types import Containers, Modules, Robots
 from ..types.intermediate_types import IntermediateNetworks
+from ..utilities.hardware_utils import is_ot2, is_ot3
 from .hardware_models import OT2InputModel, OT3InputModel
 
 
@@ -162,3 +163,70 @@ class SystemConfigurationModel(BaseModel):
     def from_dict(cls, obj: Dict) -> SystemConfigurationModel:
         """Parse from dict."""
         return parse_obj_as(cls, obj)
+
+    @property
+    def local_ot3_builder_required(self) -> bool:
+        """Whether or not a local-ot3-firmware-builder container is required."""
+        req: bool
+        if self.robot is None:
+            req = False
+        else:
+            req = is_ot3(self.robot) and self.robot.source_type == SourceType.LOCAL
+        return req
+
+    @property
+    def local_opentrons_modules_builder_required(self) -> bool:
+        """Whether or not a local-opentrons-modules-builder container is required."""
+        if self.modules is None:
+            return False
+        return any(
+            [
+                module.emulation_level == EmulationLevels.HARDWARE
+                and module.source_type == SourceType.LOCAL
+                for module in self.modules
+            ]
+        )
+
+    @property
+    def local_monorepo_builder_required(self) -> bool:
+        """Whether or not a local-monorepo-builder container is required."""
+        # emulator-proxy cannot be local as of 11/8/2022, including the variable
+        # so it is clear that evaluating the source-type of emulator proxy was not missed
+        local_emulator_proxy = False
+        local_can_server = (
+            self.robot is not None
+            and is_ot3(self.robot)
+            and self.robot.can_server_source_type == SourceType.LOCAL
+        )
+        local_opentrons_hardware = (
+            self.robot is not None
+            and is_ot3(self.robot)
+            and self.robot.opentrons_hardware_source_type == SourceType.LOCAL
+        )
+        local_smoothie = (
+            self.robot is not None
+            and is_ot2(self.robot)
+            and self.robot.source_type == SourceType.LOCAL
+        )
+        local_modules = self.modules is not None and any(
+            (
+                module.emulation_level == EmulationLevels.FIRMWARE
+                and module.source_type == SourceType.LOCAL
+            )
+            for module in self.modules
+        )
+        local_robot_server = (
+            self.robot is not None
+            and self.robot.robot_server_source_type == SourceType.LOCAL
+        )
+
+        return any(
+            [
+                local_emulator_proxy,
+                local_can_server,
+                local_opentrons_hardware,
+                local_smoothie,
+                local_modules,
+                local_robot_server,
+            ]
+        )

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_builder_creation_logic.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_builder_creation_logic.py
@@ -1,0 +1,131 @@
+"""Tests to confirm that builder creation logic is correct."""
+
+from typing import Any, Dict
+
+import pytest
+from pydantic import parse_obj_as
+from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
+
+from emulation_system.compose_file_creator.input.configuration_file import (
+    SystemConfigurationModel,
+)
+
+
+def test_local_ot3_builder_required(ot3_local_source: Dict[str, Any]) -> None:
+    """Test all configurations that require local-ot3-firmware-builder."""
+    config_model = parse_obj_as(SystemConfigurationModel, ot3_local_source)
+    assert config_model.local_ot3_builder_required
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        lazy_fixture("ot3_remote_everything_latest"),
+        lazy_fixture("ot3_remote_everything_commit_id"),
+        lazy_fixture("ot3_local_can"),
+        lazy_fixture("ot3_local_robot"),
+        lazy_fixture("ot3_local_opentrons_hardware"),
+        lazy_fixture("ot2_remote_everything_latest"),
+        lazy_fixture("ot2_remote_everything_commit_id"),
+        lazy_fixture("ot2_local_source"),
+        lazy_fixture("ot2_local_robot"),
+        lazy_fixture("heater_shaker_module_hardware_local"),
+        lazy_fixture("heater_shaker_module_hardware_remote"),
+        lazy_fixture("thermocycler_module_firmware_local"),
+        lazy_fixture("thermocycler_module_hardware_local"),
+        lazy_fixture("thermocycler_module_firmware_remote"),
+        lazy_fixture("thermocycler_module_hardware_remote"),
+        lazy_fixture("temperature_module_firmware_local"),
+        lazy_fixture("temperature_module_firmware_remote"),
+        lazy_fixture("magnetic_module_firmware_remote"),
+        lazy_fixture("magnetic_module_firmware_local"),
+    ],
+)
+def test_local_ot3_builder_not_required(config: Dict[str, Any]) -> None:
+    """Test all configurations that do not require local-ot3-firmware-builder."""
+    config_model = parse_obj_as(SystemConfigurationModel, config)
+    assert not config_model.local_ot3_builder_required
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        lazy_fixture("heater_shaker_module_hardware_local"),
+        lazy_fixture("thermocycler_module_hardware_local"),
+    ],
+)
+def test_local_opentrons_modules_builder_required(config: Dict[str, Any]) -> None:
+    """Test all configurations that require local-opentrons-modules-builder."""
+    config_model = parse_obj_as(SystemConfigurationModel, config)
+    assert config_model.local_opentrons_modules_builder_required
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        lazy_fixture("ot3_remote_everything_latest"),
+        lazy_fixture("ot3_remote_everything_commit_id"),
+        lazy_fixture("ot3_local_source"),
+        lazy_fixture("ot3_local_can"),
+        lazy_fixture("ot3_local_robot"),
+        lazy_fixture("ot3_local_opentrons_hardware"),
+        lazy_fixture("ot2_remote_everything_latest"),
+        lazy_fixture("ot2_remote_everything_commit_id"),
+        lazy_fixture("ot2_local_source"),
+        lazy_fixture("ot2_local_robot"),
+        lazy_fixture("heater_shaker_module_hardware_remote"),
+        lazy_fixture("thermocycler_module_firmware_local"),
+        lazy_fixture("thermocycler_module_firmware_remote"),
+        lazy_fixture("thermocycler_module_hardware_remote"),
+        lazy_fixture("temperature_module_firmware_local"),
+        lazy_fixture("temperature_module_firmware_remote"),
+        lazy_fixture("magnetic_module_firmware_remote"),
+        lazy_fixture("magnetic_module_firmware_local"),
+    ],
+)
+def test_local_opentrons_modules_builder_not_required(config: Dict[str, Any]) -> None:
+    """Test all configurations that do not require local-opentrons-modules-builder."""
+    config_model = parse_obj_as(SystemConfigurationModel, config)
+    assert not config_model.local_opentrons_modules_builder_required
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        lazy_fixture("ot3_local_can"),
+        lazy_fixture("ot3_local_robot"),
+        lazy_fixture("ot3_local_opentrons_hardware"),
+        lazy_fixture("ot2_local_source"),
+        lazy_fixture("ot2_local_robot"),
+        lazy_fixture("thermocycler_module_firmware_local"),
+        lazy_fixture("temperature_module_firmware_local"),
+        lazy_fixture("magnetic_module_firmware_local"),
+    ],
+)
+def test_local_monorepo_builder_required(config: Dict[str, Any]) -> None:
+    """Test all configurations that require local-monorepo-builder."""
+    config_model = parse_obj_as(SystemConfigurationModel, config)
+    assert config_model.local_monorepo_builder_required
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        lazy_fixture("ot3_remote_everything_latest"),
+        lazy_fixture("ot3_remote_everything_commit_id"),
+        lazy_fixture("ot3_local_source"),
+        lazy_fixture("ot2_remote_everything_latest"),
+        lazy_fixture("ot2_remote_everything_commit_id"),
+        lazy_fixture("heater_shaker_module_hardware_local"),
+        lazy_fixture("heater_shaker_module_hardware_remote"),
+        lazy_fixture("thermocycler_module_hardware_local"),
+        lazy_fixture("thermocycler_module_firmware_remote"),
+        lazy_fixture("thermocycler_module_hardware_remote"),
+        lazy_fixture("temperature_module_firmware_remote"),
+        lazy_fixture("magnetic_module_firmware_remote"),
+    ],
+)
+def test_local_monorepo_builder_not_required(config: Dict[str, Any]) -> None:
+    """Test all configurations that do not require local-monorepo-builder."""
+    config_model = parse_obj_as(SystemConfigurationModel, config)
+    assert not config_model.local_monorepo_builder_required

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_source_code_insertion.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_source_code_insertion.py
@@ -1,458 +1,42 @@
 """Test everything around inserting source code into containers."""
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Dict
 
 import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 
 from emulation_system import OpentronsEmulationConfiguration
 from emulation_system.compose_file_creator.config_file_settings import (
-    EmulationLevels,
     RepoToBuildArgMapping,
-    SourceType,
 )
 from emulation_system.compose_file_creator.conversion.conversion_functions import (
     convert_from_obj,
 )
-from emulation_system.compose_file_creator.output.runtime_compose_file_model import (
-    RuntimeComposeFileModel,
-)
 from tests.compose_file_creator.conversion_logic.conftest import (
-    FAKE_COMMIT_ID,
     build_args_are_none,
     get_source_code_build_args,
     partial_string_in_mount,
 )
 
 
-@pytest.fixture
-def robot_set_source_type_params(
-    testing_global_em_config: OpentronsEmulationConfiguration,
-) -> Callable:
-    """Create a runnable fixture that builds a RuntimeComposeFileModel."""
-
-    def robot_set_source_type_params(
-        robot_dict: Dict[str, Any],
-        source_type: SourceType,
-        source_location: str,
-        robot_server_source_type: SourceType,
-        robot_server_source_location: str,
-        can_server_source_type: Optional[SourceType],
-        can_server_source_location: Optional[str],
-        opentrons_hardware_source_type: Optional[SourceType],
-        opentrons_hardware_source_location: Optional[str],
-    ) -> RuntimeComposeFileModel:
-        robot_dict["source-type"] = source_type
-        robot_dict["source-location"] = source_location
-        robot_dict["robot-server-source-type"] = robot_server_source_type
-        robot_dict["robot-server-source-location"] = robot_server_source_location
-
-        if (
-            can_server_source_type is not None
-            and can_server_source_location is not None
-        ):
-            robot_dict["can-server-source-type"] = can_server_source_type
-            robot_dict["can-server-source-location"] = can_server_source_location
-
-        if (
-            opentrons_hardware_source_type is not None
-            and opentrons_hardware_source_location is not None
-        ):
-            robot_dict[
-                "opentrons-hardware-source-type"
-            ] = opentrons_hardware_source_type
-            robot_dict[
-                "opentrons-hardware-source-location"
-            ] = opentrons_hardware_source_location
-
-        return convert_from_obj({"robot": robot_dict}, testing_global_em_config, False)
-
-    return robot_set_source_type_params
-
-
-@pytest.fixture
-def module_set_source_type_params(
-    testing_global_em_config: OpentronsEmulationConfiguration,
-) -> Callable:
-    """Create a runnable fixture that builds a RuntimeComposeFileModel."""
-
-    def module_set_source_type_params(
-        module_dict: Dict[str, Any],
-        source_type: SourceType,
-        source_location: str,
-        emulation_level: EmulationLevels,
-    ) -> RuntimeComposeFileModel:
-        module_dict["source-type"] = source_type
-        module_dict["source-location"] = source_location
-        module_dict["emulation-level"] = emulation_level
-
-        return convert_from_obj(
-            {"modules": [module_dict]}, testing_global_em_config, False
-        )
-
-    return module_set_source_type_params
-
-
-@pytest.fixture
-def ot3_remote_everything_latest(
-    ot3_default: Dict[str, Any], robot_set_source_type_params: Callable
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot3_default,
-        source_type=SourceType.REMOTE,
-        source_location="latest",
-        robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location="latest",
-        can_server_source_type=SourceType.REMOTE,
-        can_server_source_location="latest",
-        opentrons_hardware_source_type=SourceType.REMOTE,
-        opentrons_hardware_source_location="latest",
-    )
-
-
-@pytest.fixture
-def ot3_remote_everything_commit_id(
-    ot3_default: Dict[str, Any], robot_set_source_type_params: Callable
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot3_default,
-        source_type=SourceType.REMOTE,
-        source_location=FAKE_COMMIT_ID,
-        robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location=FAKE_COMMIT_ID,
-        can_server_source_type=SourceType.REMOTE,
-        can_server_source_location=FAKE_COMMIT_ID,
-        opentrons_hardware_source_type=SourceType.REMOTE,
-        opentrons_hardware_source_location=FAKE_COMMIT_ID,
-    )
-
-
-@pytest.fixture
-def ot3_local_robot(
-    ot3_default: Dict[str, Any],
-    opentrons_dir: str,
-    robot_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot3_default,
-        source_type=SourceType.REMOTE,
-        source_location="latest",
-        robot_server_source_type=SourceType.LOCAL,
-        robot_server_source_location=opentrons_dir,
-        can_server_source_type=SourceType.REMOTE,
-        can_server_source_location="latest",
-        opentrons_hardware_source_type=SourceType.REMOTE,
-        opentrons_hardware_source_location="latest",
-    )
-
-
-@pytest.fixture
-def ot3_local_source(
-    ot3_default: Dict[str, Any],
-    opentrons_dir: str,
-    ot3_firmware_dir: str,
-    robot_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot3_default,
-        source_type=SourceType.LOCAL,
-        source_location=ot3_firmware_dir,
-        robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location="latest",
-        can_server_source_type=SourceType.REMOTE,
-        can_server_source_location="latest",
-        opentrons_hardware_source_type=SourceType.REMOTE,
-        opentrons_hardware_source_location="latest",
-    )
-
-
-@pytest.fixture
-def ot3_local_can(
-    ot3_default: Dict[str, Any],
-    opentrons_dir: str,
-    robot_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot3_default,
-        source_type=SourceType.REMOTE,
-        source_location="latest",
-        robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location="latest",
-        can_server_source_type=SourceType.LOCAL,
-        can_server_source_location=opentrons_dir,
-        opentrons_hardware_source_type=SourceType.REMOTE,
-        opentrons_hardware_source_location="latest",
-    )
-
-
-@pytest.fixture
-def ot3_local_opentrons_hardware(
-    ot3_default: Dict[str, Any],
-    opentrons_dir: str,
-    robot_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot3_default,
-        source_type=SourceType.REMOTE,
-        source_location="latest",
-        robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location="latest",
-        can_server_source_type=SourceType.REMOTE,
-        can_server_source_location="latest",
-        opentrons_hardware_source_type=SourceType.LOCAL,
-        opentrons_hardware_source_location=opentrons_dir,
-    )
-
-
-@pytest.fixture
-def ot2_remote_everything_latest(
-    ot2_default: Dict[str, Any], robot_set_source_type_params: Callable
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot2_default,
-        source_type=SourceType.REMOTE,
-        source_location="latest",
-        robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location="latest",
-        can_server_source_type=None,
-        can_server_source_location=None,
-        opentrons_hardware_source_type=None,
-        opentrons_hardware_source_location=None,
-    )
-
-
-@pytest.fixture
-def ot2_remote_everything_commit_id(
-    ot2_default: Dict[str, Any], robot_set_source_type_params: Callable
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot2_default,
-        source_type=SourceType.REMOTE,
-        source_location=FAKE_COMMIT_ID,
-        robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location=FAKE_COMMIT_ID,
-        can_server_source_type=None,
-        can_server_source_location=None,
-        opentrons_hardware_source_type=None,
-        opentrons_hardware_source_location=None,
-    )
-
-
-@pytest.fixture
-def ot2_local_source(
-    ot2_default: Dict[str, Any],
-    opentrons_dir: str,
-    robot_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot2_default,
-        source_type=SourceType.LOCAL,
-        source_location=opentrons_dir,
-        robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location="latest",
-        can_server_source_type=None,
-        can_server_source_location=None,
-        opentrons_hardware_source_type=None,
-        opentrons_hardware_source_location=None,
-    )
-
-
-@pytest.fixture
-def ot2_local_robot(
-    ot2_default: Dict[str, Any],
-    opentrons_dir: str,
-    robot_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot2_default,
-        source_type=SourceType.REMOTE,
-        source_location="latest",
-        robot_server_source_type=SourceType.LOCAL,
-        robot_server_source_location=opentrons_dir,
-        can_server_source_type=None,
-        can_server_source_location=None,
-        opentrons_hardware_source_type=None,
-        opentrons_hardware_source_location=None,
-    )
-
-
-@pytest.fixture
-def heater_shaker_module_hardware_local(
-    heater_shaker_module_default: Dict[str, Any],
-    opentrons_modules_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for local source."""
-    return module_set_source_type_params(
-        module_dict=heater_shaker_module_default,
-        source_type="local",
-        source_location=opentrons_modules_dir,
-        emulation_level="hardware",
-    )
-
-
-@pytest.fixture
-def temperature_module_firmware_local(
-    temperature_module_default: Dict[str, Any],
-    opentrons_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for local source."""
-    return module_set_source_type_params(
-        module_dict=temperature_module_default,
-        source_type="local",
-        source_location=opentrons_dir,
-        emulation_level="firmware",
-    )
-
-
-@pytest.fixture
-def magnetic_module_firmware_local(
-    magnetic_module_default: Dict[str, Any],
-    opentrons_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for local source."""
-    return module_set_source_type_params(
-        module_dict=magnetic_module_default,
-        source_type="local",
-        source_location=opentrons_dir,
-        emulation_level="firmware",
-    )
-
-
-@pytest.fixture
-def thermocycler_module_firmware_local(
-    thermocycler_module_default: Dict[str, Any],
-    opentrons_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for local source."""
-    return module_set_source_type_params(
-        module_dict=thermocycler_module_default,
-        source_type="local",
-        source_location=opentrons_dir,
-        emulation_level="firmware",
-    )
-
-
-@pytest.fixture
-def thermocycler_module_hardware_local(
-    thermocycler_module_default: Dict[str, Any],
-    opentrons_modules_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for local source."""
-    return module_set_source_type_params(
-        module_dict=thermocycler_module_default,
-        source_type="local",
-        source_location=opentrons_modules_dir,
-        emulation_level="hardware",
-    )
-
-
-@pytest.fixture
-def heater_shaker_module_hardware_remote(
-    heater_shaker_module_default: Dict[str, Any],
-    opentrons_modules_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for remote source."""
-    return module_set_source_type_params(
-        module_dict=heater_shaker_module_default,
-        source_type="remote",
-        source_location="latest",
-        emulation_level="hardware",
-    )
-
-
-@pytest.fixture
-def temperature_module_firmware_remote(
-    temperature_module_default: Dict[str, Any],
-    opentrons_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for remote source."""
-    return module_set_source_type_params(
-        module_dict=temperature_module_default,
-        source_type="remote",
-        source_location="latest",
-        emulation_level="firmware",
-    )
-
-
-@pytest.fixture
-def magnetic_module_firmware_remote(
-    magnetic_module_default: Dict[str, Any],
-    opentrons_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for remote source."""
-    return module_set_source_type_params(
-        module_dict=magnetic_module_default,
-        source_type="remote",
-        source_location="latest",
-        emulation_level="firmware",
-    )
-
-
-@pytest.fixture
-def thermocycler_module_firmware_remote(
-    thermocycler_module_default: Dict[str, Any],
-    opentrons_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for remote source."""
-    return module_set_source_type_params(
-        module_dict=thermocycler_module_default,
-        source_type="remote",
-        source_location="latest",
-        emulation_level="firmware",
-    )
-
-
-@pytest.fixture
-def thermocycler_module_hardware_remote(
-    thermocycler_module_default: Dict[str, Any],
-    opentrons_modules_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for remote source."""
-    return module_set_source_type_params(
-        module_dict=thermocycler_module_default,
-        source_type="remote",
-        source_location="latest",
-        emulation_level="hardware",
-    )
-
-
 @pytest.mark.parametrize(
-    "compose_file_model",
+    "config_dict",
     [
         lazy_fixture("ot3_remote_everything_latest"),
         lazy_fixture("ot3_remote_everything_commit_id"),
     ],
 )
 def test_ot3_remote_everything_mounts(
-    compose_file_model: RuntimeComposeFileModel,
+    config_dict: Dict[str, Any],
     testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when all source-types are remote.
 
     Confirm that when all source-types are remote, nothing is mounted to any container.
     """
-    robot_server = compose_file_model.robot_server
-    can_server = compose_file_model.can_server
-    emulators = compose_file_model.ot3_emulators
+    config_file = convert_from_obj(config_dict, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -466,17 +50,21 @@ def test_ot3_remote_everything_mounts(
 
 
 def test_ot3_remote_everything_latest_build_args(
-    ot3_remote_everything_latest: RuntimeComposeFileModel,
+    ot3_remote_everything_latest: Dict[str, Any],
     opentrons_head: str,
     ot3_firmware_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build args when all source-types are remote latest.
 
     Confirm that all build args are using the head of their individual repos.
     """
-    robot_server = ot3_remote_everything_latest.robot_server
-    can_server = ot3_remote_everything_latest.can_server
-    emulators = ot3_remote_everything_latest.ot3_emulators
+    config_file = convert_from_obj(
+        ot3_remote_everything_latest, testing_global_em_config, False
+    )
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -503,17 +91,21 @@ def test_ot3_remote_everything_latest_build_args(
 
 
 def test_ot3_remote_everything_commit_id_build_args(
-    ot3_remote_everything_commit_id: RuntimeComposeFileModel,
+    ot3_remote_everything_commit_id: Dict[str, Any],
     opentrons_commit: str,
     ot3_firmware_commit: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build args when all source-types are remote commit id.
 
     Confirm that all build args are using the head of their individual repos.
     """
-    robot_server = ot3_remote_everything_commit_id.robot_server
-    can_server = ot3_remote_everything_commit_id.can_server
-    emulators = ot3_remote_everything_commit_id.ot3_emulators
+    config_file = convert_from_obj(
+        ot3_remote_everything_commit_id, testing_global_em_config, False
+    )
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -540,15 +132,19 @@ def test_ot3_remote_everything_commit_id_build_args(
         assert emulator_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_commit
 
 
-def test_ot3_local_source_mounts(ot3_local_source: RuntimeComposeFileModel) -> None:
+def test_ot3_local_source_mounts(
+    ot3_local_source: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
     """Test mounts when source-type is set to local.
 
     Confirm that ot3-firmware and entrypoint.sh is mounted to emulator containers.
     Confirm other containers have nothing mounted.
     """
-    robot_server = ot3_local_source.robot_server
-    can_server = ot3_local_source.can_server
-    emulators = ot3_local_source.ot3_emulators
+    config_file = convert_from_obj(ot3_local_source, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -572,18 +168,20 @@ def test_ot3_local_source_mounts(ot3_local_source: RuntimeComposeFileModel) -> N
 
 
 def test_ot3_local_source_build_args(
-    ot3_local_source: RuntimeComposeFileModel,
+    ot3_local_source: Dict[str, Any],
     opentrons_head: str,
     ot3_firmware_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build args when source-type is set to local.
 
     Confirm that robot-server and can-server have source build args.
     Emulators should not have source build args.
     """
-    robot_server = ot3_local_source.robot_server
-    can_server = ot3_local_source.can_server
-    emulators = ot3_local_source.ot3_emulators
+    config_file = convert_from_obj(ot3_local_source, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -606,15 +204,19 @@ def test_ot3_local_source_build_args(
         assert RepoToBuildArgMapping.OT3_FIRMWARE not in emulator_build_args
 
 
-def test_ot3_local_can_server_mounts(ot3_local_can: RuntimeComposeFileModel) -> None:
+def test_ot3_local_can_server_mounts(
+    ot3_local_can: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
     """Test mounts when can-server-source-type is set to local.
 
     Confirm that robot server and emulators have no mounts.
     Confirm that can-server has opentrons and entrypoint.sh mounted in.
     """
-    robot_server = ot3_local_can.robot_server
-    can_server = ot3_local_can.can_server
-    emulators = ot3_local_can.ot3_emulators
+    config_file = convert_from_obj(ot3_local_can, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -629,13 +231,16 @@ def test_ot3_local_can_server_mounts(ot3_local_can: RuntimeComposeFileModel) -> 
 
     assert len(can_server.volumes) == 3
 
-    assert ot3_local_can.ot3_emulators is not None
-    for emulator in ot3_local_can.ot3_emulators:
+    assert config_file.ot3_emulators is not None
+    for emulator in config_file.ot3_emulators:
         assert emulator.volumes is None
 
 
 def test_ot3_local_can_server_build_args(
-    ot3_local_can: RuntimeComposeFileModel, opentrons_head: str, ot3_firmware_head: str
+    ot3_local_can: Dict[str, Any],
+    opentrons_head: str,
+    ot3_firmware_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build arguments when can-server-source-type is set to local.
 
@@ -643,9 +248,10 @@ def test_ot3_local_can_server_build_args(
     Confirm that robot-server is looking for the opentrons repo head.
     Confirm that the emulators are looking for the ot3-firmware repo head.
     """
-    robot_server = ot3_local_can.robot_server
-    can_server = ot3_local_can.can_server
-    emulators = ot3_local_can.ot3_emulators
+    config_file = convert_from_obj(ot3_local_can, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -671,16 +277,18 @@ def test_ot3_local_can_server_build_args(
 
 
 def test_ot3_local_robot_server_mounts(
-    ot3_local_robot: RuntimeComposeFileModel,
+    ot3_local_robot: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when robot-server-source-type is set to local.
 
     Confirm that can server and emulators have no mounts.
     Confirm that robot server has opentrons and entrypoint.sh mounted in.
     """
-    robot_server = ot3_local_robot.robot_server
-    can_server = ot3_local_robot.can_server
-    emulators = ot3_local_robot.ot3_emulators
+    config_file = convert_from_obj(ot3_local_robot, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -695,15 +303,16 @@ def test_ot3_local_robot_server_mounts(
 
     assert can_server.volumes is None
 
-    assert ot3_local_robot.ot3_emulators is not None
-    for emulator in ot3_local_robot.ot3_emulators:
+    assert config_file.ot3_emulators is not None
+    for emulator in config_file.ot3_emulators:
         assert emulator.volumes is None
 
 
 def test_ot3_local_robot_server_build_args(
-    ot3_local_robot: RuntimeComposeFileModel,
+    ot3_local_robot: Dict[str, Any],
     opentrons_head: str,
     ot3_firmware_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build arguments when robot-server-source-type is set to local.
 
@@ -711,9 +320,10 @@ def test_ot3_local_robot_server_build_args(
     Confirm that can server is looking for the opentrons repo head.
     Confirm that the emulators are looking for the ot3-firmware repo head.
     """
-    robot_server = ot3_local_robot.robot_server
-    can_server = ot3_local_robot.can_server
-    emulators = ot3_local_robot.ot3_emulators
+    config_file = convert_from_obj(ot3_local_robot, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -738,9 +348,10 @@ def test_ot3_local_robot_server_build_args(
 
 
 def test_ot3_local_opentrons_hardware_build_args(
-    ot3_local_opentrons_hardware: RuntimeComposeFileModel,
+    ot3_local_opentrons_hardware: Dict[str, Any],
     opentrons_head: str,
     ot3_firmware_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build arguments when robot-server-source-type is set to local.
 
@@ -748,9 +359,12 @@ def test_ot3_local_opentrons_hardware_build_args(
     Confirm that can server is looking for the opentrons repo head.
     Confirm that the emulators are looking for the ot3-firmware repo head.
     """
-    robot_server = ot3_local_opentrons_hardware.robot_server
-    can_server = ot3_local_opentrons_hardware.can_server
-    emulators = ot3_local_opentrons_hardware.ot3_emulators
+    config_file = convert_from_obj(
+        ot3_local_opentrons_hardware, testing_global_em_config, False
+    )
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -776,16 +390,20 @@ def test_ot3_local_opentrons_hardware_build_args(
 
 
 def test_ot3_local_opentrons_hardware_mounts(
-    ot3_local_opentrons_hardware: RuntimeComposeFileModel,
+    ot3_local_opentrons_hardware: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when robot-server-source-type is set to local.
 
     Confirm that can server and emulators have no mounts.
     Confirm that robot server has opentrons and entrypoint.sh mounted in.
     """
-    robot_server = ot3_local_opentrons_hardware.robot_server
-    can_server = ot3_local_opentrons_hardware.can_server
-    emulators = ot3_local_opentrons_hardware.ot3_emulators
+    config_file = convert_from_obj(
+        ot3_local_opentrons_hardware, testing_global_em_config, False
+    )
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -795,9 +413,9 @@ def test_ot3_local_opentrons_hardware_mounts(
 
     assert can_server.volumes is None
 
-    assert ot3_local_opentrons_hardware.ot3_emulators is not None
+    assert config_file.ot3_emulators is not None
 
-    for emulator in ot3_local_opentrons_hardware.ot3_emulators:
+    for emulator in config_file.ot3_emulators:
         assert emulator.volumes is not None
         assert len(emulator.volumes) == 3
         assert partial_string_in_mount("opentrons:/opentrons", emulator.volumes)
@@ -806,21 +424,23 @@ def test_ot3_local_opentrons_hardware_mounts(
 
 
 @pytest.mark.parametrize(
-    "compose_file_model",
+    "config_dict",
     [
         lazy_fixture("ot2_remote_everything_latest"),
         lazy_fixture("ot2_remote_everything_commit_id"),
     ],
 )
 def test_ot2_remote_everything_mounts(
-    compose_file_model: RuntimeComposeFileModel,
+    config_dict: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when all source-types are remote.
 
     Confirm that smoothie and robot server have no mounts.
     """
-    robot_server = compose_file_model.robot_server
-    smoothie = compose_file_model.smoothie_emulator
+    config_file = convert_from_obj(config_dict, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    smoothie = config_file.smoothie_emulator
 
     assert robot_server is not None
     assert smoothie is not None
@@ -830,14 +450,19 @@ def test_ot2_remote_everything_mounts(
 
 
 def test_ot2_remote_everything_latest_build_args(
-    ot2_remote_everything_latest: RuntimeComposeFileModel, opentrons_head: str
+    ot2_remote_everything_latest: Dict[str, Any],
+    opentrons_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build arguments when all source-types are remote latest.
 
     Confirm that smoothie and robot server are both looking for the opentrons repo head.
     """
-    robot_server = ot2_remote_everything_latest.robot_server
-    smoothie = ot2_remote_everything_latest.smoothie_emulator
+    config_file = convert_from_obj(
+        ot2_remote_everything_latest, testing_global_em_config, False
+    )
+    robot_server = config_file.robot_server
+    smoothie = config_file.smoothie_emulator
 
     assert robot_server is not None
     assert smoothie is not None
@@ -851,14 +476,19 @@ def test_ot2_remote_everything_latest_build_args(
 
 
 def test_ot2_remote_everything_commit_id_build_args(
-    ot2_remote_everything_commit_id: RuntimeComposeFileModel, opentrons_commit: str
+    ot2_remote_everything_commit_id: Dict[str, Any],
+    opentrons_commit: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build arguments when all source-types are remote commit id.
 
     Confirm that smoothie and robot server are both looking for the opentrons repo head.
     """
-    robot_server = ot2_remote_everything_commit_id.robot_server
-    smoothie = ot2_remote_everything_commit_id.smoothie_emulator
+    config_file = convert_from_obj(
+        ot2_remote_everything_commit_id, testing_global_em_config, False
+    )
+    robot_server = config_file.robot_server
+    smoothie = config_file.smoothie_emulator
 
     assert robot_server is not None
     assert smoothie is not None
@@ -872,58 +502,18 @@ def test_ot2_remote_everything_commit_id_build_args(
     assert smoothie_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_commit
 
 
-def test_ot2_local_robot_server_mounts(
-    ot2_local_robot: RuntimeComposeFileModel,
+def test_ot2_local_source_mounts(
+    ot2_local_source: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
-    """Test mounts when robot-server-source-type is set to local.
-
-    Confirm that robot server has opentrons and entrypoint.sh mounted to it.
-    Confirm that smoothie has nothing mounted to it.
-    """
-    robot_server = ot2_local_robot.robot_server
-    smoothie = ot2_local_robot.smoothie_emulator
-
-    assert robot_server is not None
-    assert smoothie is not None
-
-    assert robot_server.volumes is not None
-    assert partial_string_in_mount("opentrons:/opentrons", robot_server.volumes)
-    assert partial_string_in_mount("entrypoint.sh:/entrypoint.sh", robot_server.volumes)
-    assert partial_string_in_mount("opentrons-python-dist:/dist", robot_server.volumes)
-    assert len(robot_server.volumes) == 3
-
-    assert smoothie.volumes is None
-
-
-def test_ot2_local_robot_server_build_args(
-    ot2_local_robot: RuntimeComposeFileModel, opentrons_head: str
-) -> None:
-    """Test build-args when robot-server-source-type is set to local.
-
-    Confirm that robot server has no build arguments
-    Confirm that smoothie is looking for the opentrons repo head.
-    """
-    robot_server = ot2_local_robot.robot_server
-    smoothie = ot2_local_robot.smoothie_emulator
-
-    assert robot_server is not None
-    assert smoothie is not None
-
-    assert build_args_are_none(robot_server)
-
-    smoothie_build_args = get_source_code_build_args(smoothie)
-    assert smoothie_build_args is not None
-    assert smoothie_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_head
-
-
-def test_ot2_local_source_mounts(ot2_local_source: RuntimeComposeFileModel) -> None:
     """Test mounts when source-type is set to local.
 
     Confirm that robot server has nothing mounted to it.
     Confirm that smoothie has opentrons and entrypoint.sh mounted to it.
     """
-    robot_server = ot2_local_source.robot_server
-    smoothie = ot2_local_source.smoothie_emulator
+    config_file = convert_from_obj(ot2_local_source, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    smoothie = config_file.smoothie_emulator
 
     assert robot_server is not None
     assert smoothie is not None
@@ -939,15 +529,18 @@ def test_ot2_local_source_mounts(ot2_local_source: RuntimeComposeFileModel) -> N
 
 
 def test_ot2_local_source_build_args(
-    ot2_local_source: RuntimeComposeFileModel, opentrons_head: str
+    ot2_local_source: Dict[str, Any],
+    opentrons_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build arguments when source-type is set to local.
 
     Confirm that robot server is looking for the opentrons repo head.
     Confirm that smoothie has no build arguments.
     """
-    robot_server = ot2_local_source.robot_server
-    smoothie = ot2_local_source.smoothie_emulator
+    config_file = convert_from_obj(ot2_local_source, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    smoothie = config_file.smoothie_emulator
 
     assert robot_server is not None
     assert smoothie is not None
@@ -962,8 +555,58 @@ def test_ot2_local_source_build_args(
     assert build_args_are_none(smoothie)
 
 
+def test_ot2_local_robot_server_mounts(
+    ot2_local_robot: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
+    """Test mounts when robot-server-source-type is set to local.
+
+    Confirm that robot server has opentrons and entrypoint.sh mounted to it.
+    Confirm that smoothie has nothing mounted to it.
+    """
+    config_file = convert_from_obj(ot2_local_robot, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    smoothie = config_file.smoothie_emulator
+
+    assert robot_server is not None
+    assert smoothie is not None
+
+    assert robot_server.volumes is not None
+    assert partial_string_in_mount("opentrons:/opentrons", robot_server.volumes)
+    assert partial_string_in_mount("entrypoint.sh:/entrypoint.sh", robot_server.volumes)
+    assert partial_string_in_mount("opentrons-python-dist:/dist", robot_server.volumes)
+    assert len(robot_server.volumes) == 3
+
+    assert smoothie.volumes is None
+
+
+def test_ot2_local_robot_server_build_args(
+    ot2_local_robot: Dict[str, Any],
+    opentrons_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
+    """Test build-args when robot-server-source-type is set to local.
+
+    Confirm that robot server has no build arguments
+    Confirm that smoothie is looking for the opentrons repo head.
+    """
+    config_file = convert_from_obj(ot2_local_robot, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    smoothie = config_file.smoothie_emulator
+
+    assert robot_server is not None
+    assert smoothie is not None
+
+    assert build_args_are_none(robot_server)
+
+    smoothie_build_args = get_source_code_build_args(smoothie)
+    assert smoothie_build_args is not None
+    assert smoothie_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_head
+
+
 def test_heater_shaker_hardware_local_mounts(
-    heater_shaker_module_hardware_local: RuntimeComposeFileModel,
+    heater_shaker_module_hardware_local: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to local.
 
@@ -971,7 +614,10 @@ def test_heater_shaker_hardware_local_mounts(
     Also confirm that named volumes: opentrons-modules-build-stm32-host and
     opentrons-modules-stm32-tools exist and are bound to the correct location.
     """
-    heater_shakers = heater_shaker_module_hardware_local.heater_shaker_module_emulators
+    config_file = convert_from_obj(
+        heater_shaker_module_hardware_local, testing_global_em_config, False
+    )
+    heater_shakers = config_file.heater_shaker_module_emulators
 
     assert heater_shakers is not None
     assert len(heater_shakers) == 1
@@ -998,7 +644,8 @@ def test_heater_shaker_hardware_local_mounts(
 
 
 def test_thermocycler_module_hardware_local_mounts(
-    thermocycler_module_hardware_local: RuntimeComposeFileModel,
+    thermocycler_module_hardware_local: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to local.
 
@@ -1006,9 +653,10 @@ def test_thermocycler_module_hardware_local_mounts(
     Also confirm that named volumes: opentrons-modules-build-stm32-host and
     opentrons-modules-stm32-tools exist and are bound to the correct location.
     """
-    thermocycler_modules = (
-        thermocycler_module_hardware_local.thermocycler_module_emulators
+    config_file = convert_from_obj(
+        thermocycler_module_hardware_local, testing_global_em_config, False
     )
+    thermocycler_modules = config_file.thermocycler_module_emulators
 
     assert thermocycler_modules is not None
     assert len(thermocycler_modules) == 1
@@ -1034,8 +682,41 @@ def test_thermocycler_module_hardware_local_mounts(
     assert len(thermocycler_module.volumes) == 4
 
 
+def test_thermocycler_module_firmware_local_mounts(
+    thermocycler_module_firmware_local: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
+    """Test mounts when source-type is set to local.
+
+    Confirm that thermocycler module has opentrons, entrypoint.sh mounted in.
+    Also confirm that named volumes: opentrons-python-dist bound to the correct
+    location.
+    """
+    config_file = convert_from_obj(
+        thermocycler_module_firmware_local, testing_global_em_config, False
+    )
+    thermocycler_modules = config_file.thermocycler_module_emulators
+
+    assert thermocycler_modules is not None
+    assert len(thermocycler_modules) == 1
+
+    thermocycler_module = thermocycler_modules[0]
+    assert thermocycler_module.volumes is not None
+
+    assert partial_string_in_mount("opentrons:/opentrons", thermocycler_module.volumes)
+    assert partial_string_in_mount(
+        "entrypoint.sh:/entrypoint.sh", thermocycler_module.volumes
+    )
+    assert partial_string_in_mount(
+        "opentrons-python-dist:/dist", thermocycler_module.volumes
+    )
+
+    assert len(thermocycler_module.volumes) == 3
+
+
 def test_temperature_module_firmware_local_mounts(
-    temperature_module_firmware_local: RuntimeComposeFileModel,
+    temperature_module_firmware_local: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to local.
 
@@ -1043,7 +724,10 @@ def test_temperature_module_firmware_local_mounts(
     Also confirm that named volumes: opentrons-python-dist bound to the correct
     location.
     """
-    temperature_modules = temperature_module_firmware_local.temperature_module_emulators
+    config_file = convert_from_obj(
+        temperature_module_firmware_local, testing_global_em_config, False
+    )
+    temperature_modules = config_file.temperature_module_emulators
 
     assert temperature_modules is not None
     assert len(temperature_modules) == 1
@@ -1063,7 +747,8 @@ def test_temperature_module_firmware_local_mounts(
 
 
 def test_magnetic_module_firmware_local_mounts(
-    magnetic_module_firmware_local: RuntimeComposeFileModel,
+    magnetic_module_firmware_local: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to local.
 
@@ -1071,7 +756,10 @@ def test_magnetic_module_firmware_local_mounts(
     Also confirm that named volumes: opentrons-python-dist bound to the correct
     location.
     """
-    magnetic_modules = magnetic_module_firmware_local.magnetic_module_emulators
+    config_file = convert_from_obj(
+        magnetic_module_firmware_local, testing_global_em_config, False
+    )
+    magnetic_modules = config_file.magnetic_module_emulators
 
     assert magnetic_modules is not None
     assert len(magnetic_modules) == 1
@@ -1090,38 +778,9 @@ def test_magnetic_module_firmware_local_mounts(
     assert len(magnetic_module.volumes) == 3
 
 
-def test_thermocycler_module_firmware_local_mounts(
-    thermocycler_module_firmware_local: RuntimeComposeFileModel,
-) -> None:
-    """Test mounts when source-type is set to local.
-
-    Confirm that thermocycler module has opentrons, entrypoint.sh mounted in.
-    Also confirm that named volumes: opentrons-python-dist bound to the correct
-    location.
-    """
-    thermocycler_modules = (
-        thermocycler_module_firmware_local.thermocycler_module_emulators
-    )
-
-    assert thermocycler_modules is not None
-    assert len(thermocycler_modules) == 1
-
-    thermocycler_module = thermocycler_modules[0]
-    assert thermocycler_module.volumes is not None
-
-    assert partial_string_in_mount("opentrons:/opentrons", thermocycler_module.volumes)
-    assert partial_string_in_mount(
-        "entrypoint.sh:/entrypoint.sh", thermocycler_module.volumes
-    )
-    assert partial_string_in_mount(
-        "opentrons-python-dist:/dist", thermocycler_module.volumes
-    )
-
-    assert len(thermocycler_module.volumes) == 3
-
-
 def test_heater_shaker_hardware_remote_mounts(
-    heater_shaker_module_hardware_remote: RuntimeComposeFileModel,
+    heater_shaker_module_hardware_remote: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to local.
 
@@ -1129,7 +788,10 @@ def test_heater_shaker_hardware_remote_mounts(
     Also confirm that named volumes: opentrons-modules-build-stm32-host and
     opentrons-modules-stm32-tools exist and are bound to the correct location.
     """
-    heater_shakers = heater_shaker_module_hardware_remote.heater_shaker_module_emulators
+    config_file = convert_from_obj(
+        heater_shaker_module_hardware_remote, testing_global_em_config, False
+    )
+    heater_shakers = config_file.heater_shaker_module_emulators
 
     assert heater_shakers is not None
     assert len(heater_shakers) == 1
@@ -1139,15 +801,17 @@ def test_heater_shaker_hardware_remote_mounts(
 
 
 def test_thermocycler_module_hardware_remote_mounts(
-    thermocycler_module_hardware_remote: RuntimeComposeFileModel,
+    thermocycler_module_firmware_remote: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to remote.
 
     Confirm that there are no mounts
     """
-    thermocycler_modules = (
-        thermocycler_module_hardware_remote.thermocycler_module_emulators
+    config_file = convert_from_obj(
+        thermocycler_module_firmware_remote, testing_global_em_config, False
     )
+    thermocycler_modules = config_file.thermocycler_module_emulators
 
     assert thermocycler_modules is not None
     assert len(thermocycler_modules) == 1
@@ -1157,7 +821,8 @@ def test_thermocycler_module_hardware_remote_mounts(
 
 
 def test_temperature_module_firmware_remote_mounts(
-    temperature_module_firmware_remote: RuntimeComposeFileModel,
+    temperature_module_firmware_remote: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to local.
 
@@ -1165,9 +830,10 @@ def test_temperature_module_firmware_remote_mounts(
     Also confirm that named volumes: opentrons-python-dist bound to the correct
     location.
     """
-    temperature_modules = (
-        temperature_module_firmware_remote.temperature_module_emulators
+    config_file = convert_from_obj(
+        temperature_module_firmware_remote, testing_global_em_config, False
     )
+    temperature_modules = config_file.temperature_module_emulators
 
     assert temperature_modules is not None
     assert len(temperature_modules) == 1
@@ -1177,7 +843,8 @@ def test_temperature_module_firmware_remote_mounts(
 
 
 def test_magnetic_module_firmware_remote_mounts(
-    magnetic_module_firmware_remote: RuntimeComposeFileModel,
+    magnetic_module_firmware_remote: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to local.
 
@@ -1185,7 +852,10 @@ def test_magnetic_module_firmware_remote_mounts(
     Also confirm that named volumes: opentrons-python-dist bound to the correct
     location.
     """
-    magnetic_modules = magnetic_module_firmware_remote.magnetic_module_emulators
+    config_file = convert_from_obj(
+        magnetic_module_firmware_remote, testing_global_em_config, False
+    )
+    magnetic_modules = config_file.magnetic_module_emulators
 
     assert magnetic_modules is not None
     assert len(magnetic_modules) == 1
@@ -1195,7 +865,8 @@ def test_magnetic_module_firmware_remote_mounts(
 
 
 def test_thermocycler_module_firmware_remote_mounts(
-    thermocycler_module_firmware_remote: RuntimeComposeFileModel,
+    thermocycler_module_firmware_remote: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to local.
 
@@ -1203,9 +874,10 @@ def test_thermocycler_module_firmware_remote_mounts(
     Also confirm that named volumes: opentrons-python-dist bound to the correct
     location.
     """
-    thermocycler_modules = (
-        thermocycler_module_firmware_remote.thermocycler_module_emulators
+    config_file = convert_from_obj(
+        thermocycler_module_firmware_remote, testing_global_em_config, False
     )
+    thermocycler_modules = config_file.thermocycler_module_emulators
 
     assert thermocycler_modules is not None
     assert len(thermocycler_modules) == 1
@@ -1215,7 +887,7 @@ def test_thermocycler_module_firmware_remote_mounts(
 
 
 @pytest.mark.parametrize(
-    "config",
+    "config_dict",
     [
         lazy_fixture("ot3_remote_everything_latest"),
         lazy_fixture("ot3_remote_everything_commit_id"),
@@ -1223,13 +895,17 @@ def test_thermocycler_module_firmware_remote_mounts(
         lazy_fixture("ot2_remote_everything_commit_id"),
     ],
 )
-def test_is_remote(config: RuntimeComposeFileModel) -> None:
+def test_is_remote(
+    config_dict: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
     """Confirm that when all source-types are remote, is_remote is True."""
-    assert config.is_remote
+    config_file = convert_from_obj(config_dict, testing_global_em_config, False)
+    assert config_file.is_remote
 
 
 @pytest.mark.parametrize(
-    "config",
+    "config_dict",
     [
         lazy_fixture("ot3_local_robot"),
         lazy_fixture("ot3_local_source"),
@@ -1238,6 +914,10 @@ def test_is_remote(config: RuntimeComposeFileModel) -> None:
         lazy_fixture("ot2_local_robot"),
     ],
 )
-def test_is_not_remote(config: RuntimeComposeFileModel) -> None:
+def test_is_not_remote(
+    config_dict: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
     """Confirm that when all source-types are not remote, is_remote is False."""
-    assert not config.is_remote
+    config_file = convert_from_obj(config_dict, testing_global_em_config, False)
+    assert not config_file.is_remote


### PR DESCRIPTION
# Overview

Add logic to determine whether or not a builder container needs to be added to the docker-compose file. 
Currently the methods to actually add the builder containers are stubbed with print statements. Will be adding the actual containers in another PR

# Changelog

- Create 3 new on SystemConfigurationModel: `local_ot3_builder_required`, `local_opentrons_modules_builder_required`, and `local_monorepo_builder_required`
- If the above methods return `True` create the respective builders inside of `service_builder_orchestrator.py`
- Moved source code fixtures in `test_source_code_insertion.py` to conftest so they can be used inside of `test_builder_creation_logic.py`
- Changed above fixtures to return `Dict[str, Any]` instead of `RuntimeComposeFileModel` so they can be used to create a SystemConfigurationModel object
- Added tests to confirm 3 newly created methods return `True` or `False` correctly based off of passed SystemConfigurationModel