### PR TITLE
refactor: Local Dev Refactor - Docker Changes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,10 +11,10 @@
 # Hardware Local Emulators #
 ############################
 
-FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as heater-shaker-hardware-local
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as heater-shaker-hardware
 ENV OPENTRONS_HARDWARE "heater-shaker-hardware"
 
-FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as thermocycler-hardware-local
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as thermocycler-hardware
 ENV OPENTRONS_HARDWARE "thermocycler-hardware"
 
 # Do not use common-ot3-firmware as value for OPENTRONS_HARDWARE
@@ -24,50 +24,53 @@ ENV OPENTRONS_HARDWARE "thermocycler-hardware"
 # Instead specify the individual piece of firware as the hardware. This will cause only the container to only build
 # and move firmware for itself. Eliminating the issue of them clobbering each other
 
-FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-pipettes-hardware-local
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-pipettes-hardware
 ENV OPENTRONS_HARDWARE "ot3-pipettes-hardware"
 
-FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-head-hardware-local
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-head-hardware
 ENV OPENTRONS_HARDWARE "ot3-head-hardware"
 
-FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-gantry-x-hardware-local
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-gantry-x-hardware
 ENV OPENTRONS_HARDWARE "ot3-gantry-x-hardware"
 
-FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-gantry-y-hardware-local
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-gantry-y-hardware
 ENV OPENTRONS_HARDWARE "ot3-gantry-y-hardware"
 
-FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-bootloader-hardware-local
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-bootloader-hardware
 ENV OPENTRONS_HARDWARE "ot3-bootloader-hardware"
 
-FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-gripper-hardware-local
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-gripper-hardware
 ENV OPENTRONS_HARDWARE "ot3-gripper-hardware"
+
+FROM ghcr.io/opentrons/cpp-base-${TARGETARCH} as ot3-state-manager
+ENV OPENTRONS_HARDWARE "ot3-state-manager"
 
 ############################
 # Firmware Local Emulators #
 ############################
 
-FROM ghcr.io/opentrons/python-base:latest as thermocycler-firmware-local
+FROM ghcr.io/opentrons/python-base:latest as thermocycler-firmware
 ENV OPENTRONS_HARDWARE "thermocycler-firmware"
 
-FROM ghcr.io/opentrons/python-base:latest as heater-shaker-firmware-local
+FROM ghcr.io/opentrons/python-base:latest as heater-shaker-firmware
 ENV OPENTRONS_HARDWARE "heatershaker-firmware"
 
-FROM ghcr.io/opentrons/python-base:latest as magdeck-firmware-local
+FROM ghcr.io/opentrons/python-base:latest as magdeck-firmware
 ENV OPENTRONS_HARDWARE "magdeck-firmware"
 
-FROM ghcr.io/opentrons/python-base:latest as tempdeck-firmware-local
+FROM ghcr.io/opentrons/python-base:latest as tempdeck-firmware
 ENV OPENTRONS_HARDWARE "tempdeck-firmware"
 
-FROM ghcr.io/opentrons/python-base:latest as emulator-proxy-local
+FROM ghcr.io/opentrons/python-base:latest as emulator-proxy
 ENV OPENTRONS_HARDWARE "emulator-proxy"
 
-FROM ghcr.io/opentrons/python-base:latest as robot-server-local
+FROM ghcr.io/opentrons/python-base:latest as robot-server
 ENV OPENTRONS_HARDWARE "robot-server"
 
-FROM ghcr.io/opentrons/python-base:latest as smoothie-local
+FROM ghcr.io/opentrons/python-base:latest as smoothie
 ENV OPENTRONS_HARDWARE "smoothie"
 
-FROM ghcr.io/opentrons/python-base:latest as can-server-local
+FROM ghcr.io/opentrons/python-base:latest as can-server
 ENV OPENTRONS_HARDWARE "can-server"
 
 
@@ -118,6 +121,9 @@ FROM ghcr.io/opentrons/cpp-base-${TARGETARCH}:latest as ot3-firmware-source
 ARG FIRMWARE_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/ot3-firmware/archive/refs/heads/main.zip"
 ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons/archive/refs/heads/edge.zip"
 
+ENV FIRMWARE_SOURCE_DOWNLOAD_LOCATION=$FIRMWARE_SOURCE_DOWNLOAD_LOCATION
+ENV OPENTRONS_SOURCE_DOWNLOAD_LOCATION=$OPENTRONS_SOURCE_DOWNLOAD_LOCATION
+
 ADD $FIRMWARE_SOURCE_DOWNLOAD_LOCATION /ot3-firmware.zip
 ADD $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons.zip
 
@@ -130,188 +136,44 @@ RUN (cd / &&  \
     rm -f opentrons.zip && \
     mv opentrons* opentrons)
 
-
-FROM ot3-firmware-source as local-ot3-firmware-builder
-COPY entrypoints/local_ot3_firmware_builder.sh /build.sh
+FROM ot3-firmware-source as ot3-firmware-builder
+COPY entrypoints/ot3_firmware_builder.sh /build.sh
 
 ##################
 # modules-source #
 ##################
 
 FROM ghcr.io/opentrons/cpp-base-${TARGETARCH}:latest as opentrons-modules-source
-ARG MODULE_SOURCE_DOWNLOAD_LOCATION
+ARG MODULE_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons-modules/archive/refs/heads/edge.zip"
+
+ENV MODULE_SOURCE_DOWNLOAD_LOCATION=$MODULE_SOURCE_DOWNLOAD_LOCATION
+
 ADD $MODULE_SOURCE_DOWNLOAD_LOCATION /opentrons-modules.zip
+
 RUN (cd / &&  \
     unzip -q opentrons-modules.zip && \
     rm -f opentrons-modules.zip && \
     mv opentrons-modules* opentrons-modules)
+
+FROM opentrons-modules-source as opentrons-modules-builder
+COPY entrypoints/opentrons_modules_builder.sh /build.sh
+
 
 ####################
 # opentrons-source #
 ####################
 
 FROM ghcr.io/opentrons/python-base:latest as opentrons-source
-ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION
+ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons/archive/refs/heads/edge.zip"
+
+ENV OPENTRONS_SOURCE_DOWNLOAD_LOCATION=$OPENTRONS_SOURCE_DOWNLOAD_LOCATION
+
 ADD $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons.zip
+
 RUN (cd / &&  \
     unzip -q opentrons.zip && \
     rm -f opentrons.zip && \
     mv opentrons* opentrons)
 
-#############################################################
-#                    EXECUTABLE BUILDERS                    #
-#############################################################
-
-# The following targets should build executables.
-# There should be a 1 to 1 mapping of Executable Builder to Production Target
-# The Exectuable Builder should build the executable file and the Production Target should copy over the executable file
-# from the executable builder target
-# Building separately from the Production Target to reduce image size
-
-FROM opentrons-modules-source as heater-shaker-builder
-ENV OPENTRONS_HARDWARE "heater-shaker-hardware"
-COPY entrypoint.sh /entrypoint.sh
-RUN /entrypoint.sh build
-
-FROM opentrons-modules-source as thermocycler-builder
-ENV OPENTRONS_HARDWARE "thermocycler-hardware"
-COPY entrypoint.sh /entrypoint.sh
-RUN /entrypoint.sh build
-
-FROM opentrons-source as python-emulator-builder
-ENV OPENTRONS_HARDWARE "common-firmware"
-COPY entrypoint.sh /entrypoint.sh
-RUN /entrypoint.sh build
-
-FROM ot3-firmware-source as ot3-firmware-builder
-ENV OPENTRONS_HARDWARE "common-ot3-firmware"
-COPY entrypoint.sh /entrypoint.sh
-RUN /entrypoint.sh build
-
-##################
-# Firmware Common #
-##################
-
-# Added this firmware-common image because all firmware level emulator images are based off of
-# the opentrons monorepo, it's just a different command that is ran for each.
-
-FROM ghcr.io/opentrons/python-base:latest as firmware-common
-RUN mkdir /dist
-COPY --from=python-emulator-builder /dist/* /dist/
-RUN pip install /dist/*
-
-##############################################################
-#                       REMOTE TARGETS                       #
-##############################################################
-
-# Targets for all remote builds of emulators
-# Make sure to include the OPENTRONS_HARDWARE env variable
-# Each Remote Target should copy in entrypoint.sh
-
-FROM ot3-firmware-builder as ot3-state-manager
-ENV OPENTRONS_HARDWARE "ot3-state-manager"
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-#############################
-# Hardware Remote Emulators #
-#############################
-
-# These emulators run C++ firmware code and emulate the hardware
-# Each Hardware Production Target should copy the executable from the Executable Builder target
-# Each Hardware Production Target should have a corresponding Executable Builder target
-
-FROM ghcr.io/opentrons/ubuntu-base-${TARGETARCH}:latest as ot3-pipettes-hardware-remote
-ENV OPENTRONS_HARDWARE "ot3-pipettes-hardware"
-COPY --from=ot3-firmware-builder /pipettes-simulator /pipettes-simulator
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-FROM ghcr.io/opentrons/ubuntu-base-${TARGETARCH}:latest as ot3-head-hardware-remote
-ENV OPENTRONS_HARDWARE "ot3-head-hardware"
-COPY --from=ot3-firmware-builder /head-simulator /head-simulator
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-FROM ghcr.io/opentrons/ubuntu-base-${TARGETARCH}:latest as ot3-gantry-x-hardware-remote
-ENV OPENTRONS_HARDWARE "ot3-gantry-x-hardware"
-COPY --from=ot3-firmware-builder /gantry-x-simulator /gantry-x-simulator
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-FROM ghcr.io/opentrons/ubuntu-base-${TARGETARCH}:latest as ot3-gantry-y-hardware-remote
-ENV OPENTRONS_HARDWARE "ot3-gantry-y-hardware"
-COPY --from=ot3-firmware-builder /gantry-y-simulator /gantry-y-simulator
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-FROM ghcr.io/opentrons/ubuntu-base-${TARGETARCH}:latest as ot3-bootloader-hardware-remote
-ENV OPENTRONS_HARDWARE "ot3-bootloader-hardware"
-COPY --from=ot3-firmware-builder /bootloader-simulator /bootloader-simulator
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-FROM ghcr.io/opentrons/ubuntu-base-${TARGETARCH}:latest as ot3-gripper-hardware-remote
-ENV OPENTRONS_HARDWARE "ot3-gripper-hardware"
-COPY --from=ot3-firmware-builder /gripper-simulator /gripper-simulator
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-FROM ghcr.io/opentrons/ubuntu-base-${TARGETARCH}:latest as heater-shaker-hardware-remote
-ENV OPENTRONS_HARDWARE "heater-shaker-hardware"
-COPY --from=heater-shaker-builder /heater-shaker-simulator /heater-shaker-simulator
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-FROM ghcr.io/opentrons/ubuntu-base-${TARGETARCH}:latest as thermocycler-hardware-remote
-ENV OPENTRONS_HARDWARE "thermocycler-hardware"
-COPY --from=thermocycler-builder /thermocycler-gen2-simulator /thermocycler-gen2-simulator
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-#################################
-# Firmware Production Emulators #
-#################################
-
-# There emulators run python driver code and emulator the firmware
-# All Firmware level emulators should be based off of firmware-common
-
-FROM firmware-common as thermocycler-firmware-remote
-ENV OPENTRONS_HARDWARE "thermocycler-firmware"
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-FROM firmware-common as heater-shaker-firmware-remote
-ENV OPENTRONS_HARDWARE "heater-shaker-firmware"
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-FROM firmware-common as magdeck-firmware-remote
-ENV OPENTRONS_HARDWARE "magdeck-firmware"
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-FROM firmware-common as tempdeck-firmware-remote
-ENV OPENTRONS_HARDWARE "tempdeck-firmware"
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-FROM firmware-common as emulator-proxy-remote
-ENV OPENTRONS_HARDWARE "emulator-proxy"
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-FROM firmware-common as robot-server-remote
-ENV OPENTRONS_HARDWARE "robot-server"
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-FROM firmware-common as smoothie-remote
-ENV OPENTRONS_HARDWARE "smoothie"
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
-
-FROM firmware-common as can-server-remote
-ENV OPENTRONS_HARDWARE "can-server"
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh", "run"]
+FROM opentrons-source as monorepo-builder
+COPY entrypoints/monorepo_builder.sh /build.sh

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,99 +1,9 @@
 #!/bin/bash
 
-if [ $# -lt 1 ]; then
-  echo "Must provide \"command\""
-  echo "Usage: $(basename "${BASH_SOURCE[0]}") <command>"
-  exit 1
-fi
-
-COMMAND=$1
-
-if [ "$COMMAND" != "build" ] && [ "$COMMAND" != "run" ]; then
-  echo "Valid commands are \"build\" and \"run\""
-  echo "You passed $COMMAND"
-  echo "Usage: $(basename "${BASH_SOURCE[0]}") <command>"
-  exit 1
-fi
-
-build_ot3_firmware_simulators()
-  (
-    cd /ot3-firmware && \
-    cmake --preset host-gcc10 && \
-    cmake --build --preset=simulators -j $(expr $(nproc) - 1)
-  )
-
-build_module_simulator() {
-  (cd /opentrons-modules && cmake --preset=stm32-host-gcc10 . && cmake --build ./build-stm32-host -j $(expr $(nproc) - 1) --target $1)
-}
-
-build_ot3_firmware_single_simulator() {
-  (
-    cd /ot3-firmware && \
-    cmake --preset host-gcc10 && \
-    cmake --build ./build-host -j $(expr $(nproc) - 1) --target $1
-    )
-}
-# OPENTRONS_HARDWARE is an env variable that is passed to every container
-
-FULL_COMMAND="$COMMAND"-"$OPENTRONS_HARDWARE"
 OTHER_ARGS=`echo "${@:2}"`
-echo "${FULL_COMMAND}"
-case $FULL_COMMAND in
 
-  # Hardware Level
-
-  build-heater-shaker-hardware)
-    build_module_simulator "heater-shaker-simulator"
-    cp /opentrons-modules/build-stm32-host/stm32-modules/heater-shaker/simulator/heater-shaker-simulator /heater-shaker-simulator
-    ;;
-  build-thermocycler-hardware)
-    build_module_simulator "thermocycler-gen2-simulator"
-    cp /opentrons-modules/build-stm32-host/stm32-modules/thermocycler-gen2/simulator/thermocycler-gen2-simulator /thermocycler-gen2-simulator
-    ;;
-
-  # Will only use this for remote builds when we can control everything being built at once and then picking
-  # and choosing which executeable is sent to which container
-  build-common-ot3-firmware)
-    build_ot3_firmware_simulators
-    cp /ot3-firmware/build-host/pipettes/simulator/pipettes-single-simulator /pipettes-simulator
-    cp /ot3-firmware/build-host/head/simulator/head-simulator /head-simulator
-    cp /ot3-firmware/build-host/gantry/simulator/gantry-x-simulator /gantry-x-simulator
-    cp /ot3-firmware/build-host/gantry/simulator/gantry-y-simulator /gantry-y-simulator
-    cp /ot3-firmware/build-host/bootloader/simulator/bootloader-simulator /bootloader-simulator
-    cp /ot3-firmware/build-host/gripper/simulator/gripper-simulator /gripper-simulator
-    ;;
-
-  # TODO: Figure out why below ot3 builders are failing if I build just the single simulator and not all of them.
-
-  build-ot3-gantry-x-hardware)
-    build_ot3_firmware_simulators
-    cp /ot3-firmware/build-host/gantry/simulator/gantry-x-simulator /gantry-x-simulator
-    ;;
-
-  build-ot3-gantry-y-hardware)
-    build_ot3_firmware_simulators
-    cp /ot3-firmware/build-host/gantry/simulator/gantry-y-simulator /gantry-y-simulator
-    ;;
-
-  build-ot3-head-hardware)
-    build_ot3_firmware_simulators
-    cp /ot3-firmware/build-host/head/simulator/head-simulator /head-simulator
-    ;;
-
-  build-ot3-pipettes-hardware)
-    build_ot3_firmware_simulators
-    cp /ot3-firmware/build-host/pipettes/simulator/pipettes-single-simulator /pipettes-simulator
-    ;;
-
-  build-ot3-bootloader-hardware)
-    build_ot3_firmware_simulators
-    cp /ot3-firmware/build-host/bootloader/simulator/bootloader-simulator /bootloader-simulator
-    ;;
-
-  build-ot3-gripper-hardware)
-    build_ot3_firmware_simulators
-    cp /ot3-firmware/build-host/gripper/simulator/gripper-simulator /gripper-simulator
-    ;;
+# OPENTRONS_HARDWARE is an env variable that is passed to every container
+case $OPENTRONS_HARDWARE in
 
   run-heater-shaker-hardware)
     bash -c "/heater-shaker-simulator $OTHER_ARGS"
@@ -103,22 +13,22 @@ case $FULL_COMMAND in
     ;;
 
   run-ot3-pipettes-hardware)
-    /pipettes-simulator
+    /executable/pipettes-simulator
     ;;
   run-ot3-head-hardware)
-    /head-simulator
+    /executable/head-simulator
     ;;
   run-ot3-gantry-x-hardware)
-    /gantry-x-simulator
+    /executable/gantry-x-simulator
     ;;
   run-ot3-gantry-y-hardware)
-    /gantry-y-simulator
+    /executable/gantry-y-simulator
     ;;
   run-ot3-bootloader-hardware)
-    /bootloader-simulator
+    /executable/bootloader-simulator
     ;;
   run-ot3-gripper-hardware)
-    /gripper-simulator
+    /executable/gripper-simulator
     ;;
   run-ot3-state-manager)
     # 9999 is the hardcoded state manager port
@@ -126,18 +36,6 @@ case $FULL_COMMAND in
       cd /ot3-firmware/state_manager && \
       ../stm32-tools/poetry/bin/poetry run python3 -m state_manager.state_manager --right-pipette P1000-multi-96 0.0.0.0 9999
     )
-    ;;
-
-  # Firmware Level
-
-  build-thermocycler-firmware|build-heater-shaker-firmware|build-magdeck-firmware|build-tempdeck-firmware|build-emulator-proxy|build-robot-server|build-common-firmware|build-smoothie|build-can-server)
-    monorepo_python -m pip uninstall --yes /dist/*
-    (cd /opentrons/shared-data/python && monorepo_python setup.py bdist_wheel -d /dist/)
-    (cd /opentrons/api && monorepo_python setup.py bdist_wheel -d /dist/)
-    (cd /opentrons/notify-server && monorepo_python setup.py bdist_wheel -d /dist/)
-    (cd /opentrons/robot-server && monorepo_python setup.py bdist_wheel -d /dist/)
-    (cd /opentrons/hardware && monorepo_python setup.py bdist_wheel -d /dist/)
-    monorepo_python -m pip install /dist/*
     ;;
 
   run-thermocycler-firmware)
@@ -166,7 +64,7 @@ case $FULL_COMMAND in
     ;;
 
   *)
-    echo "Command ${FULL_COMMAND} not found."
+    echo "Command ${OPENTRONS_HARDWARE} not found."
     exit 2
     ;;
 esac

--- a/docker/entrypoints/monorepo_builder.sh
+++ b/docker/entrypoints/monorepo_builder.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Build all necessary wheels for running:
+# Robot Server
+# Smoothie Emulation
+# Firmware Module Emulation
+# CAN Server
+# Emulator Proxy
+
+# /dist will be loaded into a volume in local-monorepo-builder container
+# All emulator containers needing the wheels will use that volume and bind it to /dist
+
+(cd /opentrons/shared-data/python && monorepo_python setup.py bdist_wheel -d /dist/)
+(cd /opentrons/api && monorepo_python setup.py bdist_wheel -d /dist/)
+(cd /opentrons/notify-server && monorepo_python setup.py bdist_wheel -d /dist/)
+(cd /opentrons/robot-server && monorepo_python setup.py bdist_wheel -d /dist/)
+(cd /opentrons/hardware && monorepo_python setup.py bdist_wheel -d /dist/)

--- a/docker/entrypoints/opentrons_modules_builder.sh
+++ b/docker/entrypoints/opentrons_modules_builder.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+build_module_simulator() {
+  (cd /opentrons-modules && cmake --preset=stm32-host-gcc10 . && cmake --build ./build-stm32-host -j $(expr $(nproc) - 1) --target $1)
+}
+
+build_module_simulator "heater-shaker-simulator"
+build_module_simulator "thermocycler-gen2-simulator"
+
+mkdir -p \
+  /volumes/heater_shaker_volume \
+  /volumes/thermocycler_volume
+
+cp /opentrons-modules/build-stm32-host/stm32-modules/heater-shaker/simulator/heater-shaker-simulator /volumes/heater_shaker_volume/heater-shaker-simulator
+cp /opentrons-modules/build-stm32-host/stm32-modules/thermocycler-gen2/simulator/thermocycler-gen2-simulator /volumes/thermocycler_volume/thermocycler-simulator

--- a/docker/entrypoints/ot3_firmware_builder.sh
+++ b/docker/entrypoints/ot3_firmware_builder.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 
+# Build all simulators in ot3-firmware
+# Create a directory for each simulator to live
+# On local-ot3-firwmare-builder container create a volume for each simulator and bind each simulator directory to it
+# On each OT-3 Firmware emulator container attach its respective volume
+
+echo "Building ot3-firmware"
+
 (
   cd /ot3-firmware && \
   cmake --preset host-gcc10 && \
   cmake --build ./build-host -j $(expr $(nproc) - 1)
 )
+
+echo "Creating simulator directories"
 
 mkdir -p \
   /volumes/pipettes_volume \
@@ -13,7 +22,10 @@ mkdir -p \
   /volumes/gantry_y_volume \
   /volumes/gantry_y_volume \
   /volumes/bootloader_volume \
-  /volumes/gripper_volume
+  /volumes/gripper_volume \
+  /volumes/state_manager_venv
+
+echo "Copying simulator files to simulator directories"
 
 cp /ot3-firmware/build-host/pipettes/simulator/pipettes-single-simulator /volumes/pipettes_volume/pipettes-simulator
 cp /ot3-firmware/build-host/head/simulator/head-simulator /volumes/head_volume/head-simulator
@@ -21,3 +33,4 @@ cp /ot3-firmware/build-host/gantry/simulator/gantry-x-simulator /volumes/gantry_
 cp /ot3-firmware/build-host/gantry/simulator/gantry-y-simulator /volumes/gantry_y_volume/gantry-y-simulator
 cp /ot3-firmware/build-host/bootloader/simulator/bootloader-simulator /volumes/bootloader_volume/bootloader-simulator
 cp /ot3-firmware/build-host/gripper/simulator/gripper-simulator /volumes/gripper_volume/gripper-simulator
+cp -r /ot3-firmware/build-host/.venv /volumes/state_manager_venv/


### PR DESCRIPTION
**NOTE: THIS WILL NOT PASS PROBABLY ANY CI CHECKS. SPLITTING UP FOR SAKE OF REVIEWING**

# Overview

Refactor Dockerfile
Move all build logic from entrypoint.sh to builder entrypoints

# Changelog

**Dockerfile**

- Remove local and remote image distinction
- Push SOURCE_DOWNLOAD_LOCATION build args into env vars
- Provide default download locations for MODULE_SOURCE_DOWNLOAD_LOCATION AND OPENTRONS_SOURCE_DOWNLOAD_LOCATIONS
- Define opentrons, ot3-firmware, and opentrons-modules builder containers

**Entrypoints**

- Move all source code build logic into entrypoints split by repo type
- Remove all build logic from entrypoint.sh

# Relevant Excerpts from Main PR

### Docker Architecture Changes - Dockerfile

To support builder containers and simplify architecture the Dockerfile has been heavily modified. 

#### Remove `local` and `remote` image distiction

Due to all building now happening inside of the builder containers, we no longer have to support `local` and `remote`
versions of the docker images. All handling for local or remote source code will be done inside of the builder containers.

#### Push build args into env vars 

Pushed `FIRMWARE_SOURCE_DOWNLOAD_LOCATION`, `OPENTRONS_SOURCE_DOWNLOAD_LOCATION`, and
`MODULE_SOURCE_DOWNLOAD_LOCATION` into containers as environment variables. This is used for e2e testing

#### Add builder container images and entrypoint files

Each builder needs it's own image and entrypoint file. 