### PR TITLE
Local dev refactor

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,9 +7,6 @@
 # entrypoint.sh should also be bind-mounted in so do not copy it in either
 # Make sure to include the OPENTRONS_HARDWARE env variable
 
-FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as local-ot3-firmware-builder
-COPY entrypoints/local_ot3_firmware_builder.sh /build.sh
-
 ############################
 # Hardware Local Emulators #
 ############################
@@ -118,8 +115,8 @@ ENV OPENTRONS_HARDWARE "can-server"
 #######################
 
 FROM ghcr.io/opentrons/cpp-base-${TARGETARCH}:latest as ot3-firmware-source
-ARG FIRMWARE_SOURCE_DOWNLOAD_LOCATION
-ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION
+ARG FIRMWARE_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/ot3-firmware/archive/refs/heads/main.zip"
+ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons/archive/refs/heads/edge.zip"
 
 ADD $FIRMWARE_SOURCE_DOWNLOAD_LOCATION /ot3-firmware.zip
 ADD $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons.zip
@@ -132,6 +129,10 @@ RUN (cd / &&  \
     unzip -q opentrons.zip && \
     rm -f opentrons.zip && \
     mv opentrons* opentrons)
+
+
+FROM ot3-firmware-source as local-ot3-firmware-builder
+COPY entrypoints/local_ot3_firmware_builder.sh /build.sh
 
 ##################
 # modules-source #

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,22 +7,14 @@
 # entrypoint.sh should also be bind-mounted in so do not copy it in either
 # Make sure to include the OPENTRONS_HARDWARE env variable
 
-FROM ghcr.io/opentrons/cpp-base-${TARGETARCH}:latest as cpp-base-with-rebuild-script
-COPY rebuild.sh /rebuild.sh
-ENTRYPOINT ["/rebuild.sh"]
-
-FROM ghcr.io/opentrons/python-base:latest as python-base-with-rebuild-script
-COPY rebuild.sh /rebuild.sh
-ENTRYPOINT ["/rebuild.sh"]
-
 ############################
 # Hardware Local Emulators #
 ############################
 
-FROM cpp-base-with-rebuild-script as heater-shaker-hardware-local
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as heater-shaker-hardware-local
 ENV OPENTRONS_HARDWARE "heater-shaker-hardware"
 
-FROM cpp-base-with-rebuild-script as thermocycler-hardware-local
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as thermocycler-hardware-local
 ENV OPENTRONS_HARDWARE "thermocycler-hardware"
 
 # Do not use common-ot3-firmware as value for OPENTRONS_HARDWARE
@@ -32,50 +24,50 @@ ENV OPENTRONS_HARDWARE "thermocycler-hardware"
 # Instead specify the individual piece of firware as the hardware. This will cause only the container to only build
 # and move firmware for itself. Eliminating the issue of them clobbering each other
 
-FROM cpp-base-with-rebuild-script as ot3-pipettes-hardware-local
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-pipettes-hardware-local
 ENV OPENTRONS_HARDWARE "ot3-pipettes-hardware"
 
-FROM cpp-base-with-rebuild-script as ot3-head-hardware-local
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-head-hardware-local
 ENV OPENTRONS_HARDWARE "ot3-head-hardware"
 
-FROM cpp-base-with-rebuild-script as ot3-gantry-x-hardware-local
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-gantry-x-hardware-local
 ENV OPENTRONS_HARDWARE "ot3-gantry-x-hardware"
 
-FROM cpp-base-with-rebuild-script as ot3-gantry-y-hardware-local
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-gantry-y-hardware-local
 ENV OPENTRONS_HARDWARE "ot3-gantry-y-hardware"
 
-FROM cpp-base-with-rebuild-script as ot3-bootloader-hardware-local
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-bootloader-hardware-local
 ENV OPENTRONS_HARDWARE "ot3-bootloader-hardware"
 
-FROM cpp-base-with-rebuild-script as ot3-gripper-hardware-local
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-gripper-hardware-local
 ENV OPENTRONS_HARDWARE "ot3-gripper-hardware"
 
 ############################
 # Firmware Local Emulators #
 ############################
 
-FROM python-base-with-rebuild-script as thermocycler-firmware-local
+FROM ghcr.io/opentrons/python-base:latest as thermocycler-firmware-local
 ENV OPENTRONS_HARDWARE "thermocycler-firmware"
 
-FROM python-base-with-rebuild-script as heater-shaker-firmware-local
+FROM ghcr.io/opentrons/python-base:latest as heater-shaker-firmware-local
 ENV OPENTRONS_HARDWARE "heatershaker-firmware"
 
-FROM python-base-with-rebuild-script as magdeck-firmware-local
+FROM ghcr.io/opentrons/python-base:latest as magdeck-firmware-local
 ENV OPENTRONS_HARDWARE "magdeck-firmware"
 
-FROM python-base-with-rebuild-script as tempdeck-firmware-local
+FROM ghcr.io/opentrons/python-base:latest as tempdeck-firmware-local
 ENV OPENTRONS_HARDWARE "tempdeck-firmware"
 
-FROM python-base-with-rebuild-script as emulator-proxy-local
+FROM ghcr.io/opentrons/python-base:latest as emulator-proxy-local
 ENV OPENTRONS_HARDWARE "emulator-proxy"
 
-FROM python-base-with-rebuild-script as robot-server-local
+FROM ghcr.io/opentrons/python-base:latest as robot-server-local
 ENV OPENTRONS_HARDWARE "robot-server"
 
-FROM python-base-with-rebuild-script as smoothie-local
+FROM ghcr.io/opentrons/python-base:latest as smoothie-local
 ENV OPENTRONS_HARDWARE "smoothie"
 
-FROM python-base-with-rebuild-script as can-server-local
+FROM ghcr.io/opentrons/python-base:latest as can-server-local
 ENV OPENTRONS_HARDWARE "can-server"
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,9 @@
 # entrypoint.sh should also be bind-mounted in so do not copy it in either
 # Make sure to include the OPENTRONS_HARDWARE env variable
 
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as local-ot3-firmware-builder
+COPY entrypoints/local_ot3_firmware_builder.sh /build.sh
+
 ############################
 # Hardware Local Emulators #
 ############################

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,8 +8,8 @@ fi
 
 COMMAND=$1
 
-if [ "$COMMAND" != "build" ] && [ "$COMMAND" != "run" ] && [ "$COMMAND" != "stop" ]; then
-  echo "Valid commands are \"build\", \"run\", and \"stop\""
+if [ "$COMMAND" != "build" ] && [ "$COMMAND" != "run" ]; then
+  echo "Valid commands are \"build\" and \"run\""
   echo "You passed $COMMAND"
   echo "Usage: $(basename "${BASH_SOURCE[0]}") <command>"
   exit 1
@@ -33,15 +33,6 @@ build_ot3_firmware_single_simulator() {
     cmake --build ./build-host -j $(expr $(nproc) - 1) --target $1
     )
 }
-
-kill_process() {
-  if [[ "$COMMAND" != "stop" ]]; then
-    echo "Cannot run kill_process outside of the stop command."
-    exit 1
-  fi
-  pkill -9 -f ${1:?error, must pass parameter to kill_process}
-}
-
 # OPENTRONS_HARDWARE is an env variable that is passed to every container
 
 FULL_COMMAND="$COMMAND"-"$OPENTRONS_HARDWARE"
@@ -137,10 +128,6 @@ case $FULL_COMMAND in
     )
     ;;
 
-  stop-ot3-gantry-y-hardware|stop-heater-shaker-hardware|stop-thermocycler-hardware|stop-ot3-pipettes-hardware|stop-ot3-head-hardware|stop-ot3-gantry-x-hardware)
-    kill_process $OPENTRONS_HARDWARE
-    ;;
-
   # Firmware Level
 
   build-thermocycler-firmware|build-heater-shaker-firmware|build-magdeck-firmware|build-tempdeck-firmware|build-emulator-proxy|build-robot-server|build-common-firmware|build-smoothie|build-can-server)
@@ -176,22 +163,6 @@ case $FULL_COMMAND in
     ;;
   run-can-server)
     bash -c "monorepo_python -m opentrons_hardware.scripts.sim_socket_can"
-    ;;
-
-  stop-thermocycler-firmware|stop-tempdeck-firmware|stop-magdeck-firmware)
-    kill_process opentrons.hardware_control.emulation.scripts.run_module_emulator
-    ;;
-  stop-emulator-proxy)
-    kill_process opentrons.hardware_control.emulation.app
-    ;;
-  stop-robot-server)
-    kill_process /usr/local/bin/uvicorn
-    ;;
-  stop-smoothie)
-    kill_process opentrons.hardware_control.emulation.script
-    ;;
-  stop-can-server)
-    kill_process opentrons_hardware.script
     ;;
 
   *)

--- a/docker/entrypoints/local_ot3_firmware_builder.sh
+++ b/docker/entrypoints/local_ot3_firmware_builder.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+(
+  cd /ot3-firmware && \
+  cmake --preset host-gcc10 && \
+  cmake --build ./build-host -j $(expr $(nproc) - 1)
+)
+
+mkdir -p \
+  /volumes/pipettes_volume \
+  /volumes/head_volume \
+  /volumes/gantry_x_volume \
+  /volumes/gantry_y_volume \
+  /volumes/gantry_y_volume \
+  /volumes/bootloader_volume \
+  /volumes/gripper_volume
+
+cp /ot3-firmware/build-host/pipettes/simulator/pipettes-single-simulator /volumes/pipettes_volume/pipettes-simulator
+cp /ot3-firmware/build-host/head/simulator/head-simulator /volumes/head_volume/head-simulator
+cp /ot3-firmware/build-host/gantry/simulator/gantry-x-simulator /volumes/gantry_x_volume/gantry-x-simulator
+cp /ot3-firmware/build-host/gantry/simulator/gantry-y-simulator /volumes/gantry_y_volume/gantry-y-simulator
+cp /ot3-firmware/build-host/bootloader/simulator/bootloader-simulator /volumes/bootloader_volume/bootloader-simulator
+cp /ot3-firmware/build-host/gripper/simulator/gripper-simulator /volumes/gripper_volume/gripper-simulator

--- a/docker/rebuild.sh
+++ b/docker/rebuild.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-rm /.build_finished
-/entrypoint.sh build
-touch /.build_finished
-/entrypoint.sh run

--- a/emulation_system/emulation_system/compose_file_creator/config_file_settings.py
+++ b/emulation_system/emulation_system/compose_file_creator/config_file_settings.py
@@ -29,6 +29,25 @@ class OT3Hardware(str, Enum):
     BOOTLOADER = "ot3-bootloader"
     GRIPPER = "ot3-gripper"
 
+    def _remove_prefix(self) -> str:
+        return self.value.replace("ot3-", "")
+
+    def _to_volume_name(self) -> str:
+        switch_dashes_to_underscores = self._remove_prefix().replace("-", "_")
+        return f"{switch_dashes_to_underscores}_executable"
+
+    def _to_volume_path(self) -> str:
+        switch_dashes_to_underscores = self._remove_prefix().replace("-", "_")
+        return f"/volumes/{switch_dashes_to_underscores}/"
+
+    def to_simulator_name(self) -> str:
+        """Generates simulator name."""
+        return f"{self._remove_prefix()}-simulator."
+
+    def generate_executable_storage_volume_string(self) -> str:
+        """Generates volume string for local-ot3-firmware-builder."""
+        return f"{self._to_volume_name()}:{self._to_volume_path()}"
+
 
 class EmulationLevels(str, Enum):
     """The emulation level of the emulator."""

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/__init__.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/__init__.py
@@ -2,6 +2,9 @@
 from .concrete_can_server_service_builder import ConcreteCANServerServiceBuilder
 from .concrete_emulator_proxy_service_builder import ConcreteEmulatorProxyServiceBuilder
 from .concrete_input_service_builder import ConcreteInputServiceBuilder
+from .concrete_local_ot3_firmware_builder_builder import (
+    ConcreteLocalOT3FirmwareBuilderBuilder,
+)
 from .concrete_ot3_service_builder import ConcreteOT3ServiceBuilder
 from .concrete_ot3_state_manager_builder import ConcreteOT3StateManagerBuilder
 from .concrete_smoothie_service_builder import ConcreteSmoothieServiceBuilder
@@ -15,4 +18,5 @@ __all__ = [
     "ConcreteOT3ServiceBuilder",
     "ConcreteInputServiceBuilder",
     "ConcreteOT3StateManagerBuilder",
+    "ConcreteLocalOT3FirmwareBuilderBuilder",
 ]

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/service_builder_orchestrator.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/service_builder_orchestrator.py
@@ -18,6 +18,7 @@ from . import (
     ConcreteCANServerServiceBuilder,
     ConcreteEmulatorProxyServiceBuilder,
     ConcreteInputServiceBuilder,
+    ConcreteLocalOT3FirmwareBuilderBuilder,
     ConcreteOT3ServiceBuilder,
     ConcreteOT3StateManagerBuilder,
     ConcreteSmoothieServiceBuilder,
@@ -158,7 +159,11 @@ class ServiceBuilderOrchestrator:
             self._services[service.container_name] = service
 
     def __add_local_ot3_builder(self) -> None:
-        print("Local ot3-firmware builder required")
+        local_ot3_builder = ConcreteLocalOT3FirmwareBuilderBuilder(
+            self._config_model, self._global_settings, self._dev
+        ).build_service()
+        assert local_ot3_builder.container_name is not None
+        self._services[local_ot3_builder.container_name] = local_ot3_builder
 
     def __add_local_opentrons_modules_builder(self) -> None:
         print("Local opentrons-modules builder required")

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/service_builder_orchestrator.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/service_builder_orchestrator.py
@@ -157,6 +157,15 @@ class ServiceBuilderOrchestrator:
             assert service.container_name is not None
             self._services[service.container_name] = service
 
+    def __add_local_ot3_builder(self) -> None:
+        print("Local ot3-firmware builder required")
+
+    def __add_local_opentrons_modules_builder(self) -> None:
+        print("Local opentrons-modules builder required")
+
+    def __add_local_monorepo_builder(self) -> None:
+        print("Local monorepo builder required")
+
     def build_services(self) -> DockerServices:
         """Build services."""
         emulator_proxy_name = self.__add_emulator_proxy_service()
@@ -169,5 +178,13 @@ class ServiceBuilderOrchestrator:
         self.__add_input_services(
             emulator_proxy_name, smoothie_name, can_server_service_name
         )
+        if self._config_model.local_ot3_builder_required:
+            self.__add_local_ot3_builder()
+
+        if self._config_model.local_opentrons_modules_builder_required:
+            self.__add_local_opentrons_modules_builder()
+
+        if self._config_model.local_monorepo_builder_required:
+            self.__add_local_monorepo_builder()
 
         return DockerServices(self._services)

--- a/emulation_system/tests/compose_file_creator/conversion_logic/conftest.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/conftest.py
@@ -233,7 +233,6 @@ def ot3_remote_everything_commit_id(
 @pytest.fixture
 def ot3_local_source(
     ot3_default: Dict[str, Any],
-    opentrons_dir: str,
     ot3_firmware_dir: str,
     robot_set_source_type_params: Callable,
 ) -> Dict[str, Any]:
@@ -248,6 +247,26 @@ def ot3_local_source(
         can_server_source_location="latest",
         opentrons_hardware_source_type=SourceType.REMOTE,
         opentrons_hardware_source_location="latest",
+    )
+
+
+@pytest.fixture
+def ot3_remote_source_local_opentrons_hardware(
+    ot3_default: Dict[str, Any],
+    opentrons_dir: str,
+    robot_set_source_type_params: Callable,
+) -> Dict[str, Any]:
+    """Get OT3 configured for local source and local robot source."""
+    return robot_set_source_type_params(
+        robot_dict=ot3_default,
+        source_type=SourceType.REMOTE,
+        source_location="latest",
+        robot_server_source_type=SourceType.REMOTE,
+        robot_server_source_location="latest",
+        can_server_source_type=SourceType.REMOTE,
+        can_server_source_location="latest",
+        opentrons_hardware_source_type=SourceType.LOCAL,
+        opentrons_hardware_source_location=opentrons_dir,
     )
 
 
@@ -288,6 +307,27 @@ def ot3_local_robot(
         can_server_source_location="latest",
         opentrons_hardware_source_type=SourceType.REMOTE,
         opentrons_hardware_source_location="latest",
+    )
+
+
+@pytest.fixture
+def ot3_local_everything(
+    ot3_default: Dict[str, Any],
+    opentrons_dir: str,
+    ot3_firmware_dir: str,
+    robot_set_source_type_params: Callable,
+) -> Dict[str, Any]:
+    """Get OT3 configured for local source and local robot source."""
+    return robot_set_source_type_params(
+        robot_dict=ot3_default,
+        source_type=SourceType.LOCAL,
+        source_location=ot3_firmware_dir,
+        robot_server_source_type=SourceType.LOCAL,
+        robot_server_source_location=opentrons_dir,
+        can_server_source_type=SourceType.LOCAL,
+        can_server_source_location=opentrons_dir,
+        opentrons_hardware_source_type=SourceType.LOCAL,
+        opentrons_hardware_source_location=opentrons_dir,
     )
 
 

--- a/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_local_ot3_firmware_builder_builder.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_local_ot3_firmware_builder_builder.py
@@ -1,0 +1,118 @@
+"""Tests to confirm that local-ot3-firmware-builder container is created correctly."""
+
+from typing import Any, Dict
+
+import pytest
+from pydantic import parse_obj_as
+from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
+
+from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
+from emulation_system.compose_file_creator.config_file_settings import (
+    RepoToBuildArgMapping,
+)
+from emulation_system.compose_file_creator.conversion.service_builders import (
+    ConcreteLocalOT3FirmwareBuilderBuilder,
+)
+from tests.compose_file_creator.conversion_logic.conftest import (
+    build_args_are_none,
+    get_source_code_build_args,
+)
+
+
+@pytest.mark.parametrize(
+    "config_model",
+    [
+        lazy_fixture("ot3_local_source"),
+        lazy_fixture("ot3_remote_source_local_opentrons_hardware"),
+        lazy_fixture("ot3_local_everything"),
+    ],
+)
+def test_simple_values(
+    config_model: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
+    """Test values common to all 3 configs."""
+    model = parse_obj_as(SystemConfigurationModel, config_model)
+    service = ConcreteLocalOT3FirmwareBuilderBuilder(
+        model, testing_global_em_config, False
+    ).build_service()
+
+    assert service.image is not None
+    assert service.image == "local-ot3-firmware-builder"
+    assert service.container_name is not None
+    assert service.container_name == "local-ot3-firmware-builder"
+    assert service.tty
+    assert isinstance(service.networks, list)
+    assert len(service.networks) == 2
+    assert "local-network" in service.networks
+    assert "can-network" in service.networks
+    assert service.command is None
+    assert service.ports is None
+    assert service.environment is None
+
+
+def test_local_ot3_firmware_remote_monorepo(
+    ot3_local_source: Dict[str, Any],
+    opentrons_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
+    """Tests for when you are using local ot3-firmware and remote monorepo."""
+    model = parse_obj_as(SystemConfigurationModel, ot3_local_source)
+    service = ConcreteLocalOT3FirmwareBuilderBuilder(
+        model, testing_global_em_config, False
+    ).build_service()
+
+    monorepo_build_arg = RepoToBuildArgMapping.OPENTRONS
+    build_args = get_source_code_build_args(service)
+    assert len(build_args) == 1
+    assert monorepo_build_arg in build_args
+    assert build_args[monorepo_build_arg] == opentrons_head
+
+    volumes = service.volumes
+    assert volumes is not None
+
+    # TODO: Add volume checks when refactoring of local source is finished
+
+
+def test_remote_ot3_firmware_local_monorepo(
+    ot3_remote_source_local_opentrons_hardware: Dict[str, Any],
+    ot3_firmware_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
+    """Tests for when you are using remote ot3-firmware and local monorepo."""
+    model = parse_obj_as(
+        SystemConfigurationModel, ot3_remote_source_local_opentrons_hardware
+    )
+    service = ConcreteLocalOT3FirmwareBuilderBuilder(
+        model, testing_global_em_config, False
+    ).build_service()
+
+    ot3_firmware_build_arg = RepoToBuildArgMapping.OT3_FIRMWARE
+    build_args = get_source_code_build_args(service)
+    assert len(build_args) == 1
+    assert ot3_firmware_build_arg in build_args
+    assert build_args[ot3_firmware_build_arg] == ot3_firmware_head
+
+    volumes = service.volumes
+    assert volumes is not None
+
+    # TODO: Add volume checks when refactoring of local source is finished
+
+
+def test_local_everything(
+    ot3_local_everything: Dict[str, Any],
+    opentrons_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
+    """Tests for when you are using local ot3-firmware and local monorepo."""
+    model = parse_obj_as(SystemConfigurationModel, ot3_local_everything)
+    service = ConcreteLocalOT3FirmwareBuilderBuilder(
+        model, testing_global_em_config, False
+    ).build_service()
+
+    assert build_args_are_none(service)
+
+    volumes = service.volumes
+    assert volumes is not None
+
+    # TODO: Add volume checks when refactoring of local source is finished

--- a/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_ot3_service_builder.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_ot3_service_builder.py
@@ -22,7 +22,6 @@ from emulation_system.compose_file_creator.images import (
 )
 from emulation_system.consts import DEV_DOCKERFILE_NAME, DOCKERFILE_NAME
 from tests.compose_file_creator.conversion_logic.conftest import (
-    FAKE_COMMIT_ID,
     build_args_are_none,
     get_source_code_build_args,
     partial_string_in_mount,
@@ -30,48 +29,37 @@ from tests.compose_file_creator.conversion_logic.conftest import (
 
 
 @pytest.fixture
-def remote_source_latest(ot3_only: Dict[str, Any]) -> SystemConfigurationModel:
+def remote_source_latest(
+    ot3_remote_everything_latest: Dict[str, Any]
+) -> SystemConfigurationModel:
     """Gets SystemConfigurationModel.
 
     source-type is set to remote.
     source-location is set to latest.
     """
-    ot3_only["robot"]["source-type"] = "remote"
-    ot3_only["robot"]["source-location"] = "latest"
-    ot3_only["robot"]["opentrons-hardware-source-type"] = "remote"
-    ot3_only["robot"]["opentrons-hardware-source-location"] = "latest"
-    return parse_obj_as(SystemConfigurationModel, ot3_only)
+    return parse_obj_as(SystemConfigurationModel, ot3_remote_everything_latest)
 
 
 @pytest.fixture
-def remote_source_commit_id(ot3_only: Dict[str, Any]) -> SystemConfigurationModel:
+def remote_source_commit_id(
+    ot3_remote_everything_commit_id: Dict[str, Any]
+) -> SystemConfigurationModel:
     """Gets SystemConfigurationModel.
 
     source-type is set to remote.
     source-location is set a commit id.
     """
-    ot3_only["robot"]["source-type"] = "remote"
-    ot3_only["robot"]["source-location"] = FAKE_COMMIT_ID
-    ot3_only["robot"]["opentrons-hardware-source-type"] = "remote"
-    ot3_only["robot"]["opentrons-hardware-source-location"] = FAKE_COMMIT_ID
-    return parse_obj_as(SystemConfigurationModel, ot3_only)
+    return parse_obj_as(SystemConfigurationModel, ot3_remote_everything_commit_id)
 
 
 @pytest.fixture
-def local_source(
-    ot3_only: Dict[str, Any], ot3_firmware_dir: str, opentrons_dir: str
-) -> SystemConfigurationModel:
+def local_source(ot3_local_everything: Dict[str, Any]) -> SystemConfigurationModel:
     """Gets SystemConfigurationModel.
 
     source-type is set to local.
     source-location is set to a monorepo dir.
     """
-    ot3_only["robot"]["source-type"] = "local"
-    ot3_only["robot"]["source-location"] = ot3_firmware_dir
-    ot3_only["robot"]["opentrons-hardware-source-type"] = "local"
-    ot3_only["robot"]["opentrons-hardware-source-location"] = opentrons_dir
-
-    return parse_obj_as(SystemConfigurationModel, ot3_only)
+    return parse_obj_as(SystemConfigurationModel, ot3_local_everything)
 
 
 def get_ot3_service(service_list: List[Service], hardware: OT3Hardware) -> Service:

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_builder_creation_logic.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_builder_creation_logic.py
@@ -1,0 +1,131 @@
+"""Tests to confirm that builder creation logic is correct."""
+
+from typing import Any, Dict
+
+import pytest
+from pydantic import parse_obj_as
+from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
+
+from emulation_system.compose_file_creator.input.configuration_file import (
+    SystemConfigurationModel,
+)
+
+
+def test_local_ot3_builder_required(ot3_local_source: Dict[str, Any]) -> None:
+    """Test all configurations that require local-ot3-firmware-builder."""
+    config_model = parse_obj_as(SystemConfigurationModel, ot3_local_source)
+    assert config_model.local_ot3_builder_required
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        lazy_fixture("ot3_remote_everything_latest"),
+        lazy_fixture("ot3_remote_everything_commit_id"),
+        lazy_fixture("ot3_local_can"),
+        lazy_fixture("ot3_local_robot"),
+        lazy_fixture("ot3_local_opentrons_hardware"),
+        lazy_fixture("ot2_remote_everything_latest"),
+        lazy_fixture("ot2_remote_everything_commit_id"),
+        lazy_fixture("ot2_local_source"),
+        lazy_fixture("ot2_local_robot"),
+        lazy_fixture("heater_shaker_module_hardware_local"),
+        lazy_fixture("heater_shaker_module_hardware_remote"),
+        lazy_fixture("thermocycler_module_firmware_local"),
+        lazy_fixture("thermocycler_module_hardware_local"),
+        lazy_fixture("thermocycler_module_firmware_remote"),
+        lazy_fixture("thermocycler_module_hardware_remote"),
+        lazy_fixture("temperature_module_firmware_local"),
+        lazy_fixture("temperature_module_firmware_remote"),
+        lazy_fixture("magnetic_module_firmware_remote"),
+        lazy_fixture("magnetic_module_firmware_local"),
+    ],
+)
+def test_local_ot3_builder_not_required(config: Dict[str, Any]) -> None:
+    """Test all configurations that do not require local-ot3-firmware-builder."""
+    config_model = parse_obj_as(SystemConfigurationModel, config)
+    assert not config_model.local_ot3_builder_required
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        lazy_fixture("heater_shaker_module_hardware_local"),
+        lazy_fixture("thermocycler_module_hardware_local"),
+    ],
+)
+def test_local_opentrons_modules_builder_required(config: Dict[str, Any]) -> None:
+    """Test all configurations that require local-opentrons-modules-builder."""
+    config_model = parse_obj_as(SystemConfigurationModel, config)
+    assert config_model.local_opentrons_modules_builder_required
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        lazy_fixture("ot3_remote_everything_latest"),
+        lazy_fixture("ot3_remote_everything_commit_id"),
+        lazy_fixture("ot3_local_source"),
+        lazy_fixture("ot3_local_can"),
+        lazy_fixture("ot3_local_robot"),
+        lazy_fixture("ot3_local_opentrons_hardware"),
+        lazy_fixture("ot2_remote_everything_latest"),
+        lazy_fixture("ot2_remote_everything_commit_id"),
+        lazy_fixture("ot2_local_source"),
+        lazy_fixture("ot2_local_robot"),
+        lazy_fixture("heater_shaker_module_hardware_remote"),
+        lazy_fixture("thermocycler_module_firmware_local"),
+        lazy_fixture("thermocycler_module_firmware_remote"),
+        lazy_fixture("thermocycler_module_hardware_remote"),
+        lazy_fixture("temperature_module_firmware_local"),
+        lazy_fixture("temperature_module_firmware_remote"),
+        lazy_fixture("magnetic_module_firmware_remote"),
+        lazy_fixture("magnetic_module_firmware_local"),
+    ],
+)
+def test_local_opentrons_modules_builder_not_required(config: Dict[str, Any]) -> None:
+    """Test all configurations that do not require local-opentrons-modules-builder."""
+    config_model = parse_obj_as(SystemConfigurationModel, config)
+    assert not config_model.local_opentrons_modules_builder_required
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        lazy_fixture("ot3_local_can"),
+        lazy_fixture("ot3_local_robot"),
+        lazy_fixture("ot3_local_opentrons_hardware"),
+        lazy_fixture("ot2_local_source"),
+        lazy_fixture("ot2_local_robot"),
+        lazy_fixture("thermocycler_module_firmware_local"),
+        lazy_fixture("temperature_module_firmware_local"),
+        lazy_fixture("magnetic_module_firmware_local"),
+    ],
+)
+def test_local_monorepo_builder_required(config: Dict[str, Any]) -> None:
+    """Test all configurations that require local-monorepo-builder."""
+    config_model = parse_obj_as(SystemConfigurationModel, config)
+    assert config_model.local_monorepo_builder_required
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        lazy_fixture("ot3_remote_everything_latest"),
+        lazy_fixture("ot3_remote_everything_commit_id"),
+        lazy_fixture("ot3_local_source"),
+        lazy_fixture("ot2_remote_everything_latest"),
+        lazy_fixture("ot2_remote_everything_commit_id"),
+        lazy_fixture("heater_shaker_module_hardware_local"),
+        lazy_fixture("heater_shaker_module_hardware_remote"),
+        lazy_fixture("thermocycler_module_hardware_local"),
+        lazy_fixture("thermocycler_module_firmware_remote"),
+        lazy_fixture("thermocycler_module_hardware_remote"),
+        lazy_fixture("temperature_module_firmware_remote"),
+        lazy_fixture("magnetic_module_firmware_remote"),
+    ],
+)
+def test_local_monorepo_builder_not_required(config: Dict[str, Any]) -> None:
+    """Test all configurations that do not require local-monorepo-builder."""
+    config_model = parse_obj_as(SystemConfigurationModel, config)
+    assert not config_model.local_monorepo_builder_required

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_source_code_insertion.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_source_code_insertion.py
@@ -1,458 +1,42 @@
 """Test everything around inserting source code into containers."""
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Dict
 
 import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 
 from emulation_system import OpentronsEmulationConfiguration
 from emulation_system.compose_file_creator.config_file_settings import (
-    EmulationLevels,
     RepoToBuildArgMapping,
-    SourceType,
 )
 from emulation_system.compose_file_creator.conversion.conversion_functions import (
     convert_from_obj,
 )
-from emulation_system.compose_file_creator.output.runtime_compose_file_model import (
-    RuntimeComposeFileModel,
-)
 from tests.compose_file_creator.conversion_logic.conftest import (
-    FAKE_COMMIT_ID,
     build_args_are_none,
     get_source_code_build_args,
     partial_string_in_mount,
 )
 
 
-@pytest.fixture
-def robot_set_source_type_params(
-    testing_global_em_config: OpentronsEmulationConfiguration,
-) -> Callable:
-    """Create a runnable fixture that builds a RuntimeComposeFileModel."""
-
-    def robot_set_source_type_params(
-        robot_dict: Dict[str, Any],
-        source_type: SourceType,
-        source_location: str,
-        robot_server_source_type: SourceType,
-        robot_server_source_location: str,
-        can_server_source_type: Optional[SourceType],
-        can_server_source_location: Optional[str],
-        opentrons_hardware_source_type: Optional[SourceType],
-        opentrons_hardware_source_location: Optional[str],
-    ) -> RuntimeComposeFileModel:
-        robot_dict["source-type"] = source_type
-        robot_dict["source-location"] = source_location
-        robot_dict["robot-server-source-type"] = robot_server_source_type
-        robot_dict["robot-server-source-location"] = robot_server_source_location
-
-        if (
-            can_server_source_type is not None
-            and can_server_source_location is not None
-        ):
-            robot_dict["can-server-source-type"] = can_server_source_type
-            robot_dict["can-server-source-location"] = can_server_source_location
-
-        if (
-            opentrons_hardware_source_type is not None
-            and opentrons_hardware_source_location is not None
-        ):
-            robot_dict[
-                "opentrons-hardware-source-type"
-            ] = opentrons_hardware_source_type
-            robot_dict[
-                "opentrons-hardware-source-location"
-            ] = opentrons_hardware_source_location
-
-        return convert_from_obj({"robot": robot_dict}, testing_global_em_config, False)
-
-    return robot_set_source_type_params
-
-
-@pytest.fixture
-def module_set_source_type_params(
-    testing_global_em_config: OpentronsEmulationConfiguration,
-) -> Callable:
-    """Create a runnable fixture that builds a RuntimeComposeFileModel."""
-
-    def module_set_source_type_params(
-        module_dict: Dict[str, Any],
-        source_type: SourceType,
-        source_location: str,
-        emulation_level: EmulationLevels,
-    ) -> RuntimeComposeFileModel:
-        module_dict["source-type"] = source_type
-        module_dict["source-location"] = source_location
-        module_dict["emulation-level"] = emulation_level
-
-        return convert_from_obj(
-            {"modules": [module_dict]}, testing_global_em_config, False
-        )
-
-    return module_set_source_type_params
-
-
-@pytest.fixture
-def ot3_remote_everything_latest(
-    ot3_default: Dict[str, Any], robot_set_source_type_params: Callable
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot3_default,
-        source_type=SourceType.REMOTE,
-        source_location="latest",
-        robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location="latest",
-        can_server_source_type=SourceType.REMOTE,
-        can_server_source_location="latest",
-        opentrons_hardware_source_type=SourceType.REMOTE,
-        opentrons_hardware_source_location="latest",
-    )
-
-
-@pytest.fixture
-def ot3_remote_everything_commit_id(
-    ot3_default: Dict[str, Any], robot_set_source_type_params: Callable
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot3_default,
-        source_type=SourceType.REMOTE,
-        source_location=FAKE_COMMIT_ID,
-        robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location=FAKE_COMMIT_ID,
-        can_server_source_type=SourceType.REMOTE,
-        can_server_source_location=FAKE_COMMIT_ID,
-        opentrons_hardware_source_type=SourceType.REMOTE,
-        opentrons_hardware_source_location=FAKE_COMMIT_ID,
-    )
-
-
-@pytest.fixture
-def ot3_local_robot(
-    ot3_default: Dict[str, Any],
-    opentrons_dir: str,
-    robot_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot3_default,
-        source_type=SourceType.REMOTE,
-        source_location="latest",
-        robot_server_source_type=SourceType.LOCAL,
-        robot_server_source_location=opentrons_dir,
-        can_server_source_type=SourceType.REMOTE,
-        can_server_source_location="latest",
-        opentrons_hardware_source_type=SourceType.REMOTE,
-        opentrons_hardware_source_location="latest",
-    )
-
-
-@pytest.fixture
-def ot3_local_source(
-    ot3_default: Dict[str, Any],
-    opentrons_dir: str,
-    ot3_firmware_dir: str,
-    robot_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot3_default,
-        source_type=SourceType.LOCAL,
-        source_location=ot3_firmware_dir,
-        robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location="latest",
-        can_server_source_type=SourceType.REMOTE,
-        can_server_source_location="latest",
-        opentrons_hardware_source_type=SourceType.REMOTE,
-        opentrons_hardware_source_location="latest",
-    )
-
-
-@pytest.fixture
-def ot3_local_can(
-    ot3_default: Dict[str, Any],
-    opentrons_dir: str,
-    robot_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot3_default,
-        source_type=SourceType.REMOTE,
-        source_location="latest",
-        robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location="latest",
-        can_server_source_type=SourceType.LOCAL,
-        can_server_source_location=opentrons_dir,
-        opentrons_hardware_source_type=SourceType.REMOTE,
-        opentrons_hardware_source_location="latest",
-    )
-
-
-@pytest.fixture
-def ot3_local_opentrons_hardware(
-    ot3_default: Dict[str, Any],
-    opentrons_dir: str,
-    robot_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot3_default,
-        source_type=SourceType.REMOTE,
-        source_location="latest",
-        robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location="latest",
-        can_server_source_type=SourceType.REMOTE,
-        can_server_source_location="latest",
-        opentrons_hardware_source_type=SourceType.LOCAL,
-        opentrons_hardware_source_location=opentrons_dir,
-    )
-
-
-@pytest.fixture
-def ot2_remote_everything_latest(
-    ot2_default: Dict[str, Any], robot_set_source_type_params: Callable
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot2_default,
-        source_type=SourceType.REMOTE,
-        source_location="latest",
-        robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location="latest",
-        can_server_source_type=None,
-        can_server_source_location=None,
-        opentrons_hardware_source_type=None,
-        opentrons_hardware_source_location=None,
-    )
-
-
-@pytest.fixture
-def ot2_remote_everything_commit_id(
-    ot2_default: Dict[str, Any], robot_set_source_type_params: Callable
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot2_default,
-        source_type=SourceType.REMOTE,
-        source_location=FAKE_COMMIT_ID,
-        robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location=FAKE_COMMIT_ID,
-        can_server_source_type=None,
-        can_server_source_location=None,
-        opentrons_hardware_source_type=None,
-        opentrons_hardware_source_location=None,
-    )
-
-
-@pytest.fixture
-def ot2_local_source(
-    ot2_default: Dict[str, Any],
-    opentrons_dir: str,
-    robot_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot2_default,
-        source_type=SourceType.LOCAL,
-        source_location=opentrons_dir,
-        robot_server_source_type=SourceType.REMOTE,
-        robot_server_source_location="latest",
-        can_server_source_type=None,
-        can_server_source_location=None,
-        opentrons_hardware_source_type=None,
-        opentrons_hardware_source_location=None,
-    )
-
-
-@pytest.fixture
-def ot2_local_robot(
-    ot2_default: Dict[str, Any],
-    opentrons_dir: str,
-    robot_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get OT3 configured for local source and local robot source."""
-    return robot_set_source_type_params(
-        robot_dict=ot2_default,
-        source_type=SourceType.REMOTE,
-        source_location="latest",
-        robot_server_source_type=SourceType.LOCAL,
-        robot_server_source_location=opentrons_dir,
-        can_server_source_type=None,
-        can_server_source_location=None,
-        opentrons_hardware_source_type=None,
-        opentrons_hardware_source_location=None,
-    )
-
-
-@pytest.fixture
-def heater_shaker_module_hardware_local(
-    heater_shaker_module_default: Dict[str, Any],
-    opentrons_modules_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for local source."""
-    return module_set_source_type_params(
-        module_dict=heater_shaker_module_default,
-        source_type="local",
-        source_location=opentrons_modules_dir,
-        emulation_level="hardware",
-    )
-
-
-@pytest.fixture
-def temperature_module_firmware_local(
-    temperature_module_default: Dict[str, Any],
-    opentrons_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for local source."""
-    return module_set_source_type_params(
-        module_dict=temperature_module_default,
-        source_type="local",
-        source_location=opentrons_dir,
-        emulation_level="firmware",
-    )
-
-
-@pytest.fixture
-def magnetic_module_firmware_local(
-    magnetic_module_default: Dict[str, Any],
-    opentrons_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for local source."""
-    return module_set_source_type_params(
-        module_dict=magnetic_module_default,
-        source_type="local",
-        source_location=opentrons_dir,
-        emulation_level="firmware",
-    )
-
-
-@pytest.fixture
-def thermocycler_module_firmware_local(
-    thermocycler_module_default: Dict[str, Any],
-    opentrons_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for local source."""
-    return module_set_source_type_params(
-        module_dict=thermocycler_module_default,
-        source_type="local",
-        source_location=opentrons_dir,
-        emulation_level="firmware",
-    )
-
-
-@pytest.fixture
-def thermocycler_module_hardware_local(
-    thermocycler_module_default: Dict[str, Any],
-    opentrons_modules_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for local source."""
-    return module_set_source_type_params(
-        module_dict=thermocycler_module_default,
-        source_type="local",
-        source_location=opentrons_modules_dir,
-        emulation_level="hardware",
-    )
-
-
-@pytest.fixture
-def heater_shaker_module_hardware_remote(
-    heater_shaker_module_default: Dict[str, Any],
-    opentrons_modules_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for remote source."""
-    return module_set_source_type_params(
-        module_dict=heater_shaker_module_default,
-        source_type="remote",
-        source_location="latest",
-        emulation_level="hardware",
-    )
-
-
-@pytest.fixture
-def temperature_module_firmware_remote(
-    temperature_module_default: Dict[str, Any],
-    opentrons_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for remote source."""
-    return module_set_source_type_params(
-        module_dict=temperature_module_default,
-        source_type="remote",
-        source_location="latest",
-        emulation_level="firmware",
-    )
-
-
-@pytest.fixture
-def magnetic_module_firmware_remote(
-    magnetic_module_default: Dict[str, Any],
-    opentrons_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for remote source."""
-    return module_set_source_type_params(
-        module_dict=magnetic_module_default,
-        source_type="remote",
-        source_location="latest",
-        emulation_level="firmware",
-    )
-
-
-@pytest.fixture
-def thermocycler_module_firmware_remote(
-    thermocycler_module_default: Dict[str, Any],
-    opentrons_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for remote source."""
-    return module_set_source_type_params(
-        module_dict=thermocycler_module_default,
-        source_type="remote",
-        source_location="latest",
-        emulation_level="firmware",
-    )
-
-
-@pytest.fixture
-def thermocycler_module_hardware_remote(
-    thermocycler_module_default: Dict[str, Any],
-    opentrons_modules_dir: str,
-    module_set_source_type_params: Callable,
-) -> RuntimeComposeFileModel:
-    """Get Heater Shaker configuration for remote source."""
-    return module_set_source_type_params(
-        module_dict=thermocycler_module_default,
-        source_type="remote",
-        source_location="latest",
-        emulation_level="hardware",
-    )
-
-
 @pytest.mark.parametrize(
-    "compose_file_model",
+    "config_dict",
     [
         lazy_fixture("ot3_remote_everything_latest"),
         lazy_fixture("ot3_remote_everything_commit_id"),
     ],
 )
 def test_ot3_remote_everything_mounts(
-    compose_file_model: RuntimeComposeFileModel,
+    config_dict: Dict[str, Any],
     testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when all source-types are remote.
 
     Confirm that when all source-types are remote, nothing is mounted to any container.
     """
-    robot_server = compose_file_model.robot_server
-    can_server = compose_file_model.can_server
-    emulators = compose_file_model.ot3_emulators
+    config_file = convert_from_obj(config_dict, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -466,17 +50,21 @@ def test_ot3_remote_everything_mounts(
 
 
 def test_ot3_remote_everything_latest_build_args(
-    ot3_remote_everything_latest: RuntimeComposeFileModel,
+    ot3_remote_everything_latest: Dict[str, Any],
     opentrons_head: str,
     ot3_firmware_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build args when all source-types are remote latest.
 
     Confirm that all build args are using the head of their individual repos.
     """
-    robot_server = ot3_remote_everything_latest.robot_server
-    can_server = ot3_remote_everything_latest.can_server
-    emulators = ot3_remote_everything_latest.ot3_emulators
+    config_file = convert_from_obj(
+        ot3_remote_everything_latest, testing_global_em_config, False
+    )
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -503,17 +91,21 @@ def test_ot3_remote_everything_latest_build_args(
 
 
 def test_ot3_remote_everything_commit_id_build_args(
-    ot3_remote_everything_commit_id: RuntimeComposeFileModel,
+    ot3_remote_everything_commit_id: Dict[str, Any],
     opentrons_commit: str,
     ot3_firmware_commit: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build args when all source-types are remote commit id.
 
     Confirm that all build args are using the head of their individual repos.
     """
-    robot_server = ot3_remote_everything_commit_id.robot_server
-    can_server = ot3_remote_everything_commit_id.can_server
-    emulators = ot3_remote_everything_commit_id.ot3_emulators
+    config_file = convert_from_obj(
+        ot3_remote_everything_commit_id, testing_global_em_config, False
+    )
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -540,15 +132,19 @@ def test_ot3_remote_everything_commit_id_build_args(
         assert emulator_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_commit
 
 
-def test_ot3_local_source_mounts(ot3_local_source: RuntimeComposeFileModel) -> None:
+def test_ot3_local_source_mounts(
+    ot3_local_source: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
     """Test mounts when source-type is set to local.
 
     Confirm that ot3-firmware and entrypoint.sh is mounted to emulator containers.
     Confirm other containers have nothing mounted.
     """
-    robot_server = ot3_local_source.robot_server
-    can_server = ot3_local_source.can_server
-    emulators = ot3_local_source.ot3_emulators
+    config_file = convert_from_obj(ot3_local_source, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -572,18 +168,20 @@ def test_ot3_local_source_mounts(ot3_local_source: RuntimeComposeFileModel) -> N
 
 
 def test_ot3_local_source_build_args(
-    ot3_local_source: RuntimeComposeFileModel,
+    ot3_local_source: Dict[str, Any],
     opentrons_head: str,
     ot3_firmware_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build args when source-type is set to local.
 
     Confirm that robot-server and can-server have source build args.
     Emulators should not have source build args.
     """
-    robot_server = ot3_local_source.robot_server
-    can_server = ot3_local_source.can_server
-    emulators = ot3_local_source.ot3_emulators
+    config_file = convert_from_obj(ot3_local_source, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -606,15 +204,19 @@ def test_ot3_local_source_build_args(
         assert RepoToBuildArgMapping.OT3_FIRMWARE not in emulator_build_args
 
 
-def test_ot3_local_can_server_mounts(ot3_local_can: RuntimeComposeFileModel) -> None:
+def test_ot3_local_can_server_mounts(
+    ot3_local_can: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
     """Test mounts when can-server-source-type is set to local.
 
     Confirm that robot server and emulators have no mounts.
     Confirm that can-server has opentrons and entrypoint.sh mounted in.
     """
-    robot_server = ot3_local_can.robot_server
-    can_server = ot3_local_can.can_server
-    emulators = ot3_local_can.ot3_emulators
+    config_file = convert_from_obj(ot3_local_can, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -629,13 +231,16 @@ def test_ot3_local_can_server_mounts(ot3_local_can: RuntimeComposeFileModel) -> 
 
     assert len(can_server.volumes) == 3
 
-    assert ot3_local_can.ot3_emulators is not None
-    for emulator in ot3_local_can.ot3_emulators:
+    assert config_file.ot3_emulators is not None
+    for emulator in config_file.ot3_emulators:
         assert emulator.volumes is None
 
 
 def test_ot3_local_can_server_build_args(
-    ot3_local_can: RuntimeComposeFileModel, opentrons_head: str, ot3_firmware_head: str
+    ot3_local_can: Dict[str, Any],
+    opentrons_head: str,
+    ot3_firmware_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build arguments when can-server-source-type is set to local.
 
@@ -643,9 +248,10 @@ def test_ot3_local_can_server_build_args(
     Confirm that robot-server is looking for the opentrons repo head.
     Confirm that the emulators are looking for the ot3-firmware repo head.
     """
-    robot_server = ot3_local_can.robot_server
-    can_server = ot3_local_can.can_server
-    emulators = ot3_local_can.ot3_emulators
+    config_file = convert_from_obj(ot3_local_can, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -671,16 +277,18 @@ def test_ot3_local_can_server_build_args(
 
 
 def test_ot3_local_robot_server_mounts(
-    ot3_local_robot: RuntimeComposeFileModel,
+    ot3_local_robot: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when robot-server-source-type is set to local.
 
     Confirm that can server and emulators have no mounts.
     Confirm that robot server has opentrons and entrypoint.sh mounted in.
     """
-    robot_server = ot3_local_robot.robot_server
-    can_server = ot3_local_robot.can_server
-    emulators = ot3_local_robot.ot3_emulators
+    config_file = convert_from_obj(ot3_local_robot, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -695,15 +303,16 @@ def test_ot3_local_robot_server_mounts(
 
     assert can_server.volumes is None
 
-    assert ot3_local_robot.ot3_emulators is not None
-    for emulator in ot3_local_robot.ot3_emulators:
+    assert config_file.ot3_emulators is not None
+    for emulator in config_file.ot3_emulators:
         assert emulator.volumes is None
 
 
 def test_ot3_local_robot_server_build_args(
-    ot3_local_robot: RuntimeComposeFileModel,
+    ot3_local_robot: Dict[str, Any],
     opentrons_head: str,
     ot3_firmware_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build arguments when robot-server-source-type is set to local.
 
@@ -711,9 +320,10 @@ def test_ot3_local_robot_server_build_args(
     Confirm that can server is looking for the opentrons repo head.
     Confirm that the emulators are looking for the ot3-firmware repo head.
     """
-    robot_server = ot3_local_robot.robot_server
-    can_server = ot3_local_robot.can_server
-    emulators = ot3_local_robot.ot3_emulators
+    config_file = convert_from_obj(ot3_local_robot, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -738,9 +348,10 @@ def test_ot3_local_robot_server_build_args(
 
 
 def test_ot3_local_opentrons_hardware_build_args(
-    ot3_local_opentrons_hardware: RuntimeComposeFileModel,
+    ot3_local_opentrons_hardware: Dict[str, Any],
     opentrons_head: str,
     ot3_firmware_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build arguments when robot-server-source-type is set to local.
 
@@ -748,9 +359,12 @@ def test_ot3_local_opentrons_hardware_build_args(
     Confirm that can server is looking for the opentrons repo head.
     Confirm that the emulators are looking for the ot3-firmware repo head.
     """
-    robot_server = ot3_local_opentrons_hardware.robot_server
-    can_server = ot3_local_opentrons_hardware.can_server
-    emulators = ot3_local_opentrons_hardware.ot3_emulators
+    config_file = convert_from_obj(
+        ot3_local_opentrons_hardware, testing_global_em_config, False
+    )
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -776,16 +390,20 @@ def test_ot3_local_opentrons_hardware_build_args(
 
 
 def test_ot3_local_opentrons_hardware_mounts(
-    ot3_local_opentrons_hardware: RuntimeComposeFileModel,
+    ot3_local_opentrons_hardware: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when robot-server-source-type is set to local.
 
     Confirm that can server and emulators have no mounts.
     Confirm that robot server has opentrons and entrypoint.sh mounted in.
     """
-    robot_server = ot3_local_opentrons_hardware.robot_server
-    can_server = ot3_local_opentrons_hardware.can_server
-    emulators = ot3_local_opentrons_hardware.ot3_emulators
+    config_file = convert_from_obj(
+        ot3_local_opentrons_hardware, testing_global_em_config, False
+    )
+    robot_server = config_file.robot_server
+    can_server = config_file.can_server
+    emulators = config_file.ot3_emulators
 
     assert robot_server is not None
     assert can_server is not None
@@ -795,9 +413,9 @@ def test_ot3_local_opentrons_hardware_mounts(
 
     assert can_server.volumes is None
 
-    assert ot3_local_opentrons_hardware.ot3_emulators is not None
+    assert config_file.ot3_emulators is not None
 
-    for emulator in ot3_local_opentrons_hardware.ot3_emulators:
+    for emulator in config_file.ot3_emulators:
         assert emulator.volumes is not None
         assert len(emulator.volumes) == 3
         assert partial_string_in_mount("opentrons:/opentrons", emulator.volumes)
@@ -806,21 +424,23 @@ def test_ot3_local_opentrons_hardware_mounts(
 
 
 @pytest.mark.parametrize(
-    "compose_file_model",
+    "config_dict",
     [
         lazy_fixture("ot2_remote_everything_latest"),
         lazy_fixture("ot2_remote_everything_commit_id"),
     ],
 )
 def test_ot2_remote_everything_mounts(
-    compose_file_model: RuntimeComposeFileModel,
+    config_dict: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when all source-types are remote.
 
     Confirm that smoothie and robot server have no mounts.
     """
-    robot_server = compose_file_model.robot_server
-    smoothie = compose_file_model.smoothie_emulator
+    config_file = convert_from_obj(config_dict, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    smoothie = config_file.smoothie_emulator
 
     assert robot_server is not None
     assert smoothie is not None
@@ -830,14 +450,19 @@ def test_ot2_remote_everything_mounts(
 
 
 def test_ot2_remote_everything_latest_build_args(
-    ot2_remote_everything_latest: RuntimeComposeFileModel, opentrons_head: str
+    ot2_remote_everything_latest: Dict[str, Any],
+    opentrons_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build arguments when all source-types are remote latest.
 
     Confirm that smoothie and robot server are both looking for the opentrons repo head.
     """
-    robot_server = ot2_remote_everything_latest.robot_server
-    smoothie = ot2_remote_everything_latest.smoothie_emulator
+    config_file = convert_from_obj(
+        ot2_remote_everything_latest, testing_global_em_config, False
+    )
+    robot_server = config_file.robot_server
+    smoothie = config_file.smoothie_emulator
 
     assert robot_server is not None
     assert smoothie is not None
@@ -851,14 +476,19 @@ def test_ot2_remote_everything_latest_build_args(
 
 
 def test_ot2_remote_everything_commit_id_build_args(
-    ot2_remote_everything_commit_id: RuntimeComposeFileModel, opentrons_commit: str
+    ot2_remote_everything_commit_id: Dict[str, Any],
+    opentrons_commit: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build arguments when all source-types are remote commit id.
 
     Confirm that smoothie and robot server are both looking for the opentrons repo head.
     """
-    robot_server = ot2_remote_everything_commit_id.robot_server
-    smoothie = ot2_remote_everything_commit_id.smoothie_emulator
+    config_file = convert_from_obj(
+        ot2_remote_everything_commit_id, testing_global_em_config, False
+    )
+    robot_server = config_file.robot_server
+    smoothie = config_file.smoothie_emulator
 
     assert robot_server is not None
     assert smoothie is not None
@@ -872,58 +502,18 @@ def test_ot2_remote_everything_commit_id_build_args(
     assert smoothie_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_commit
 
 
-def test_ot2_local_robot_server_mounts(
-    ot2_local_robot: RuntimeComposeFileModel,
+def test_ot2_local_source_mounts(
+    ot2_local_source: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
-    """Test mounts when robot-server-source-type is set to local.
-
-    Confirm that robot server has opentrons and entrypoint.sh mounted to it.
-    Confirm that smoothie has nothing mounted to it.
-    """
-    robot_server = ot2_local_robot.robot_server
-    smoothie = ot2_local_robot.smoothie_emulator
-
-    assert robot_server is not None
-    assert smoothie is not None
-
-    assert robot_server.volumes is not None
-    assert partial_string_in_mount("opentrons:/opentrons", robot_server.volumes)
-    assert partial_string_in_mount("entrypoint.sh:/entrypoint.sh", robot_server.volumes)
-    assert partial_string_in_mount("opentrons-python-dist:/dist", robot_server.volumes)
-    assert len(robot_server.volumes) == 3
-
-    assert smoothie.volumes is None
-
-
-def test_ot2_local_robot_server_build_args(
-    ot2_local_robot: RuntimeComposeFileModel, opentrons_head: str
-) -> None:
-    """Test build-args when robot-server-source-type is set to local.
-
-    Confirm that robot server has no build arguments
-    Confirm that smoothie is looking for the opentrons repo head.
-    """
-    robot_server = ot2_local_robot.robot_server
-    smoothie = ot2_local_robot.smoothie_emulator
-
-    assert robot_server is not None
-    assert smoothie is not None
-
-    assert build_args_are_none(robot_server)
-
-    smoothie_build_args = get_source_code_build_args(smoothie)
-    assert smoothie_build_args is not None
-    assert smoothie_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_head
-
-
-def test_ot2_local_source_mounts(ot2_local_source: RuntimeComposeFileModel) -> None:
     """Test mounts when source-type is set to local.
 
     Confirm that robot server has nothing mounted to it.
     Confirm that smoothie has opentrons and entrypoint.sh mounted to it.
     """
-    robot_server = ot2_local_source.robot_server
-    smoothie = ot2_local_source.smoothie_emulator
+    config_file = convert_from_obj(ot2_local_source, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    smoothie = config_file.smoothie_emulator
 
     assert robot_server is not None
     assert smoothie is not None
@@ -939,15 +529,18 @@ def test_ot2_local_source_mounts(ot2_local_source: RuntimeComposeFileModel) -> N
 
 
 def test_ot2_local_source_build_args(
-    ot2_local_source: RuntimeComposeFileModel, opentrons_head: str
+    ot2_local_source: Dict[str, Any],
+    opentrons_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test build arguments when source-type is set to local.
 
     Confirm that robot server is looking for the opentrons repo head.
     Confirm that smoothie has no build arguments.
     """
-    robot_server = ot2_local_source.robot_server
-    smoothie = ot2_local_source.smoothie_emulator
+    config_file = convert_from_obj(ot2_local_source, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    smoothie = config_file.smoothie_emulator
 
     assert robot_server is not None
     assert smoothie is not None
@@ -962,8 +555,58 @@ def test_ot2_local_source_build_args(
     assert build_args_are_none(smoothie)
 
 
+def test_ot2_local_robot_server_mounts(
+    ot2_local_robot: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
+    """Test mounts when robot-server-source-type is set to local.
+
+    Confirm that robot server has opentrons and entrypoint.sh mounted to it.
+    Confirm that smoothie has nothing mounted to it.
+    """
+    config_file = convert_from_obj(ot2_local_robot, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    smoothie = config_file.smoothie_emulator
+
+    assert robot_server is not None
+    assert smoothie is not None
+
+    assert robot_server.volumes is not None
+    assert partial_string_in_mount("opentrons:/opentrons", robot_server.volumes)
+    assert partial_string_in_mount("entrypoint.sh:/entrypoint.sh", robot_server.volumes)
+    assert partial_string_in_mount("opentrons-python-dist:/dist", robot_server.volumes)
+    assert len(robot_server.volumes) == 3
+
+    assert smoothie.volumes is None
+
+
+def test_ot2_local_robot_server_build_args(
+    ot2_local_robot: Dict[str, Any],
+    opentrons_head: str,
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
+    """Test build-args when robot-server-source-type is set to local.
+
+    Confirm that robot server has no build arguments
+    Confirm that smoothie is looking for the opentrons repo head.
+    """
+    config_file = convert_from_obj(ot2_local_robot, testing_global_em_config, False)
+    robot_server = config_file.robot_server
+    smoothie = config_file.smoothie_emulator
+
+    assert robot_server is not None
+    assert smoothie is not None
+
+    assert build_args_are_none(robot_server)
+
+    smoothie_build_args = get_source_code_build_args(smoothie)
+    assert smoothie_build_args is not None
+    assert smoothie_build_args[RepoToBuildArgMapping.OPENTRONS] == opentrons_head
+
+
 def test_heater_shaker_hardware_local_mounts(
-    heater_shaker_module_hardware_local: RuntimeComposeFileModel,
+    heater_shaker_module_hardware_local: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to local.
 
@@ -971,7 +614,10 @@ def test_heater_shaker_hardware_local_mounts(
     Also confirm that named volumes: opentrons-modules-build-stm32-host and
     opentrons-modules-stm32-tools exist and are bound to the correct location.
     """
-    heater_shakers = heater_shaker_module_hardware_local.heater_shaker_module_emulators
+    config_file = convert_from_obj(
+        heater_shaker_module_hardware_local, testing_global_em_config, False
+    )
+    heater_shakers = config_file.heater_shaker_module_emulators
 
     assert heater_shakers is not None
     assert len(heater_shakers) == 1
@@ -998,7 +644,8 @@ def test_heater_shaker_hardware_local_mounts(
 
 
 def test_thermocycler_module_hardware_local_mounts(
-    thermocycler_module_hardware_local: RuntimeComposeFileModel,
+    thermocycler_module_hardware_local: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to local.
 
@@ -1006,9 +653,10 @@ def test_thermocycler_module_hardware_local_mounts(
     Also confirm that named volumes: opentrons-modules-build-stm32-host and
     opentrons-modules-stm32-tools exist and are bound to the correct location.
     """
-    thermocycler_modules = (
-        thermocycler_module_hardware_local.thermocycler_module_emulators
+    config_file = convert_from_obj(
+        thermocycler_module_hardware_local, testing_global_em_config, False
     )
+    thermocycler_modules = config_file.thermocycler_module_emulators
 
     assert thermocycler_modules is not None
     assert len(thermocycler_modules) == 1
@@ -1034,8 +682,41 @@ def test_thermocycler_module_hardware_local_mounts(
     assert len(thermocycler_module.volumes) == 4
 
 
+def test_thermocycler_module_firmware_local_mounts(
+    thermocycler_module_firmware_local: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
+    """Test mounts when source-type is set to local.
+
+    Confirm that thermocycler module has opentrons, entrypoint.sh mounted in.
+    Also confirm that named volumes: opentrons-python-dist bound to the correct
+    location.
+    """
+    config_file = convert_from_obj(
+        thermocycler_module_firmware_local, testing_global_em_config, False
+    )
+    thermocycler_modules = config_file.thermocycler_module_emulators
+
+    assert thermocycler_modules is not None
+    assert len(thermocycler_modules) == 1
+
+    thermocycler_module = thermocycler_modules[0]
+    assert thermocycler_module.volumes is not None
+
+    assert partial_string_in_mount("opentrons:/opentrons", thermocycler_module.volumes)
+    assert partial_string_in_mount(
+        "entrypoint.sh:/entrypoint.sh", thermocycler_module.volumes
+    )
+    assert partial_string_in_mount(
+        "opentrons-python-dist:/dist", thermocycler_module.volumes
+    )
+
+    assert len(thermocycler_module.volumes) == 3
+
+
 def test_temperature_module_firmware_local_mounts(
-    temperature_module_firmware_local: RuntimeComposeFileModel,
+    temperature_module_firmware_local: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to local.
 
@@ -1043,7 +724,10 @@ def test_temperature_module_firmware_local_mounts(
     Also confirm that named volumes: opentrons-python-dist bound to the correct
     location.
     """
-    temperature_modules = temperature_module_firmware_local.temperature_module_emulators
+    config_file = convert_from_obj(
+        temperature_module_firmware_local, testing_global_em_config, False
+    )
+    temperature_modules = config_file.temperature_module_emulators
 
     assert temperature_modules is not None
     assert len(temperature_modules) == 1
@@ -1063,7 +747,8 @@ def test_temperature_module_firmware_local_mounts(
 
 
 def test_magnetic_module_firmware_local_mounts(
-    magnetic_module_firmware_local: RuntimeComposeFileModel,
+    magnetic_module_firmware_local: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to local.
 
@@ -1071,7 +756,10 @@ def test_magnetic_module_firmware_local_mounts(
     Also confirm that named volumes: opentrons-python-dist bound to the correct
     location.
     """
-    magnetic_modules = magnetic_module_firmware_local.magnetic_module_emulators
+    config_file = convert_from_obj(
+        magnetic_module_firmware_local, testing_global_em_config, False
+    )
+    magnetic_modules = config_file.magnetic_module_emulators
 
     assert magnetic_modules is not None
     assert len(magnetic_modules) == 1
@@ -1090,38 +778,9 @@ def test_magnetic_module_firmware_local_mounts(
     assert len(magnetic_module.volumes) == 3
 
 
-def test_thermocycler_module_firmware_local_mounts(
-    thermocycler_module_firmware_local: RuntimeComposeFileModel,
-) -> None:
-    """Test mounts when source-type is set to local.
-
-    Confirm that thermocycler module has opentrons, entrypoint.sh mounted in.
-    Also confirm that named volumes: opentrons-python-dist bound to the correct
-    location.
-    """
-    thermocycler_modules = (
-        thermocycler_module_firmware_local.thermocycler_module_emulators
-    )
-
-    assert thermocycler_modules is not None
-    assert len(thermocycler_modules) == 1
-
-    thermocycler_module = thermocycler_modules[0]
-    assert thermocycler_module.volumes is not None
-
-    assert partial_string_in_mount("opentrons:/opentrons", thermocycler_module.volumes)
-    assert partial_string_in_mount(
-        "entrypoint.sh:/entrypoint.sh", thermocycler_module.volumes
-    )
-    assert partial_string_in_mount(
-        "opentrons-python-dist:/dist", thermocycler_module.volumes
-    )
-
-    assert len(thermocycler_module.volumes) == 3
-
-
 def test_heater_shaker_hardware_remote_mounts(
-    heater_shaker_module_hardware_remote: RuntimeComposeFileModel,
+    heater_shaker_module_hardware_remote: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to local.
 
@@ -1129,7 +788,10 @@ def test_heater_shaker_hardware_remote_mounts(
     Also confirm that named volumes: opentrons-modules-build-stm32-host and
     opentrons-modules-stm32-tools exist and are bound to the correct location.
     """
-    heater_shakers = heater_shaker_module_hardware_remote.heater_shaker_module_emulators
+    config_file = convert_from_obj(
+        heater_shaker_module_hardware_remote, testing_global_em_config, False
+    )
+    heater_shakers = config_file.heater_shaker_module_emulators
 
     assert heater_shakers is not None
     assert len(heater_shakers) == 1
@@ -1139,15 +801,17 @@ def test_heater_shaker_hardware_remote_mounts(
 
 
 def test_thermocycler_module_hardware_remote_mounts(
-    thermocycler_module_hardware_remote: RuntimeComposeFileModel,
+    thermocycler_module_firmware_remote: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to remote.
 
     Confirm that there are no mounts
     """
-    thermocycler_modules = (
-        thermocycler_module_hardware_remote.thermocycler_module_emulators
+    config_file = convert_from_obj(
+        thermocycler_module_firmware_remote, testing_global_em_config, False
     )
+    thermocycler_modules = config_file.thermocycler_module_emulators
 
     assert thermocycler_modules is not None
     assert len(thermocycler_modules) == 1
@@ -1157,7 +821,8 @@ def test_thermocycler_module_hardware_remote_mounts(
 
 
 def test_temperature_module_firmware_remote_mounts(
-    temperature_module_firmware_remote: RuntimeComposeFileModel,
+    temperature_module_firmware_remote: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to local.
 
@@ -1165,9 +830,10 @@ def test_temperature_module_firmware_remote_mounts(
     Also confirm that named volumes: opentrons-python-dist bound to the correct
     location.
     """
-    temperature_modules = (
-        temperature_module_firmware_remote.temperature_module_emulators
+    config_file = convert_from_obj(
+        temperature_module_firmware_remote, testing_global_em_config, False
     )
+    temperature_modules = config_file.temperature_module_emulators
 
     assert temperature_modules is not None
     assert len(temperature_modules) == 1
@@ -1177,7 +843,8 @@ def test_temperature_module_firmware_remote_mounts(
 
 
 def test_magnetic_module_firmware_remote_mounts(
-    magnetic_module_firmware_remote: RuntimeComposeFileModel,
+    magnetic_module_firmware_remote: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to local.
 
@@ -1185,7 +852,10 @@ def test_magnetic_module_firmware_remote_mounts(
     Also confirm that named volumes: opentrons-python-dist bound to the correct
     location.
     """
-    magnetic_modules = magnetic_module_firmware_remote.magnetic_module_emulators
+    config_file = convert_from_obj(
+        magnetic_module_firmware_remote, testing_global_em_config, False
+    )
+    magnetic_modules = config_file.magnetic_module_emulators
 
     assert magnetic_modules is not None
     assert len(magnetic_modules) == 1
@@ -1195,7 +865,8 @@ def test_magnetic_module_firmware_remote_mounts(
 
 
 def test_thermocycler_module_firmware_remote_mounts(
-    thermocycler_module_firmware_remote: RuntimeComposeFileModel,
+    thermocycler_module_firmware_remote: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
 ) -> None:
     """Test mounts when source-type is set to local.
 
@@ -1203,9 +874,10 @@ def test_thermocycler_module_firmware_remote_mounts(
     Also confirm that named volumes: opentrons-python-dist bound to the correct
     location.
     """
-    thermocycler_modules = (
-        thermocycler_module_firmware_remote.thermocycler_module_emulators
+    config_file = convert_from_obj(
+        thermocycler_module_firmware_remote, testing_global_em_config, False
     )
+    thermocycler_modules = config_file.thermocycler_module_emulators
 
     assert thermocycler_modules is not None
     assert len(thermocycler_modules) == 1
@@ -1215,7 +887,7 @@ def test_thermocycler_module_firmware_remote_mounts(
 
 
 @pytest.mark.parametrize(
-    "config",
+    "config_dict",
     [
         lazy_fixture("ot3_remote_everything_latest"),
         lazy_fixture("ot3_remote_everything_commit_id"),
@@ -1223,13 +895,17 @@ def test_thermocycler_module_firmware_remote_mounts(
         lazy_fixture("ot2_remote_everything_commit_id"),
     ],
 )
-def test_is_remote(config: RuntimeComposeFileModel) -> None:
+def test_is_remote(
+    config_dict: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
     """Confirm that when all source-types are remote, is_remote is True."""
-    assert config.is_remote
+    config_file = convert_from_obj(config_dict, testing_global_em_config, False)
+    assert config_file.is_remote
 
 
 @pytest.mark.parametrize(
-    "config",
+    "config_dict",
     [
         lazy_fixture("ot3_local_robot"),
         lazy_fixture("ot3_local_source"),
@@ -1238,6 +914,10 @@ def test_is_remote(config: RuntimeComposeFileModel) -> None:
         lazy_fixture("ot2_local_robot"),
     ],
 )
-def test_is_not_remote(config: RuntimeComposeFileModel) -> None:
+def test_is_not_remote(
+    config_dict: Dict[str, Any],
+    testing_global_em_config: OpentronsEmulationConfiguration,
+) -> None:
     """Confirm that when all source-types are not remote, is_remote is False."""
-    assert not config.is_remote
+    config_file = convert_from_obj(config_dict, testing_global_em_config, False)
+    assert not config_file.is_remote


### PR DESCRIPTION
# Local Dev Refactor

Okay, so this is a massive PR.
There is no way I would ever expect anyone to go through the whole thing and understand it.
So what I am going to do is go over the highlights of the PR. 

## Overview

The whole point of this PR is to enable developers to use their local source code to build the emulators. 
Previous iterations of this repository failed to adequately support this use case. 

This PR strives to fill the following requirements:

1. Simplify YAML configuration file
2. Allow developers to easily bind their local code into an emulated robot and modules
3. Utilize built in caching methods of pipenv, poetry, and cmake to facillitate rebuilding of source
4. Provide End to End test coverage of common OT-3 use cases

## YAML Configuration File Simplification

Previous iterations of `opentrons-emulation` required the user to specify various source fields in the yaml configuration
file. With fields like `source-type`, `source-location`, `robot-server-source-type`, `robot-server-source-location` 
it was extremely confusing what to put for each field. Plus the were scoped to each emulator, requiring a ton of repition.

To simplify this, all that has been ripped out and burned in the eternal flames of my SSD. 
`source-type` and `source-location` has been removed and replaced with 3 new fields: 

- `monorepo-source`
- `ot3-firmware-source`
- `opentrons-modules-source`

Each field can accept 3 different values. 

1. The string `latest`. This tells the system to build from the latest source code of the `main` branch from Github
2. A commit ID. This tells the system to build from the specified commit from Github.
3. A local path on your system. This tells the system to build from your local source code. 

Source type is now inferred from the value passed to the `source` fields.
Furthermore, these fields are now scoped at the top level of the yaml file and apply to all emulators that need them. 

Below is an example of the change. 

**OLD YAML CONFIG**

```yaml
robot:
  id: otie
  hardware: ot3
  source-type: remote
  source-location: latest
  robot-server-source-type: remote
  robot-server-source-location: f3146770463ad7217905ea74f37206059f61952c
  can-server-source-type: local
  can-server-source-location: /home/derek-maggio/Documents/repos/opentrons
  opentrons-hardware-source-type: remote
  opentrons-hardware-source-location: latest
  emulation-level: hardware
  exposed-port: 31950
  can-server-exposed-port: 9898
```

**NEW YAML CONFIG**

```yaml
robot:
  id: otie
  hardware: ot3
  emulation-level: hardware
  exposed-port: 31950
  can-server-exposed-port: 9898

monorepo-source: latest  # Pull latest code
ot3-firmware-source: f3146770463ad7217905ea74f37206059f61952c  # Pull this commit
opentrons-modules-source: /home/derek-maggio/Documents/repos/opentrons-modules  # Bind my local source code in
```

## Local Dev Enablement

Previously building local source code was not well supported. It was brittle, slow, and required a full rebuild of the 
Dockerfile whenever you wanted to rebuild and push your source code to the emulators. 

The Docker architecture for the containers has change drastically to fix the above issues. 
In response, the `emulation_system` Python framework has also changed to support the architecture changes. 

### Docker Architecture Changes - Builder Containers

In order to fix issues with build source code, the actual building of source code is now done inside of "builder"
containers. These builder containers live alongside your emulators, are automatically created, and do not need to be
specified anywhere by the user. The builder containers build the source code and push the executables/binaries 
into the emulator containers. 

The workflow for this is as follows:

1. The location to get source code is specified, through the various `source` fields, by the user in YAML file
2. Source code is inserted into builder containers
3. Builder containers build source code
4. Builder containers push executables/binaries into emulators

```mermaid
---
title: General Builder Container Architecture
---
flowchart LR
    local-source[Local Source]
    remote-source[Remote Source]
    source-selection{Source Selection}
    builder-container[Builder Container]
    emulator[Emulator]
    
    local-source -- User specifies folder path --- source-selection
    remote-source -- User specifies latest or commit id --- source-selection
    
    source-selection -- Insert Source --- builder-container
    builder-container -- Build source code ---builder-container
    builder-container -- Insert executables --- emulator
```

### Docker Architecture Changes - Dockerfile

To support builder containers and simplify architecture the Dockerfile has been heavily modified. 

#### Remove `local` and `remote` image distiction

Due to all building now happening inside of the builder containers, we no longer have to support `local` and `remote`
versions of the docker images. All handling for local or remote source code will be done inside of the builder containers.

#### Push build args into env vars 

Pushed `FIRMWARE_SOURCE_DOWNLOAD_LOCATION`, `OPENTRONS_SOURCE_DOWNLOAD_LOCATION`, and
`MODULE_SOURCE_DOWNLOAD_LOCATION` into containers as environment variables. This is used for e2e testing

#### Add builder container images and entrypoint files

Each builder needs it's own image and entrypoint file. 

## Add Build Caching

Since source code building is now deferred to the builder containers we can utilize any build caching. 
As long as the builder containers are not deleted their local file system will contain all build caching.

NOTE: On the initial build, no build cache will yet exist, so build times will not be shorter. 
Any subsequent builds will be.

## Provide Common OT-3 Use Case E2E Testing

To validate that this refactor works I have added End to End style testing for the common OT-3 `opentrons-emulation`
use cases. 

The use cases are as follows: 

- OT-3 Remote Source
- OT-3 Local Source
- OT-3 with Modules
 
I used the [Python Docker SDK](https://docker-py.readthedocs.io/en/stable/) to create a framework tointrospect into 
an actual emulated Docker system. From there the created containers, volumes, bind mounts, and build arguments 
are confirmed to be as expected.

The following general checks are performed:

- Builder containers are created when expected
- Any default bind mounts are always added
- If building from local source code, that bind mount from host system to build container exists
- If building from remote source code, that bind mount from host system to build container does not exist
- After building, all executables are present and correctly configured
- Build args are configured as expected

