### PR TITLE
feat: Create ConcreteLocalOT3FirmwareBuilderBuilder (RQA-371)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,9 +7,6 @@
 # entrypoint.sh should also be bind-mounted in so do not copy it in either
 # Make sure to include the OPENTRONS_HARDWARE env variable
 
-FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as local-ot3-firmware-builder
-COPY entrypoints/local_ot3_firmware_builder.sh /build.sh
-
 ############################
 # Hardware Local Emulators #
 ############################
@@ -118,8 +115,8 @@ ENV OPENTRONS_HARDWARE "can-server"
 #######################
 
 FROM ghcr.io/opentrons/cpp-base-${TARGETARCH}:latest as ot3-firmware-source
-ARG FIRMWARE_SOURCE_DOWNLOAD_LOCATION
-ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION
+ARG FIRMWARE_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/ot3-firmware/archive/refs/heads/main.zip"
+ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons/archive/refs/heads/edge.zip"
 
 ADD $FIRMWARE_SOURCE_DOWNLOAD_LOCATION /ot3-firmware.zip
 ADD $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons.zip
@@ -133,12 +130,16 @@ RUN (cd / &&  \
     rm -f opentrons.zip && \
     mv opentrons* opentrons)
 
+
+FROM ot3-firmware-source as local-ot3-firmware-builder
+COPY entrypoints/local_ot3_firmware_builder.sh /build.sh
+
 ##################
 # modules-source #
 ##################
 
 FROM ghcr.io/opentrons/cpp-base-${TARGETARCH}:latest as opentrons-modules-source
-ARG MODULE_SOURCE_DOWNLOAD_LOCATION
+ARG MODULE_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons-modules/archive/refs/heads/edge.zip"
 ADD $MODULE_SOURCE_DOWNLOAD_LOCATION /opentrons-modules.zip
 RUN (cd / &&  \
     unzip -q opentrons-modules.zip && \
@@ -150,7 +151,7 @@ RUN (cd / &&  \
 ####################
 
 FROM ghcr.io/opentrons/python-base:latest as opentrons-source
-ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION
+ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons/archive/refs/heads/edge.zip"
 ADD $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons.zip
 RUN (cd / &&  \
     unzip -q opentrons.zip && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -139,7 +139,7 @@ COPY entrypoints/local_ot3_firmware_builder.sh /build.sh
 ##################
 
 FROM ghcr.io/opentrons/cpp-base-${TARGETARCH}:latest as opentrons-modules-source
-ARG MODULE_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons-modules/archive/refs/heads/edge.zip"
+ARG MODULE_SOURCE_DOWNLOAD_LOCATION
 ADD $MODULE_SOURCE_DOWNLOAD_LOCATION /opentrons-modules.zip
 RUN (cd / &&  \
     unzip -q opentrons-modules.zip && \
@@ -151,7 +151,7 @@ RUN (cd / &&  \
 ####################
 
 FROM ghcr.io/opentrons/python-base:latest as opentrons-source
-ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons/archive/refs/heads/edge.zip"
+ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION
 ADD $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons.zip
 RUN (cd / &&  \
     unzip -q opentrons.zip && \

--- a/emulation_system/emulation_system/compose_file_creator/config_file_settings.py
+++ b/emulation_system/emulation_system/compose_file_creator/config_file_settings.py
@@ -29,6 +29,25 @@ class OT3Hardware(str, Enum):
     BOOTLOADER = "ot3-bootloader"
     GRIPPER = "ot3-gripper"
 
+    def _remove_prefix(self) -> str:
+        return self.value.replace("ot3-", "")
+
+    def _to_volume_name(self) -> str:
+        switch_dashes_to_underscores = self._remove_prefix().replace("-", "_")
+        return f"{switch_dashes_to_underscores}_executable"
+
+    def _to_volume_path(self) -> str:
+        switch_dashes_to_underscores = self._remove_prefix().replace("-", "_")
+        return f"/volumes/{switch_dashes_to_underscores}/"
+
+    def to_simulator_name(self) -> str:
+        """Generates simulator name."""
+        return f"{self._remove_prefix()}-simulator."
+
+    def generate_executable_storage_volume_string(self) -> str:
+        """Generates volume string for local-ot3-firmware-builder."""
+        return f"{self._to_volume_name()}:{self._to_volume_path()}"
+
 
 class EmulationLevels(str, Enum):
     """The emulation level of the emulator."""

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/__init__.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/__init__.py
@@ -3,7 +3,7 @@ from .concrete_can_server_service_builder import ConcreteCANServerServiceBuilder
 from .concrete_emulator_proxy_service_builder import ConcreteEmulatorProxyServiceBuilder
 from .concrete_input_service_builder import ConcreteInputServiceBuilder
 from .concrete_local_ot3_firmware_builder_builder import (
-    ConcreateLocalOT3FirmwareBuilderBuilder,
+    ConcreteLocalOT3FirmwareBuilderBuilder,
 )
 from .concrete_ot3_service_builder import ConcreteOT3ServiceBuilder
 from .concrete_ot3_state_manager_builder import ConcreteOT3StateManagerBuilder
@@ -18,5 +18,5 @@ __all__ = [
     "ConcreteOT3ServiceBuilder",
     "ConcreteInputServiceBuilder",
     "ConcreteOT3StateManagerBuilder",
-    "ConcreateLocalOT3FirmwareBuilderBuilder",
+    "ConcreteLocalOT3FirmwareBuilderBuilder",
 ]

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/__init__.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/__init__.py
@@ -2,6 +2,9 @@
 from .concrete_can_server_service_builder import ConcreteCANServerServiceBuilder
 from .concrete_emulator_proxy_service_builder import ConcreteEmulatorProxyServiceBuilder
 from .concrete_input_service_builder import ConcreteInputServiceBuilder
+from .concrete_local_ot3_firmware_builder_builder import (
+    ConcreateLocalOT3FirmwareBuilderBuilder,
+)
 from .concrete_ot3_service_builder import ConcreteOT3ServiceBuilder
 from .concrete_ot3_state_manager_builder import ConcreteOT3StateManagerBuilder
 from .concrete_smoothie_service_builder import ConcreteSmoothieServiceBuilder
@@ -15,4 +18,5 @@ __all__ = [
     "ConcreteOT3ServiceBuilder",
     "ConcreteInputServiceBuilder",
     "ConcreteOT3StateManagerBuilder",
+    "ConcreateLocalOT3FirmwareBuilderBuilder",
 ]

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_local_ot3_firmware_builder_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_local_ot3_firmware_builder_builder.py
@@ -1,10 +1,7 @@
 """Module containing ConcreteOT3ServiceBuilder class."""
 from typing import Optional
 
-from emulation_system import (
-    OpentronsEmulationConfiguration,
-    SystemConfigurationModel,
-)
+from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
 from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediateBuildArgs,
     IntermediateCommand,
@@ -15,16 +12,13 @@ from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediatePorts,
     IntermediateVolumes,
 )
-from .abstract_service_builder import AbstractServiceBuilder
-from ...config_file_settings import (
-    OT3Hardware,
-    OpentronsRepository,
-    SourceType,
-)
+
+from ...config_file_settings import OpentronsRepository, OT3Hardware, SourceType
 from ...utilities.shared_functions import get_build_args
+from .abstract_service_builder import AbstractServiceBuilder
 
 
-class ConcreateLocalOT3FirmwareBuilderBuilder(AbstractServiceBuilder):
+class ConcreteLocalOT3FirmwareBuilderBuilder(AbstractServiceBuilder):
     """Concrete implementation of AbstractServiceBuilder for building local-ot3-firmware-builder Service."""
 
     IMAGE_NAME = "local-ot3-firmware-builder"

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_local_ot3_firmware_builder_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_local_ot3_firmware_builder_builder.py
@@ -96,7 +96,7 @@ class ConcreteLocalOT3FirmwareBuilderBuilder(AbstractServiceBuilder):
     def generate_volumes(self) -> Optional[IntermediateVolumes]:
         """Generates value for volumes parameter."""
         mount_strings: List[str] = []
-        if self._ot3.source_type == SourceType.REMOTE:
+        if self._ot3.source_type == SourceType.LOCAL:
             mount_strings.extend(
                 [
                     member.generate_executable_storage_volume_string()

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_local_ot3_firmware_builder_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_local_ot3_firmware_builder_builder.py
@@ -1,0 +1,125 @@
+"""Module containing ConcreteOT3ServiceBuilder class."""
+from typing import Optional
+
+from emulation_system import (
+    OpentronsEmulationConfiguration,
+    SystemConfigurationModel,
+)
+from emulation_system.compose_file_creator.types.intermediate_types import (
+    IntermediateBuildArgs,
+    IntermediateCommand,
+    IntermediateDependsOn,
+    IntermediateEnvironmentVariables,
+    IntermediateHealthcheck,
+    IntermediateNetworks,
+    IntermediatePorts,
+    IntermediateVolumes,
+)
+from .abstract_service_builder import AbstractServiceBuilder
+from ...config_file_settings import (
+    OT3Hardware,
+    OpentronsRepository,
+    SourceType,
+)
+from ...utilities.shared_functions import get_build_args
+
+
+class ConcreateLocalOT3FirmwareBuilderBuilder(AbstractServiceBuilder):
+    """Concrete implementation of AbstractServiceBuilder for building local-ot3-firmware-builder Service."""
+
+    IMAGE_NAME = "local-ot3-firmware-builder"
+    CONTAINER_NAME = IMAGE_NAME
+
+    def __init__(
+        self,
+        config_model: SystemConfigurationModel,
+        global_settings: OpentronsEmulationConfiguration,
+        dev: bool,
+    ) -> None:
+        """Instantiates a ConcreteOT3ServiceBuilder object."""
+        super().__init__(config_model, global_settings, dev)
+        self._ot3 = self.get_ot3(self._config_model)
+
+    @property
+    def _image(self) -> str:
+        return self.IMAGE_NAME
+
+    def generate_container_name(self) -> str:
+        """Generates value for container_name parameter."""
+        system_unique_id = self._config_model.system_unique_id
+        container_name = super()._generate_container_name(
+            self.CONTAINER_NAME, system_unique_id
+        )
+        return container_name
+
+    def generate_image(self) -> str:
+        """Generates value for image parameter."""
+        return self.IMAGE_NAME
+
+    def is_tty(self) -> bool:
+        """Generates value for tty parameter."""
+        return True
+
+    def generate_networks(self) -> IntermediateNetworks:
+        """Generates value for networks parameter."""
+        networks = self._config_model.required_networks
+        return networks
+
+    def generate_healthcheck(self) -> IntermediateHealthcheck:
+        """Check to see if ot3-firmware and monorepo exist."""
+        return IntermediateHealthcheck(
+            interval=10,
+            retries=6,
+            timeout=10,
+            command="(cd /ot3-firmware) && (cd /opentrons)",
+        )
+
+    def generate_build_args(self) -> Optional[IntermediateBuildArgs]:
+        """Generates value for build parameter."""
+        ot3_firmware_repo = OpentronsRepository.OT3_FIRMWARE
+        monorepo = OpentronsRepository.OPENTRONS
+        build_args: IntermediateBuildArgs = {}
+        if self._ot3.source_type == SourceType.REMOTE:
+            ot3_firmware_build_args = get_build_args(
+                ot3_firmware_repo,
+                self._ot3.source_location,
+                self._global_settings.get_repo_commit(ot3_firmware_repo),
+                self._global_settings.get_repo_head(ot3_firmware_repo),
+            )
+            build_args.update(ot3_firmware_build_args)
+
+        if self._ot3.opentrons_hardware_source_type == SourceType.REMOTE:
+            monorepo_build_args = get_build_args(
+                monorepo,
+                self._ot3.opentrons_hardware_source_location,
+                self._global_settings.get_repo_commit(monorepo),
+                self._global_settings.get_repo_head(monorepo),
+            )
+            build_args.update(monorepo_build_args)
+
+        return build_args if len(build_args) > 0 else None
+
+    def generate_volumes(self) -> Optional[IntermediateVolumes]:
+        """Generates value for volumes parameter."""
+        mount_strings = [
+            member.generate_executable_storage_volume_string()
+            for member in OT3Hardware.__members__.values()
+        ]
+        mount_strings.extend(self._ot3.get_mount_strings())
+        return mount_strings
+
+    def generate_command(self) -> Optional[IntermediateCommand]:
+        """Generates value for command parameter."""
+        return None
+
+    def generate_ports(self) -> Optional[IntermediatePorts]:
+        """Generates value for ports parameter."""
+        return None
+
+    def generate_depends_on(self) -> Optional[IntermediateDependsOn]:
+        """Generates value for depends_on parameter."""
+        return None
+
+    def generate_env_vars(self) -> Optional[IntermediateEnvironmentVariables]:
+        """Generates value for environment parameter."""
+        return None

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_local_ot3_firmware_builder_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_local_ot3_firmware_builder_builder.py
@@ -1,5 +1,5 @@
 """Module containing ConcreteOT3ServiceBuilder class."""
-from typing import Optional
+from typing import List, Optional
 
 from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
 from emulation_system.compose_file_creator.types.intermediate_types import (
@@ -95,10 +95,16 @@ class ConcreteLocalOT3FirmwareBuilderBuilder(AbstractServiceBuilder):
 
     def generate_volumes(self) -> Optional[IntermediateVolumes]:
         """Generates value for volumes parameter."""
-        mount_strings = [
-            member.generate_executable_storage_volume_string()
-            for member in OT3Hardware.__members__.values()
-        ]
+        mount_strings: List[str] = []
+        if self._ot3.source_type == SourceType.REMOTE:
+            mount_strings.extend(
+                [
+                    member.generate_executable_storage_volume_string()
+                    for member in OT3Hardware.__members__.values()
+                ]
+            )
+
+        # TODO: Add executable volume string for monorepo if opentrons-hardware-source-type is local
         mount_strings.extend(self._ot3.get_mount_strings())
         return mount_strings
 

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_state_manager_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_state_manager_builder.py
@@ -1,10 +1,7 @@
 """Module containing ConcreteOT3ServiceBuilder class."""
 from typing import Optional
 
-from emulation_system import (
-    OpentronsEmulationConfiguration,
-    SystemConfigurationModel,
-)
+from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
 from emulation_system.compose_file_creator.config_file_settings import (
     OpentronsRepository,
     SourceType,
@@ -22,6 +19,7 @@ from emulation_system.compose_file_creator.types.intermediate_types import (
 from emulation_system.compose_file_creator.utilities.shared_functions import (
     get_build_args,
 )
+
 from .abstract_service_builder import AbstractServiceBuilder
 
 

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/service_builder_orchestrator.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/service_builder_orchestrator.py
@@ -15,10 +15,10 @@ from ...images import (
 )
 from ...types.intermediate_types import DockerServices
 from . import (
-    ConcreateLocalOT3FirmwareBuilderBuilder,
     ConcreteCANServerServiceBuilder,
     ConcreteEmulatorProxyServiceBuilder,
     ConcreteInputServiceBuilder,
+    ConcreteLocalOT3FirmwareBuilderBuilder,
     ConcreteOT3ServiceBuilder,
     ConcreteOT3StateManagerBuilder,
     ConcreteSmoothieServiceBuilder,
@@ -159,7 +159,7 @@ class ServiceBuilderOrchestrator:
             self._services[service.container_name] = service
 
     def __add_local_ot3_builder(self) -> None:
-        local_ot3_builder = ConcreateLocalOT3FirmwareBuilderBuilder(
+        local_ot3_builder = ConcreteLocalOT3FirmwareBuilderBuilder(
             self._config_model, self._global_settings, self._dev
         ).build_service()
         assert local_ot3_builder.container_name is not None

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/service_builder_orchestrator.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/service_builder_orchestrator.py
@@ -15,6 +15,7 @@ from ...images import (
 )
 from ...types.intermediate_types import DockerServices
 from . import (
+    ConcreateLocalOT3FirmwareBuilderBuilder,
     ConcreteCANServerServiceBuilder,
     ConcreteEmulatorProxyServiceBuilder,
     ConcreteInputServiceBuilder,
@@ -158,7 +159,11 @@ class ServiceBuilderOrchestrator:
             self._services[service.container_name] = service
 
     def __add_local_ot3_builder(self) -> None:
-        print("Local ot3-firmware builder required")
+        local_ot3_builder = ConcreateLocalOT3FirmwareBuilderBuilder(
+            self._config_model, self._global_settings, self._dev
+        ).build_service()
+        assert local_ot3_builder.container_name is not None
+        self._services[local_ot3_builder.container_name] = local_ot3_builder
 
     def __add_local_opentrons_modules_builder(self) -> None:
         print("Local opentrons-modules builder required")

--- a/emulation_system/tests/compose_file_creator/conversion_logic/conftest.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/conftest.py
@@ -233,7 +233,6 @@ def ot3_remote_everything_commit_id(
 @pytest.fixture
 def ot3_local_source(
     ot3_default: Dict[str, Any],
-    opentrons_dir: str,
     ot3_firmware_dir: str,
     robot_set_source_type_params: Callable,
 ) -> Dict[str, Any]:
@@ -248,6 +247,26 @@ def ot3_local_source(
         can_server_source_location="latest",
         opentrons_hardware_source_type=SourceType.REMOTE,
         opentrons_hardware_source_location="latest",
+    )
+
+
+@pytest.fixture
+def ot3_remote_source_local_opentrons_hardware(
+    ot3_default: Dict[str, Any],
+    opentrons_dir: str,
+    robot_set_source_type_params: Callable,
+) -> Dict[str, Any]:
+    """Get OT3 configured for local source and local robot source."""
+    return robot_set_source_type_params(
+        robot_dict=ot3_default,
+        source_type=SourceType.REMOTE,
+        source_location="latest",
+        robot_server_source_type=SourceType.REMOTE,
+        robot_server_source_location="latest",
+        can_server_source_type=SourceType.REMOTE,
+        can_server_source_location="latest",
+        opentrons_hardware_source_type=SourceType.LOCAL,
+        opentrons_hardware_source_location=opentrons_dir,
     )
 
 
@@ -288,6 +307,27 @@ def ot3_local_robot(
         can_server_source_location="latest",
         opentrons_hardware_source_type=SourceType.REMOTE,
         opentrons_hardware_source_location="latest",
+    )
+
+
+@pytest.fixture
+def ot3_local_everything(
+    ot3_default: Dict[str, Any],
+    opentrons_dir: str,
+    ot3_firmware_dir: str,
+    robot_set_source_type_params: Callable,
+) -> Dict[str, Any]:
+    """Get OT3 configured for local source and local robot source."""
+    return robot_set_source_type_params(
+        robot_dict=ot3_default,
+        source_type=SourceType.LOCAL,
+        source_location=ot3_firmware_dir,
+        robot_server_source_type=SourceType.LOCAL,
+        robot_server_source_location=opentrons_dir,
+        can_server_source_type=SourceType.LOCAL,
+        can_server_source_location=opentrons_dir,
+        opentrons_hardware_source_type=SourceType.LOCAL,
+        opentrons_hardware_source_location=opentrons_dir,
     )
 
 

--- a/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_local_ot3_firmware_builder_builder.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_local_ot3_firmware_builder_builder.py
@@ -1,0 +1,118 @@
+"""Tests to confirm that local-ot3-firmware-builder container is created correctly."""
+
+from typing import Any, Dict
+
+import pytest
+from pydantic import parse_obj_as
+from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
+
+from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
+from emulation_system.compose_file_creator.config_file_settings import (
+    RepoToBuildArgMapping,
+)
+from emulation_system.compose_file_creator.conversion.service_builders import (
+    ConcreteLocalOT3FirmwareBuilderBuilder,
+)
+from tests.compose_file_creator.conversion_logic.conftest import (
+    build_args_are_none,
+    get_source_code_build_args,
+)
+
+
+@pytest.mark.parametrize(
+    "config_model",
+    [
+        lazy_fixture("ot3_local_source"),
+        lazy_fixture("ot3_remote_source_local_opentrons_hardware"),
+        lazy_fixture("ot3_local_everything"),
+    ],
+)
+def test_simple_values(
+    config_model: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
+    """Test values common to all 3 configs."""
+    model = parse_obj_as(SystemConfigurationModel, config_model)
+    service = ConcreteLocalOT3FirmwareBuilderBuilder(
+        model, testing_global_em_config, False
+    ).build_service()
+
+    assert service.image is not None
+    assert service.image == "local-ot3-firmware-builder"
+    assert service.container_name is not None
+    assert service.container_name == "local-ot3-firmware-builder"
+    assert service.tty
+    assert isinstance(service.networks, list)
+    assert len(service.networks) == 2
+    assert "local-network" in service.networks
+    assert "can-network" in service.networks
+    assert service.command is None
+    assert service.ports is None
+    assert service.environment is None
+
+
+def test_local_ot3_firmware_remote_monorepo(
+    ot3_local_source: Dict[str, Any],
+    opentrons_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
+    """Tests for when you are using local ot3-firmware and remote monorepo."""
+    model = parse_obj_as(SystemConfigurationModel, ot3_local_source)
+    service = ConcreteLocalOT3FirmwareBuilderBuilder(
+        model, testing_global_em_config, False
+    ).build_service()
+
+    monorepo_build_arg = RepoToBuildArgMapping.OPENTRONS
+    build_args = get_source_code_build_args(service)
+    assert len(build_args) == 1
+    assert monorepo_build_arg in build_args
+    assert build_args[monorepo_build_arg] == opentrons_head
+
+    volumes = service.volumes
+    assert volumes is not None
+
+    # TODO: Add volume checks when refactoring of local source is finished
+
+
+def test_remote_ot3_firmware_local_monorepo(
+    ot3_remote_source_local_opentrons_hardware: Dict[str, Any],
+    ot3_firmware_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
+    """Tests for when you are using remote ot3-firmware and local monorepo."""
+    model = parse_obj_as(
+        SystemConfigurationModel, ot3_remote_source_local_opentrons_hardware
+    )
+    service = ConcreteLocalOT3FirmwareBuilderBuilder(
+        model, testing_global_em_config, False
+    ).build_service()
+
+    ot3_firmware_build_arg = RepoToBuildArgMapping.OT3_FIRMWARE
+    build_args = get_source_code_build_args(service)
+    assert len(build_args) == 1
+    assert ot3_firmware_build_arg in build_args
+    assert build_args[ot3_firmware_build_arg] == ot3_firmware_head
+
+    volumes = service.volumes
+    assert volumes is not None
+
+    # TODO: Add volume checks when refactoring of local source is finished
+
+
+def test_local_everything(
+    ot3_local_everything: Dict[str, Any],
+    opentrons_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
+    """Tests for when you are using local ot3-firmware and local monorepo."""
+    model = parse_obj_as(SystemConfigurationModel, ot3_local_everything)
+    service = ConcreteLocalOT3FirmwareBuilderBuilder(
+        model, testing_global_em_config, False
+    ).build_service()
+
+    assert build_args_are_none(service)
+
+    volumes = service.volumes
+    assert volumes is not None
+
+    # TODO: Add volume checks when refactoring of local source is finished

--- a/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_ot3_service_builder.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_ot3_service_builder.py
@@ -22,7 +22,6 @@ from emulation_system.compose_file_creator.images import (
 )
 from emulation_system.consts import DEV_DOCKERFILE_NAME, DOCKERFILE_NAME
 from tests.compose_file_creator.conversion_logic.conftest import (
-    FAKE_COMMIT_ID,
     build_args_are_none,
     get_source_code_build_args,
     partial_string_in_mount,
@@ -30,48 +29,37 @@ from tests.compose_file_creator.conversion_logic.conftest import (
 
 
 @pytest.fixture
-def remote_source_latest(ot3_only: Dict[str, Any]) -> SystemConfigurationModel:
+def remote_source_latest(
+    ot3_remote_everything_latest: Dict[str, Any]
+) -> SystemConfigurationModel:
     """Gets SystemConfigurationModel.
 
     source-type is set to remote.
     source-location is set to latest.
     """
-    ot3_only["robot"]["source-type"] = "remote"
-    ot3_only["robot"]["source-location"] = "latest"
-    ot3_only["robot"]["opentrons-hardware-source-type"] = "remote"
-    ot3_only["robot"]["opentrons-hardware-source-location"] = "latest"
-    return parse_obj_as(SystemConfigurationModel, ot3_only)
+    return parse_obj_as(SystemConfigurationModel, ot3_remote_everything_latest)
 
 
 @pytest.fixture
-def remote_source_commit_id(ot3_only: Dict[str, Any]) -> SystemConfigurationModel:
+def remote_source_commit_id(
+    ot3_remote_everything_commit_id: Dict[str, Any]
+) -> SystemConfigurationModel:
     """Gets SystemConfigurationModel.
 
     source-type is set to remote.
     source-location is set a commit id.
     """
-    ot3_only["robot"]["source-type"] = "remote"
-    ot3_only["robot"]["source-location"] = FAKE_COMMIT_ID
-    ot3_only["robot"]["opentrons-hardware-source-type"] = "remote"
-    ot3_only["robot"]["opentrons-hardware-source-location"] = FAKE_COMMIT_ID
-    return parse_obj_as(SystemConfigurationModel, ot3_only)
+    return parse_obj_as(SystemConfigurationModel, ot3_remote_everything_commit_id)
 
 
 @pytest.fixture
-def local_source(
-    ot3_only: Dict[str, Any], ot3_firmware_dir: str, opentrons_dir: str
-) -> SystemConfigurationModel:
+def local_source(ot3_local_everything: Dict[str, Any]) -> SystemConfigurationModel:
     """Gets SystemConfigurationModel.
 
     source-type is set to local.
     source-location is set to a monorepo dir.
     """
-    ot3_only["robot"]["source-type"] = "local"
-    ot3_only["robot"]["source-location"] = ot3_firmware_dir
-    ot3_only["robot"]["opentrons-hardware-source-type"] = "local"
-    ot3_only["robot"]["opentrons-hardware-source-location"] = opentrons_dir
-
-    return parse_obj_as(SystemConfigurationModel, ot3_only)
+    return parse_obj_as(SystemConfigurationModel, ot3_local_everything)
 
 
 def get_ot3_service(service_list: List[Service], hardware: OT3Hardware) -> Service:


### PR DESCRIPTION
# Overview

Add ConcreteLocalOT3FirmwareBuilderBuilder to create `local-ot3-firmware-builder` container.

# Changelog

- Add default values for all `OPENTRONS_SOURCE_DOWNLOAD_LOCATION` and `OT3_FIRMWARE_SOURCE_DOWNLOAD_LOCATION` builds args for `ot3-firmware-source` target in Dockerfile. Have to do this because `ot3-firmware` builder requires both the monorepo and ot3-firmware repo. But you can have a configuration where one is local and one is remote. How this configuration will work is during build time either `latest` or a commit sha will be downloaded for both monorepo and ot3-firmware repo. If there are any bind mounts added at runtime, they will override the repos downloaded during build time. 
- Make local-ot3-firmware-builder inherit from `ot3-firmware-source
- Add logic for building volume names, volume paths, and simulator names to OT3Hardware
- Add ConcreteLocalOT3FirmwareBuilderBuilder class.
  - Checks for existence of both `ot3-firmware` and `opentrons` folders for healthcheck
  - Sets build arg for `ot3-firmware` if `source-type` is `remote`
  - Sets build arg for `opentrons` if `opentrons-hardware-source-type` is `remote`
  - Add volumes for `ot3-firmware` if `source-type` is 
- Fix bug in state manager where build args were being specified when they shouldn't have been
- Add tests


# Review requests

None

# Risk assessment

Low