### PR TITLE
fix: Change command to add poetry to path in login file instead of shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ You need to update pyenv. Follow [these](https://github.com/pyenv/pyenv#upgradin
 1. [Poetry Installed Globally](https://python-poetry.org/docs/master/#installing-with-the-official-installer)
    1. Run `curl -sSL https://install.python-poetry.org | python3 -`
    1. Add poetry dir to `PATH` environment variable
-      1. **Mac** - `echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc`
+      1. **Mac** - `echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zprofile`
       1. **Linux** - `echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.profile`.
          Note: On Linux this might already be on your path variable.
 


### PR DESCRIPTION
# Overview

Nus's system was not running the `.zshrc`, therefore not adding poetry to the path.
Add it to `.zprofile` to ensure it runs on login.


@sfoster1 is my logic correct here? Always get a bit mixed up on how to use the different files, especially with Mac