### PR TITLE
chore: Add use_local_host: False to default em proxy settings

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_emulator_proxy_service_builder.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/concrete_emulator_proxy_service_builder.py
@@ -116,7 +116,7 @@ class ConcreteEmulatorProxyServiceBuilder(AbstractServiceBuilder):
         repo = OpentronsRepository.OPENTRONS
         build_args = get_build_args(
             repo,
-            "latest",
+            self.get_ot2(self._config_model).source_location,
             self._global_settings.get_repo_branch(repo),
             self._global_settings.get_repo_head(repo),
         )

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/modules/module_model.py
@@ -88,5 +88,6 @@ class ModuleInputModel(HardwareModel):
         value = {
             "emulator_port": cls.proxy_info.emulator_port,
             "driver_port": cls.proxy_info.driver_port,
+            "use_local_host": False
         }
         return {cls.proxy_info.env_var_name: json.dumps(value)}


### PR DESCRIPTION
# Overview

This is for compatibility with https://github.com/Opentrons/opentrons/pull/12778

- Override default value of `use_local_host` to `False`
- Make emulator proxy build from `source-location`

# Review requests

I am considering merging this even with failing all the failing CI.
All these CI checks are going to change with release-v4.0.0 and this is just a stop gap until then.

Seems a waste of time to fix these if they are going to removed/changed

What I did instead was test manually.

To start I tested this against the `latest` version of the monorepo. As expected it failed, because the env var was not being used, therefore it the host was referenced as `127.0.0.1` and not the container id.

The next test was to reference the branch from https://github.com/Opentrons/opentrons/pull/12778 in my configuration file and validate that the emulator proxy now resolves the host name correctly. 

Also tested over in https://github.com/Opentrons/opentrons/pull/12778 that using the emulator proxy without Docker still works

# Risk assessment

None, just setting an env var. If it ends up not being used it doesn't break anything 
