### PR TITLE
chore: Add .git folder and OPENTRONS_PROJECT env var

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -6,10 +6,10 @@
                 "ot3-firmware": "https://github.com/Opentrons/ot3-firmware.git#main",
                 "modules": "https://github.com/Opentrons/opentrons-modules.git#edge"
             },
-            "commits": {
-                "opentrons": "https://github.com/Opentrons/opentrons.git#{{commit-sha}}",
-                "ot3-firmware": "https://github.com/Opentrons/ot3-firmware.git#{{commit-sha}}",
-                "modules": "https://github.com/Opentrons/opentrons-modules.git#{{commit-sha}}"
+            "branches": {
+                "opentrons": "https://github.com/Opentrons/opentrons.git#{{branch-name}}",
+                "ot3-firmware": "https://github.com/Opentrons/ot3-firmware.git#{{branch-name}}",
+                "modules": "https://github.com/Opentrons/opentrons-modules.git#{{branch-name}}"
             }
         }
     }

--- a/configuration.json
+++ b/configuration.json
@@ -2,14 +2,14 @@
     "emulation-settings": {
         "source-download-locations": {
             "heads": {
-                "opentrons": "https://github.com/Opentrons/opentrons/archive/refs/heads/edge.zip",
-                "ot3-firmware": "https://github.com/Opentrons/ot3-firmware/archive/refs/heads/main.zip",
-                "modules": "https://github.com/Opentrons/opentrons-modules/archive/refs/heads/edge.zip"
+                "opentrons": "https://github.com/Opentrons/opentrons.git",
+                "ot3-firmware": "https://github.com/Opentrons/ot3-firmware.git",
+                "modules": "https://github.com/Opentrons/opentrons-modules.git"
             },
             "commits": {
-                "opentrons": "https://github.com/Opentrons/opentrons/archive/{{commit-sha}}.zip",
-                "ot3-firmware": "https://github.com/Opentrons/ot3-firmware/archive/{{commit-sha}}.zip",
-                "modules": "https://github.com/Opentrons/opentrons-modules/archive/{{commit-sha}}.zip"
+                "opentrons": "https://github.com/Opentrons/opentrons.git#{{commit-sha}}",
+                "ot3-firmware": "https://github.com/Opentrons/ot3-firmware.git#{{commit-sha}}",
+                "modules": "https://github.com/Opentrons/opentrons-modules.git#{{commit-sha}}"
             }
         }
     }

--- a/configuration.json
+++ b/configuration.json
@@ -2,9 +2,9 @@
     "emulation-settings": {
         "source-download-locations": {
             "heads": {
-                "opentrons": "https://github.com/Opentrons/opentrons.git",
-                "ot3-firmware": "https://github.com/Opentrons/ot3-firmware.git",
-                "modules": "https://github.com/Opentrons/opentrons-modules.git"
+                "opentrons": "https://github.com/Opentrons/opentrons.git#edge",
+                "ot3-firmware": "https://github.com/Opentrons/ot3-firmware.git#main",
+                "modules": "https://github.com/Opentrons/opentrons-modules.git#edge"
             },
             "commits": {
                 "opentrons": "https://github.com/Opentrons/opentrons.git#{{commit-sha}}",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile-upstream:master-labs
 #############################################################
 #                       LOCAL TARGETS                       #
 #############################################################
@@ -126,17 +127,8 @@ FROM ghcr.io/opentrons/cpp-base-${TARGETARCH}:latest as ot3-firmware-source
 ARG FIRMWARE_SOURCE_DOWNLOAD_LOCATION
 ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION
 
-ADD $FIRMWARE_SOURCE_DOWNLOAD_LOCATION /ot3-firmware.zip
-ADD $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons.zip
-
-RUN (cd / &&  \
-    unzip -q ot3-firmware.zip && \
-    rm -f ot3-firmware.zip && \
-    mv ot3-firmware* ot3-firmware)
-RUN (cd / &&  \
-    unzip -q opentrons.zip && \
-    rm -f opentrons.zip && \
-    mv opentrons* opentrons)
+ADD --keep-git-dir=true $FIRMWARE_SOURCE_DOWNLOAD_LOCATION /ot3-firmware
+ADD --keep-git-dir=true $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons
 
 ##################
 # modules-source #
@@ -144,11 +136,7 @@ RUN (cd / &&  \
 
 FROM ghcr.io/opentrons/cpp-base-${TARGETARCH}:latest as opentrons-modules-source
 ARG MODULE_SOURCE_DOWNLOAD_LOCATION
-ADD $MODULE_SOURCE_DOWNLOAD_LOCATION /opentrons-modules.zip
-RUN (cd / &&  \
-    unzip -q opentrons-modules.zip && \
-    rm -f opentrons-modules.zip && \
-    mv opentrons-modules* opentrons-modules)
+ADD --keep-git-dir=true $MODULE_SOURCE_DOWNLOAD_LOCATION /opentrons-modules
 
 ####################
 # opentrons-source #
@@ -156,11 +144,8 @@ RUN (cd / &&  \
 
 FROM ghcr.io/opentrons/python-base:latest as opentrons-source
 ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION
-ADD $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons.zip
-RUN (cd / &&  \
-    unzip -q opentrons.zip && \
-    rm -f opentrons.zip && \
-    mv opentrons* opentrons)
+
+ADD --keep-git-dir=true $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons
 
 #############################################################
 #                    EXECUTABLE BUILDERS                    #

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_can_server_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_can_server_service_builder.py
@@ -152,10 +152,10 @@ class ConcreteCANServerServiceBuilder(AbstractServiceBuilder):
 
     def generate_env_vars(self) -> Optional[IntermediateEnvironmentVariables]:
         """Generates value for environment parameter."""
-        env_vars: IntermediateEnvironmentVariables | None = None
+        env_vars: IntermediateEnvironmentVariables | None = {"OPENTRONS_PROJECT": "ot3"}
         assert isinstance(self._config_model.robot, OT3InputModel)
         if self._config_model.robot.can_server_env_vars is not None:
-            env_vars = self._config_model.robot.can_server_env_vars
+            env_vars.update(self._config_model.robot.can_server_env_vars)
 
         self._logging_client.log_env_vars(env_vars)
         return env_vars

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_can_server_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_can_server_service_builder.py
@@ -152,7 +152,7 @@ class ConcreteCANServerServiceBuilder(AbstractServiceBuilder):
 
     def generate_env_vars(self) -> Optional[IntermediateEnvironmentVariables]:
         """Generates value for environment parameter."""
-        env_vars: IntermediateEnvironmentVariables | None = {"OPENTRONS_PROJECT": "ot3"}
+        env_vars: IntermediateEnvironmentVariables = {"OPENTRONS_PROJECT": "ot3"}
         assert isinstance(self._config_model.robot, OT3InputModel)
         if self._config_model.robot.can_server_env_vars is not None:
             env_vars.update(self._config_model.robot.can_server_env_vars)

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_can_server_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_can_server_service_builder.py
@@ -112,7 +112,7 @@ class ConcreteCANServerServiceBuilder(AbstractServiceBuilder):
             build_args = get_build_args(
                 repo,
                 self._ot3.can_server_source_location,
-                self._global_settings.get_repo_commit(repo),
+                self._global_settings.get_repo_branch(repo),
                 self._global_settings.get_repo_head(repo),
             )
 

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_emulator_proxy_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_emulator_proxy_service_builder.py
@@ -29,6 +29,7 @@ from emulation_system.compose_file_creator.utilities.shared_functions import (
 )
 
 from ...logging import EmulatorProxyLoggingClient
+from ...utilities.hardware_utils import is_ot3
 from .abstract_service_builder import AbstractServiceBuilder
 
 
@@ -154,6 +155,9 @@ class ConcreteEmulatorProxyServiceBuilder(AbstractServiceBuilder):
             for module in self.MODULE_TYPES
             for env_var_name, env_var_value in module.get_proxy_info_env_var().items()  # type: ignore [attr-defined]
         }
+
+        if is_ot3(self._config_model.robot):
+            env_vars["OPENTRONS_PROJECT"] = "ot3"
 
         if self._config_model.robot is not None:
             assert issubclass(self._config_model.robot.__class__, RobotInputModel)

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_emulator_proxy_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_emulator_proxy_service_builder.py
@@ -156,6 +156,7 @@ class ConcreteEmulatorProxyServiceBuilder(AbstractServiceBuilder):
             for env_var_name, env_var_value in module.get_proxy_info_env_var().items()  # type: ignore [attr-defined]
         }
 
+        assert self._config_model.robot is not None
         if is_ot3(self._config_model.robot):
             env_vars["OPENTRONS_PROJECT"] = "ot3"
 

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_emulator_proxy_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_emulator_proxy_service_builder.py
@@ -117,7 +117,7 @@ class ConcreteEmulatorProxyServiceBuilder(AbstractServiceBuilder):
         build_args = get_build_args(
             repo,
             "latest",
-            self._global_settings.get_repo_commit(repo),
+            self._global_settings.get_repo_branch(repo),
             self._global_settings.get_repo_head(repo),
         )
         self._logging_client.log_build_args(build_args)

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_emulator_proxy_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_emulator_proxy_service_builder.py
@@ -10,7 +10,6 @@ from emulation_system.compose_file_creator.images import EmulatorProxyImages
 from emulation_system.compose_file_creator.input.hardware_models import (
     HeaterShakerModuleInputModel,
     MagneticModuleInputModel,
-    RobotInputModel,
     TemperatureModuleInputModel,
     ThermocyclerModuleInputModel,
 )
@@ -29,7 +28,7 @@ from emulation_system.compose_file_creator.utilities.shared_functions import (
 )
 
 from ...logging import EmulatorProxyLoggingClient
-from ...utilities.hardware_utils import is_ot3
+from ...utilities.hardware_utils import is_ot3, is_robot
 from .abstract_service_builder import AbstractServiceBuilder
 
 
@@ -156,12 +155,11 @@ class ConcreteEmulatorProxyServiceBuilder(AbstractServiceBuilder):
             for env_var_name, env_var_value in module.get_proxy_info_env_var().items()  # type: ignore [attr-defined]
         }
 
-        assert self._config_model.robot is not None
-        if is_ot3(self._config_model.robot):
-            env_vars["OPENTRONS_PROJECT"] = "ot3"
+        if self._config_model.robot is not None and is_robot(self._config_model.robot):
 
-        if self._config_model.robot is not None:
-            assert issubclass(self._config_model.robot.__class__, RobotInputModel)
+            if is_ot3(self._config_model.robot):
+                env_vars["OPENTRONS_PROJECT"] = "ot3"
+
             if self._config_model.robot.emulator_proxy_env_vars is not None:
                 env_vars.update(self._config_model.robot.emulator_proxy_env_vars)
 

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_input_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_input_service_builder.py
@@ -243,6 +243,7 @@ class ConcreteInputServiceBuilder(AbstractServiceBuilder):
 
         if is_ot3(self._container):
             assert self._can_server_service_name is not None
+            temp_vars["OPENTRONS_PROJECT"] = "ot3"
             temp_vars["OT_API_FF_enableOT3HardwareController"] = True
             temp_vars["OT3_CAN_DRIVER_interface"] = "opentrons_sock"
             temp_vars["OT3_CAN_DRIVER_host"] = self._can_server_service_name

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_input_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_input_service_builder.py
@@ -159,7 +159,7 @@ class ConcreteInputServiceBuilder(AbstractServiceBuilder):
             build_args = get_build_args(
                 repo,
                 source_location,
-                self._global_settings.get_repo_commit(repo),
+                self._global_settings.get_repo_branch(repo),
                 self._global_settings.get_repo_head(repo),
             )
         self._logging_client.log_build_args(build_args)

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_service_builder.py
@@ -206,7 +206,7 @@ class ConcreteOT3ServiceBuilder(AbstractServiceBuilder):
     def generate_env_vars(self) -> Optional[IntermediateEnvironmentVariables]:
         """Generates value for environment parameter."""
         env_vars: IntermediateEnvironmentVariables = {
-            "CAN_SERVER_HOST": self._can_server_service_name,
+            "CAN_SERVER_HOST": self._can_server_service_name
         }
         if not isinstance(self._service_info.image, OT3BootloaderImages):
             env_vars["STATE_MANAGER_HOST"] = self._state_manager_name

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_service_builder.py
@@ -146,7 +146,7 @@ class ConcreteOT3ServiceBuilder(AbstractServiceBuilder):
             ot3_firmware_build_args = get_build_args(
                 ot3_firmware_repo,
                 self._ot3.source_location,
-                self._global_settings.get_repo_commit(ot3_firmware_repo),
+                self._global_settings.get_repo_branch(ot3_firmware_repo),
                 self._global_settings.get_repo_head(ot3_firmware_repo),
             )
             build_args.update(ot3_firmware_build_args)
@@ -155,7 +155,7 @@ class ConcreteOT3ServiceBuilder(AbstractServiceBuilder):
             monorepo_build_args = get_build_args(
                 monorepo,
                 self._ot3.opentrons_hardware_source_location,
-                self._global_settings.get_repo_commit(monorepo),
+                self._global_settings.get_repo_branch(monorepo),
                 self._global_settings.get_repo_head(monorepo),
             )
             build_args.update(monorepo_build_args)

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_state_manager_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_state_manager_builder.py
@@ -119,8 +119,9 @@ class ConcreteOT3StateManagerBuilder(AbstractServiceBuilder):
 
     def generate_env_vars(self) -> Optional[IntermediateEnvironmentVariables]:
         """Generates value for environment parameter."""
-        return (
-            self._ot3.state_manager_env_vars
-            if self._ot3.state_manager_env_vars is not None
-            else None
-        )
+        env_vars: IntermediateEnvironmentVariables = {"OPENTRONS_PROJECT": "ot3"}
+
+        if self._ot3.state_manager_env_vars is not None:
+            env_vars.update(self._ot3.state_manager_env_vars)
+
+        return env_vars

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_state_manager_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_ot3_state_manager_builder.py
@@ -83,7 +83,7 @@ class ConcreteOT3StateManagerBuilder(AbstractServiceBuilder):
         ot3_firmware_build_args = get_build_args(
             ot3_firmware_repo,
             self._ot3.source_location,
-            self._global_settings.get_repo_commit(ot3_firmware_repo),
+            self._global_settings.get_repo_branch(ot3_firmware_repo),
             self._global_settings.get_repo_head(ot3_firmware_repo),
         )
         build_args.update(ot3_firmware_build_args)
@@ -91,7 +91,7 @@ class ConcreteOT3StateManagerBuilder(AbstractServiceBuilder):
         monorepo_build_args = get_build_args(
             monorepo,
             self._ot3.opentrons_hardware_source_location,
-            self._global_settings.get_repo_commit(monorepo),
+            self._global_settings.get_repo_branch(monorepo),
             self._global_settings.get_repo_head(monorepo),
         )
         build_args.update(monorepo_build_args)

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_smoothie_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_smoothie_service_builder.py
@@ -111,7 +111,7 @@ class ConcreteSmoothieServiceBuilder(AbstractServiceBuilder):
             build_args = get_build_args(
                 repo,
                 self._ot2.source_location,
-                self._global_settings.get_repo_commit(repo),
+                self._global_settings.get_repo_branch(repo),
                 self._global_settings.get_repo_head(repo),
             )
 

--- a/emulation_system/emulation_system/compose_file_creator/errors.py
+++ b/emulation_system/emulation_system/compose_file_creator/errors.py
@@ -51,6 +51,16 @@ class InvalidRemoteSourceError(Exception):
         )
 
 
+class CommitShaNotSupportedError(Exception):
+    """Exception thrown when user tries to specify a commit sha for their source-location."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Usage of a commit SHA as a reference for a source location "
+            "is deprecated. Use a branch name instead."
+        )
+
+
 class DuplicateHardwareNameError(Exception):
     """Exception thrown when there is hardware with duplicate names."""
 

--- a/emulation_system/emulation_system/compose_file_creator/utilities/shared_functions.py
+++ b/emulation_system/emulation_system/compose_file_creator/utilities/shared_functions.py
@@ -21,7 +21,7 @@ def get_build_args(
     value = (
         head
         if source_location == "latest"
-        else format_string.replace("{{commit-sha}}", source_location)
+        else format_string.replace("{{branch-name}}", source_location)
     )
     return {env_var_to_use: value}
 

--- a/emulation_system/emulation_system/opentrons_emulation_configuration.py
+++ b/emulation_system/emulation_system/opentrons_emulation_configuration.py
@@ -29,8 +29,8 @@ class Heads(BaseModel):
     modules: str
 
 
-class Commits(BaseModel):
-    """Format string for where to download a specific commit sha from."""
+class Branches(BaseModel):
+    """Format string for where to download a specific branch from."""
 
     opentrons: str
     ot3_firmware: str = Field(..., alias="ot3-firmware")
@@ -41,7 +41,7 @@ class SourceDownloadLocations(BaseModel):
     """Model representing where to download source code from."""
 
     heads: Heads
-    commits: Commits
+    branches: Branches
 
 
 class EmulationSettings(BaseModel):
@@ -71,20 +71,20 @@ class OpentronsEmulationConfiguration(BaseModel):
 
         return parse_obj_as(cls, json.load(file))
 
-    def get_repo_commit(self, repo: OpentronsRepository) -> str:
-        """Helper method to get repo commit string."""
+    def get_repo_branch(self, repo: OpentronsRepository) -> str:
+        """Helper method to get repo branch string."""
         lookup = {
-            OpentronsRepository.OPENTRONS: self.emulation_settings.source_download_locations.commits.opentrons,
-            OpentronsRepository.OT3_FIRMWARE: self.emulation_settings.source_download_locations.commits.ot3_firmware,
-            OpentronsRepository.OPENTRONS_MODULES: self.emulation_settings.source_download_locations.commits.modules,
+            OpentronsRepository.OPENTRONS: self.emulation_settings.source_download_locations.branches.opentrons,
+            OpentronsRepository.OT3_FIRMWARE: self.emulation_settings.source_download_locations.branches.ot3_firmware,
+            OpentronsRepository.OPENTRONS_MODULES: self.emulation_settings.source_download_locations.branches.modules,
         }
 
         try:
-            commit = lookup[repo]
+            branch = lookup[repo]
         except KeyError:
             raise RepoDoesNotExistError(repo.value)
 
-        return commit
+        return branch
 
     def get_repo_head(self, repo: OpentronsRepository) -> str:
         """Helper method to get repo head string."""

--- a/emulation_system/tests/command_creators/test_emulation_system.py
+++ b/emulation_system/tests/command_creators/test_emulation_system.py
@@ -34,7 +34,7 @@ EXPECTED_YAML = convert_yaml(
       derek-emulator-proxy:
         build:
           args:
-            OPENTRONS_SOURCE_DOWNLOAD_LOCATION: https://github.com/AnotherOrg/opentrons/archive/refs/heads/edge.zip
+            OPENTRONS_SOURCE_DOWNLOAD_LOCATION: https://github.com/AnotherOrg/opentrons.git#edge
           context: /home/derek-maggio/Documents/repos/opentrons-emulation/emulation_system/resources/docker/
           target: emulator-proxy-remote
           dockerfile: Dockerfile

--- a/emulation_system/tests/compose_file_creator/conversion_logic/conftest.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/conftest.py
@@ -46,7 +46,7 @@ SERVICE_NAMES = [
 ]
 
 EXTRA_MOUNT_PATH = "/var/log/log_files"
-FAKE_COMMIT_ID = "ca82a6dff817ec66f44342007202690a93763949"
+FAKE_BRANCH_NAME = "test-branch-name"
 
 
 @pytest.fixture
@@ -110,18 +110,18 @@ def ot3_firmware_head(testing_global_em_config: OpentronsEmulationConfiguration)
 
 
 @pytest.fixture
-def opentrons_commit(testing_global_em_config: OpentronsEmulationConfiguration) -> str:
-    """Return commit url of opentrons repo from test config file."""
-    return testing_global_em_config.get_repo_commit(
+def opentrons_branch(testing_global_em_config: OpentronsEmulationConfiguration) -> str:
+    """Return branch url of opentrons repo from test config file."""
+    return testing_global_em_config.get_repo_branch(
         OpentronsRepository.OPENTRONS
-    ).replace("{{commit-sha}}", FAKE_COMMIT_ID)
+    ).replace("{{branch-name}}", FAKE_BRANCH_NAME)
 
 
 @pytest.fixture
-def ot3_firmware_commit(
+def ot3_firmware_branch(
     testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> str:
-    """Return commit url of ot3-firmware repo from test config file."""
-    return testing_global_em_config.get_repo_commit(
+    """Return branch url of ot3-firmware repo from test config file."""
+    return testing_global_em_config.get_repo_branch(
         OpentronsRepository.OT3_FIRMWARE
-    ).replace("{{commit-sha}}", FAKE_COMMIT_ID)
+    ).replace("{{branch-name}}", FAKE_BRANCH_NAME)

--- a/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_can_server_service_builder.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_can_server_service_builder.py
@@ -17,7 +17,7 @@ from emulation_system.compose_file_creator.conversion import (
 from emulation_system.compose_file_creator.output.compose_file_model import ListOrDict
 from emulation_system.consts import DEV_DOCKERFILE_NAME, DOCKERFILE_NAME
 from tests.compose_file_creator.conversion_logic.conftest import (
-    FAKE_COMMIT_ID,
+    FAKE_BRANCH_NAME,
     build_args_are_none,
     get_source_code_build_args,
     partial_string_in_mount,
@@ -35,13 +35,13 @@ def remote_can_latest(ot3_only: Dict[str, Any]) -> SystemConfigurationModel:
 
 
 @pytest.fixture
-def remote_can_commit_id(ot3_only: Dict[str, Any]) -> SystemConfigurationModel:
+def remote_can_branch(ot3_only: Dict[str, Any]) -> SystemConfigurationModel:
     """Gets SystemConfigurationModel.
 
     can-server-source-type is set to remote.
     can-server-source-location is set a commit id.
     """
-    ot3_only["robot"]["can-server-source-location"] = FAKE_COMMIT_ID
+    ot3_only["robot"]["can-server-source-location"] = FAKE_BRANCH_NAME
     return parse_obj_as(SystemConfigurationModel, ot3_only)
 
 
@@ -63,8 +63,8 @@ def local_can(ot3_only: Dict[str, Any], opentrons_dir: str) -> SystemConfigurati
     [
         (lazy_fixture("remote_can_latest"), True),
         (lazy_fixture("remote_can_latest"), False),
-        (lazy_fixture("remote_can_commit_id"), True),
-        (lazy_fixture("remote_can_commit_id"), False),
+        (lazy_fixture("remote_can_branch"), True),
+        (lazy_fixture("remote_can_branch"), False),
         (lazy_fixture("local_can"), True),
         (lazy_fixture("local_can"), False),
     ],
@@ -108,7 +108,7 @@ def test_simple_can_server_values(
     "config, expected_url",
     [
         (lazy_fixture("remote_can_latest"), lazy_fixture("opentrons_head")),
-        (lazy_fixture("remote_can_commit_id"), lazy_fixture("opentrons_commit")),
+        (lazy_fixture("remote_can_branch"), lazy_fixture("opentrons_branch")),
     ],
 )
 def test_can_server_remote(

--- a/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_can_server_service_builder.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_can_server_service_builder.py
@@ -1,6 +1,6 @@
 """Tests to confirm that ConcreteCANServerServiceBuilder builds the CAN Server Service correctly."""
 
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 import pytest
 from pydantic import parse_obj_as
@@ -14,6 +14,7 @@ from emulation_system.compose_file_creator.config_file_settings import (
 from emulation_system.compose_file_creator.conversion import (
     ConcreteCANServerServiceBuilder,
 )
+from emulation_system.compose_file_creator.output.compose_file_model import ListOrDict
 from emulation_system.consts import DEV_DOCKERFILE_NAME, DOCKERFILE_NAME
 from tests.compose_file_creator.conversion_logic.conftest import (
     FAKE_COMMIT_ID,
@@ -94,7 +95,13 @@ def test_simple_can_server_values(
 
     assert service.command is None
     assert service.depends_on is None
-    assert service.environment is None
+
+    can_env = service.environment
+    assert can_env is not None
+    assert isinstance(can_env, ListOrDict)
+    env_root = cast(Dict[str, Any], can_env.__root__)
+    assert env_root is not None
+    assert env_root == {"OPENTRONS_PROJECT": "ot3"}
 
 
 @pytest.mark.parametrize(

--- a/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_ot3_service_builder.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_ot3_service_builder.py
@@ -22,7 +22,7 @@ from emulation_system.compose_file_creator.images import (
 )
 from emulation_system.consts import DEV_DOCKERFILE_NAME, DOCKERFILE_NAME
 from tests.compose_file_creator.conversion_logic.conftest import (
-    FAKE_COMMIT_ID,
+    FAKE_BRANCH_NAME,
     build_args_are_none,
     get_source_code_build_args,
     partial_string_in_mount,
@@ -44,16 +44,16 @@ def remote_source_latest(ot3_only: Dict[str, Any]) -> SystemConfigurationModel:
 
 
 @pytest.fixture
-def remote_source_commit_id(ot3_only: Dict[str, Any]) -> SystemConfigurationModel:
+def remote_source_branch(ot3_only: Dict[str, Any]) -> SystemConfigurationModel:
     """Gets SystemConfigurationModel.
 
     source-type is set to remote.
     source-location is set a commit id.
     """
     ot3_only["robot"]["source-type"] = "remote"
-    ot3_only["robot"]["source-location"] = FAKE_COMMIT_ID
+    ot3_only["robot"]["source-location"] = FAKE_BRANCH_NAME
     ot3_only["robot"]["opentrons-hardware-source-type"] = "remote"
-    ot3_only["robot"]["opentrons-hardware-source-location"] = FAKE_COMMIT_ID
+    ot3_only["robot"]["opentrons-hardware-source-location"] = FAKE_BRANCH_NAME
     return parse_obj_as(SystemConfigurationModel, ot3_only)
 
 
@@ -89,8 +89,8 @@ def get_ot3_service(service_list: List[Service], hardware: OT3Hardware) -> Servi
     [
         (lazy_fixture("remote_source_latest"), True),
         (lazy_fixture("remote_source_latest"), False),
-        (lazy_fixture("remote_source_commit_id"), True),
-        (lazy_fixture("remote_source_commit_id"), False),
+        (lazy_fixture("remote_source_branch"), True),
+        (lazy_fixture("remote_source_branch"), False),
         (lazy_fixture("local_source"), True),
         (lazy_fixture("local_source"), False),
     ],
@@ -128,8 +128,8 @@ def test_simple_ot3_values(
     [
         (lazy_fixture("remote_source_latest"), True),
         (lazy_fixture("remote_source_latest"), False),
-        (lazy_fixture("remote_source_commit_id"), True),
-        (lazy_fixture("remote_source_commit_id"), False),
+        (lazy_fixture("remote_source_branch"), True),
+        (lazy_fixture("remote_source_branch"), False),
         (lazy_fixture("local_source"), True),
         (lazy_fixture("local_source"), False),
     ],
@@ -167,7 +167,7 @@ def test_ot3_service_container_names_values(
     "config_model",
     [
         lazy_fixture("remote_source_latest"),
-        lazy_fixture("remote_source_commit_id"),
+        lazy_fixture("remote_source_branch"),
         lazy_fixture("local_source"),
     ],
 )
@@ -230,9 +230,9 @@ def test_ot3_service_environment_variables(
             lazy_fixture("opentrons_head"),
         ),
         (
-            lazy_fixture("remote_source_commit_id"),
-            lazy_fixture("ot3_firmware_commit"),
-            lazy_fixture("opentrons_commit"),
+            lazy_fixture("remote_source_branch"),
+            lazy_fixture("ot3_firmware_branch"),
+            lazy_fixture("opentrons_branch"),
         ),
     ],
 )

--- a/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_smoothie_service_builder.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_smoothie_service_builder.py
@@ -18,7 +18,7 @@ from emulation_system.compose_file_creator.conversion import (
 from emulation_system.compose_file_creator.output.compose_file_model import ListOrDict
 from emulation_system.consts import DEV_DOCKERFILE_NAME, DOCKERFILE_NAME
 from tests.compose_file_creator.conversion_logic.conftest import (
-    FAKE_COMMIT_ID,
+    FAKE_BRANCH_NAME,
     build_args_are_none,
     get_source_code_build_args,
     partial_string_in_mount,
@@ -38,14 +38,14 @@ def remote_source_latest(ot2_only: Dict[str, Any]) -> SystemConfigurationModel:
 
 
 @pytest.fixture
-def remote_source_commit_id(ot2_only: Dict[str, Any]) -> SystemConfigurationModel:
+def remote_source_branch(ot2_only: Dict[str, Any]) -> SystemConfigurationModel:
     """Gets SystemConfigurationModel.
 
     source-type is set to remote.
     source-location is set a commit id.
     """
     ot2_only["robot"]["source-type"] = "remote"
-    ot2_only["robot"]["source-location"] = FAKE_COMMIT_ID
+    ot2_only["robot"]["source-location"] = FAKE_BRANCH_NAME
     return parse_obj_as(SystemConfigurationModel, ot2_only)
 
 
@@ -69,8 +69,8 @@ def local_source(
     [
         (lazy_fixture("remote_source_latest"), True),
         (lazy_fixture("remote_source_latest"), False),
-        (lazy_fixture("remote_source_commit_id"), True),
-        (lazy_fixture("remote_source_commit_id"), False),
+        (lazy_fixture("remote_source_branch"), True),
+        (lazy_fixture("remote_source_branch"), False),
         (lazy_fixture("local_source"), True),
         (lazy_fixture("local_source"), False),
     ],
@@ -126,7 +126,7 @@ def test_simple_smoothie_values(
     "config, expected_url",
     [
         (lazy_fixture("remote_source_latest"), lazy_fixture("opentrons_head")),
-        (lazy_fixture("remote_source_commit_id"), lazy_fixture("opentrons_commit")),
+        (lazy_fixture("remote_source_branch"), lazy_fixture("opentrons_branch")),
     ],
 )
 def test_smoothie_remote(

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_pure_functions.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_pure_functions.py
@@ -15,71 +15,56 @@ from emulation_system.compose_file_creator.utilities.shared_functions import (
     [
         [
             OpentronsRepository.OPENTRONS,
-            "ca82a6dff817ec66f44342007202690a93763949",
-            "https://github.com/Opentrons/opentrons/archive/{{commit-sha}}.zip",
-            "https://github.com/Opentrons/opentrons/archive/refs/heads/edge.zip",
+            "my-branch",
+            "https://github.com/Opentrons/opentrons.git#{{branch-name}}",
+            "https://github.com/Opentrons/opentrons.git#edge",
             {
-                "OPENTRONS_SOURCE_DOWNLOAD_LOCATION": "https://github.com/"
-                "Opentrons/opentrons/archive/"
-                "ca82a6dff817ec66f44342"
-                "007202690a93763949.zip"
+                "OPENTRONS_SOURCE_DOWNLOAD_LOCATION": "https://github.com/Opentrons/opentrons.git#my-branch"
             },
         ],
         [
             OpentronsRepository.OPENTRONS_MODULES,
-            "ca82a6dff817ec66f44342007202690a93763949",
-            "https://github.com/Opentrons/opentrons-modules/archive/{{commit-sha}}.zip",
-            "https://github.com/Opentrons/opentrons/archive/refs/heads/edge.zip",
+            "my-branch",
+            "https://github.com/Opentrons/opentrons-modules.git#{{branch-name}}",
+            "https://github.com/Opentrons/opentrons.git#edge",
             {
-                "MODULE_SOURCE_DOWNLOAD_LOCATION": "https://github.com/Opentrons/"
-                "opentrons-modules/archive/"
-                "ca82a6dff817ec66f4434200720269"
-                "0a93763949.zip"
+                "MODULE_SOURCE_DOWNLOAD_LOCATION": "https://github.com/Opentrons/opentrons-modules.git#my-branch"
             },
         ],
         [
             OpentronsRepository.OT3_FIRMWARE,
-            "ca82a6dff817ec66f44342007202690a93763949",
-            "https://github.com/Opentrons/ot3-firmware/archive/{{commit-sha}}.zip",
-            "https://github.com/Opentrons/opentrons/archive/refs/heads/edge.zip",
+            "my-branch",
+            "https://github.com/Opentrons/ot3-firmware.git#{{branch-name}}",
+            "https://github.com/Opentrons/opentrons.git#edge",
             {
-                "FIRMWARE_SOURCE_DOWNLOAD_LOCATION": "https://github.com/"
-                "Opentrons/ot3-firmware/"
-                "archive/ca82a6dff817ec66f443"
-                "42007202690a93763949.zip"
+                "FIRMWARE_SOURCE_DOWNLOAD_LOCATION": "https://github.com/Opentrons/ot3-firmware.git#my-branch"
             },
         ],
         [
             OpentronsRepository.OPENTRONS,
             "latest",
-            "https://github.com/Opentrons/opentrons/archive/{{commit-sha}}.zip",
-            "https://github.com/Opentrons/opentrons/archive/refs/heads/edge.zip",
+            "https://github.com/Opentrons/opentrons.git#{{branch-name}}",
+            "https://github.com/Opentrons/opentrons.git#edge",
             {
-                "OPENTRONS_SOURCE_DOWNLOAD_LOCATION": "https://github.com/"
-                "Opentrons/opentrons/archive/"
-                "refs/heads/edge.zip"
+                "OPENTRONS_SOURCE_DOWNLOAD_LOCATION": "https://github.com/Opentrons/opentrons.git#edge"
             },
         ],
         [
             OpentronsRepository.OPENTRONS_MODULES,
             "latest",
-            "https://github.com/Opentrons/opentrons-modules/archive/{{commit-sha}}.zip",
-            "https://github.com/Opentrons/opentrons-modules/archive/refs/heads/edge.zip",
+            "https://github.com/Opentrons/opentrons-modules.git#{{branch-name}}",
+            "https://github.com/Opentrons/opentrons-modules.git#edge",
             {
-                "MODULE_SOURCE_DOWNLOAD_LOCATION": "https://github.com/Opentrons/"
-                "opentrons-modules/archive/refs/"
-                "heads/edge.zip"
+                "MODULE_SOURCE_DOWNLOAD_LOCATION": "https://github.com/Opentrons/opentrons-modules.git#edge"
             },
         ],
         [
             OpentronsRepository.OT3_FIRMWARE,
             "latest",
-            "https://github.com/Opentrons/ot3-firmware/archive/{{commit-sha}}.zip",
-            "https://github.com/Opentrons/ot3-firmware/archive/refs/heads/main.zip",
+            "https://github.com/Opentrons/ot3-firmware.git#{{branch-name}}",
+            "https://github.com/Opentrons/ot3-firmware.git#main",
             {
-                "FIRMWARE_SOURCE_DOWNLOAD_LOCATION": "https://github.com/Opentrons/"
-                "ot3-firmware/archive/refs/"
-                "heads/main.zip"
+                "FIRMWARE_SOURCE_DOWNLOAD_LOCATION": "https://github.com/Opentrons/ot3-firmware.git#main"
             },
         ],
     ],

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_source_code_insertion.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_source_code_insertion.py
@@ -17,7 +17,7 @@ from emulation_system.compose_file_creator.output.runtime_compose_file_model imp
     RuntimeComposeFileModel,
 )
 from tests.compose_file_creator.conversion_logic.conftest import (
-    FAKE_COMMIT_ID,
+    FAKE_BRANCH_NAME,
     build_args_are_none,
     get_source_code_build_args,
     partial_string_in_mount,
@@ -111,20 +111,20 @@ def ot3_remote_everything_latest(
 
 
 @pytest.fixture
-def ot3_remote_everything_commit_id(
+def ot3_remote_everything_branch(
     ot3_default: Dict[str, Any], robot_set_source_type_params: Callable
 ) -> RuntimeComposeFileModel:
     """Get OT3 configured for local source and local robot source."""
     return robot_set_source_type_params(
         robot_dict=ot3_default,
         source_type=SourceType.REMOTE,
-        source_location=FAKE_COMMIT_ID,
+        source_location=FAKE_BRANCH_NAME,
         robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location=FAKE_COMMIT_ID,
+        robot_server_source_location=FAKE_BRANCH_NAME,
         can_server_source_type=SourceType.REMOTE,
-        can_server_source_location=FAKE_COMMIT_ID,
+        can_server_source_location=FAKE_BRANCH_NAME,
         opentrons_hardware_source_type=SourceType.REMOTE,
-        opentrons_hardware_source_location=FAKE_COMMIT_ID,
+        opentrons_hardware_source_location=FAKE_BRANCH_NAME,
     )
 
 
@@ -228,16 +228,16 @@ def ot2_remote_everything_latest(
 
 
 @pytest.fixture
-def ot2_remote_everything_commit_id(
+def ot2_remote_everything_branch(
     ot2_default: Dict[str, Any], robot_set_source_type_params: Callable
 ) -> RuntimeComposeFileModel:
     """Get OT3 configured for local source and local robot source."""
     return robot_set_source_type_params(
         robot_dict=ot2_default,
         source_type=SourceType.REMOTE,
-        source_location=FAKE_COMMIT_ID,
+        source_location=FAKE_BRANCH_NAME,
         robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location=FAKE_COMMIT_ID,
+        robot_server_source_location=FAKE_BRANCH_NAME,
         can_server_source_type=None,
         can_server_source_location=None,
         opentrons_hardware_source_type=None,
@@ -439,7 +439,7 @@ def thermocycler_module_hardware_remote(
     "compose_file_model",
     [
         lazy_fixture("ot3_remote_everything_latest"),
-        lazy_fixture("ot3_remote_everything_commit_id"),
+        lazy_fixture("ot3_remote_everything_branch"),
     ],
 )
 def test_ot3_remote_everything_mounts(
@@ -502,18 +502,18 @@ def test_ot3_remote_everything_latest_build_args(
         assert emulator_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_head
 
 
-def test_ot3_remote_everything_commit_id_build_args(
-    ot3_remote_everything_commit_id: RuntimeComposeFileModel,
-    opentrons_commit: str,
-    ot3_firmware_commit: str,
+def test_ot3_remote_everything_branch_build_args(
+    ot3_remote_everything_branch: RuntimeComposeFileModel,
+    opentrons_branch: str,
+    ot3_firmware_branch: str,
 ) -> None:
     """Test build args when all source-types are remote commit id.
 
     Confirm that all build args are using the head of their individual repos.
     """
-    robot_server = ot3_remote_everything_commit_id.robot_server
-    can_server = ot3_remote_everything_commit_id.can_server
-    emulators = ot3_remote_everything_commit_id.ot3_emulators
+    robot_server = ot3_remote_everything_branch.robot_server
+    can_server = ot3_remote_everything_branch.can_server
+    emulators = ot3_remote_everything_branch.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -523,10 +523,10 @@ def test_ot3_remote_everything_commit_id_build_args(
     can_server_build_args = get_source_code_build_args(can_server)
 
     assert RepoToBuildArgMapping.OPENTRONS in robot_server_build_args
-    assert robot_server_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_commit
+    assert robot_server_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_branch
 
     assert RepoToBuildArgMapping.OPENTRONS in can_server_build_args
-    assert can_server_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_commit
+    assert can_server_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_branch
 
     for emulator in emulators:
         emulator_build_args = get_source_code_build_args(emulator)
@@ -534,10 +534,10 @@ def test_ot3_remote_everything_commit_id_build_args(
         assert RepoToBuildArgMapping.OT3_FIRMWARE in emulator_build_args
         assert (
             emulator_build_args[RepoToBuildArgMapping.OT3_FIRMWARE]
-            == ot3_firmware_commit
+            == ot3_firmware_branch
         )
         assert RepoToBuildArgMapping.OPENTRONS in emulator_build_args
-        assert emulator_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_commit
+        assert emulator_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_branch
 
 
 def test_ot3_local_source_mounts(ot3_local_source: RuntimeComposeFileModel) -> None:
@@ -809,7 +809,7 @@ def test_ot3_local_opentrons_hardware_mounts(
     "compose_file_model",
     [
         lazy_fixture("ot2_remote_everything_latest"),
-        lazy_fixture("ot2_remote_everything_commit_id"),
+        lazy_fixture("ot2_remote_everything_branch"),
     ],
 )
 def test_ot2_remote_everything_mounts(
@@ -850,26 +850,26 @@ def test_ot2_remote_everything_latest_build_args(
     assert smoothie_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_head
 
 
-def test_ot2_remote_everything_commit_id_build_args(
-    ot2_remote_everything_commit_id: RuntimeComposeFileModel, opentrons_commit: str
+def test_ot2_remote_everything_branch_build_args(
+    ot2_remote_everything_branch: RuntimeComposeFileModel, opentrons_branch: str
 ) -> None:
     """Test build arguments when all source-types are remote commit id.
 
     Confirm that smoothie and robot server are both looking for the opentrons repo head.
     """
-    robot_server = ot2_remote_everything_commit_id.robot_server
-    smoothie = ot2_remote_everything_commit_id.smoothie_emulator
+    robot_server = ot2_remote_everything_branch.robot_server
+    smoothie = ot2_remote_everything_branch.smoothie_emulator
 
     assert robot_server is not None
     assert smoothie is not None
 
     robot_server_build_args = get_source_code_build_args(robot_server)
     assert robot_server_build_args is not None
-    assert robot_server_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_commit
+    assert robot_server_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_branch
 
     smoothie_build_args = get_source_code_build_args(smoothie)
     assert smoothie_build_args is not None
-    assert smoothie_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_commit
+    assert smoothie_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_branch
 
 
 def test_ot2_local_robot_server_mounts(
@@ -1218,9 +1218,9 @@ def test_thermocycler_module_firmware_remote_mounts(
     "config",
     [
         lazy_fixture("ot3_remote_everything_latest"),
-        lazy_fixture("ot3_remote_everything_commit_id"),
+        lazy_fixture("ot3_remote_everything_branch"),
         lazy_fixture("ot2_remote_everything_latest"),
-        lazy_fixture("ot2_remote_everything_commit_id"),
+        lazy_fixture("ot2_remote_everything_branch"),
     ],
 )
 def test_is_remote(config: RuntimeComposeFileModel) -> None:

--- a/emulation_system/tests/compose_file_creator/input/hardware_models/test_hardware_model.py
+++ b/emulation_system/tests/compose_file_creator/input/hardware_models/test_hardware_model.py
@@ -230,12 +230,14 @@ def test_getting_image(
 
 def test_get_image_name_from_hardware_model() -> None:
     """Test that get_image_name_from_hardware_model returns correct value."""
-    model = HeaterShakerModuleInputModel(
-        id="my-heater-shaker",
-        hardware=Hardware.HEATER_SHAKER_MODULE,
-        source_type=SourceType.REMOTE,
-        source_location="latest",
-        emulation_level=EmulationLevels.HARDWARE,
+    model = HeaterShakerModuleInputModel.parse_obj(
+        {
+            "id": "my-heater-shaker",
+            "hardware": Hardware.HEATER_SHAKER_MODULE,
+            "source-type": SourceType.REMOTE,
+            "source-location": "latest",
+            "emulation-level": EmulationLevels.HARDWARE,
+        }
     )
     assert model.get_image_name() == "heater-shaker-hardware-remote"
 

--- a/emulation_system/tests/compose_file_creator/input/hardware_models/test_hardware_model.py
+++ b/emulation_system/tests/compose_file_creator/input/hardware_models/test_hardware_model.py
@@ -14,7 +14,7 @@ from emulation_system.compose_file_creator.config_file_settings import (
     Mount,
     SourceType,
 )
-from emulation_system.compose_file_creator.errors import InvalidRemoteSourceError
+from emulation_system.compose_file_creator.errors import CommitShaNotSupportedError
 from emulation_system.compose_file_creator.images import (
     ImageNotDefinedError,
     get_image_name,
@@ -368,13 +368,13 @@ def test_exception_thrown_when_local_source_code_does_not_exist() -> None:
 
 
 @pytest.mark.parametrize(
-    "invalid_location", ["/a/file/path.txt", "notavalidsha", "", "{something}"]
+    "invalid_location", ["f50cd8bfe2b661ecf928cdb044b33e7d10c294a8"]
 )
 def test_exception_thrown_when_invalid_remote_source_location(
     invalid_location: str,
 ) -> None:
     """Confirm LocalSourceDoesNotExistError is thrown when local path does not exist."""
-    with pytest.raises(InvalidRemoteSourceError):
+    with pytest.raises(CommitShaNotSupportedError):
         HeaterShakerModuleInputModel.parse_obj(
             {
                 "id": "my-heater-shaker",
@@ -390,8 +390,7 @@ def test_exception_thrown_when_invalid_remote_source_location(
 @pytest.mark.parametrize(
     "valid_location",
     [
-        "ca82a6dff817ec66f44342007202690a93763949",
-        "CA82A6DFF817EC66F44342007202690A93763949",
+        "branch-name",
         "latest",
         "Latest",
         "LATEST",

--- a/emulation_system/tests/compose_file_creator/utilities/test_substitute_yaml_values.py
+++ b/emulation_system/tests/compose_file_creator/utilities/test_substitute_yaml_values.py
@@ -9,7 +9,7 @@ from emulation_system.compose_file_creator.utilities.substitute_yaml_values impo
 )
 
 SUB_LIST = [
-    Substitution("otie", "source-location", "48038c4d189536a0862a2c20ed832dc34bd1c8b2"),
+    Substitution("otie", "source-location", "branch-name"),
     Substitution("otie", "exposed-port", "5000"),
 ]
 
@@ -44,8 +44,5 @@ def test_yaml_substitution(remote_only_ot3: str) -> None:
         remote_only_ot3, SUB_LIST
     ).perform_substitution()
     assert resultant_config_model.robot is not None
-    assert (
-        resultant_config_model.robot.source_location
-        == "48038c4d189536a0862a2c20ed832dc34bd1c8b2"
-    )
+    assert resultant_config_model.robot.source_location == "branch-name"
     assert resultant_config_model.robot.exposed_port == 5000

--- a/emulation_system/tests/test_configuration.json
+++ b/emulation_system/tests/test_configuration.json
@@ -2,14 +2,14 @@
     "emulation-settings": {
         "source-download-locations": {
             "heads": {
-                "opentrons": "https://github.com/AnotherOrg/opentrons/archive/refs/heads/edge.zip",
-                "ot3-firmware": "https://github.com/AnotherOrg/ot3-firmware/archive/refs/heads/main.zip",
-                "modules": "https://github.com/AnotherOrg/opentrons-modules/archive/refs/heads/edge.zip"
+                "opentrons": "https://github.com/AnotherOrg/opentrons.git#edge",
+                "ot3-firmware": "https://github.com/AnotherOrg/ot3-firmware.git#main",
+                "modules": "https://github.com/AnotherOrg/opentrons-modules.git#edge"
             },
-            "commits": {
-                "opentrons": "https://github.com/AnotherOrg/opentrons/archive/{{commit-sha}}.zip",
-                "ot3-firmware": "https://github.com/AnotherOrg/ot3-firmware/archive/{{commit-sha}}.zip",
-                "modules": "https://github.com/AnotherOrg/opentrons-modules/archive/{{commit-sha}}.zip"
+            "branches": {
+                "opentrons": "https://github.com/AnotherOrg/opentrons.git#{{branch-name}}",
+                "ot3-firmware": "https://github.com/AnotherOrg/ot3-firmware.git#{{branch-name}}",
+                "modules": "https://github.com/AnotherOrg/opentrons-modules.git#{{branch-name}}"
             }
         }
     }


### PR DESCRIPTION
# Overview

Add .git folder to deal with new versioning.
Add OPENTRONS_PROJECT when building the monorepo for the OT-3

# Changelog

- Use upstream dockerfile front end syntax to gain usage of `--keep-git-dir` option for `ADD` command
- Utilize `--keep-git-dir=true` for all pulls from Github
- Add `OPENTRONS_PROJECT=ot3` to all instances of building the monorepo for OT-3
- Update tests


# Risk assessment
Medium, but soon to be a non-issue

Kinda not a fan of using the upstream Dockerfile syntax because breaking changes might be pushed to it. But this is the only way to maintain the cache. BUT this will not be an issue when https://github.com/Opentrons/opentrons-emulation/pull/230 is finished because adding the source code will be the last step in the Dockerfile and all building of source will be done at runtime of the containers. 
