### PR TITLE
feat: Update pipette specification for Flex and OT-2

### DIFF
--- a/docker/entrypoints/opentrons_modules_builder.sh
+++ b/docker/entrypoints/opentrons_modules_builder.sh
@@ -19,13 +19,13 @@ build_module_simulator "thermocycler-gen2-simulator"
 
 echo "Creating simulator directories (If needed)"
 mkdir -p \
-  /volumes/heater-shaker-volume \
-  /volumes/thermocycler-volume
+  /volumes/heater-shaker-executable \
+  /volumes/thermocycler-executable
 
 echo "Removing any existing simulators from simulator directories"
-rm -f /volumes/heater-shaker-volume/*
-rm -f /volumes/thermocycler-volume/*
+rm -f /volumes/heater-shaker-executable/*
+rm -f /volumes/thermocycler-executable/*
 
 echo "Copying built simulator files to simulator directories"
-cp /opentrons-modules/build-stm32-host/stm32-modules/heater-shaker/simulator/heater-shaker-simulator /volumes/heater-shaker-volume/heater-shaker-simulator
-cp /opentrons-modules/build-stm32-host/stm32-modules/thermocycler-gen2/simulator/thermocycler-gen2-simulator /volumes/thermocycler-volume/thermocycler-simulator
+cp /opentrons-modules/build-stm32-host/stm32-modules/heater-shaker/simulator/heater-shaker-simulator /volumes/heater-shaker-executable/heater-shaker-simulator
+cp /opentrons-modules/build-stm32-host/stm32-modules/thermocycler-gen2/simulator/thermocycler-gen2-simulator /volumes/thermocycler-executable/thermocycler-simulator

--- a/docker/entrypoints/ot3_firmware_builder.sh
+++ b/docker/entrypoints/ot3_firmware_builder.sh
@@ -24,43 +24,44 @@ echo "Building ot3-firmware State Manager"
 )
 
 
-echo "Creating simulator directories (If needed)"
+echo "Creating directories (If needed)"
 mkdir -p \
-  /volumes/pipettes-volume \
-  /volumes/head-volume \
-  /volumes/gantry-x-volume \
-  /volumes/gantry-y-volume \
-  /volumes/gantry-y-volume \
-  /volumes/bootloader-volume \
-  /volumes/gripper-volume \
-  /volumes/state-manager-venv \
-  /volumes/state-manager-dist
+  /volumes/bootloader-executable \
+  /volumes/gantry-x-executable \
+  /volumes/gantry-y-executable \
+  /volumes/gripper-executable \
+  /volumes/gripper-eeprom \
+  /volumes/head-executable \
+  /volumes/left-pipette-executable \
+  /volumes/left-pipette-eeprom \
+  /volumes/right-pipette-executable \
+  /volumes/right-pipette-eeprom \
+  /volumes/state-manager-dist \
+  /volumes/state-manager-venv 
 
-echo "Removing any existing simulators from simulator directories"
-rm -f /volumes/pipettes-volume/*
-rm -f /volumes/head-volume/*
-rm -f /volumes/gantry-x-volume/*
-rm -f /volumes/gantry-y-volume/*
-rm -f /volumes/bootloader-volume/*
-rm -f /volumes/gripper-volume/*
-rm -rf /volumes/state-manager-venv/*
+echo "Removing any files from directories"
+rm -f /volumes/bootloader-executable/*
+rm -f /volumes/gantry-x-executable/*
+rm -f /volumes/gantry-y-executable/*
+rm -f /volumes/gripper-executable/*
+rm -f /volumes/gripper-eeprom/*
+rm -f /volumes/head-executable/*
+rm -f /volumes/left-pipette-executable/*
+rm -f /volumes/left-pipette-eeprom/*
+rm -f /volumes/right-pipette-executable/*
+rm -f /volumes/right-pipette-eeprom/*
 rm -rf /volumes/state-manager-dist/*
+rm -rf /volumes/state-manager-venv/*
 
 echo "Copying built simulator files to simulator directories"
-cp /ot3-firmware/build-host/pipettes/simulator/pipettes-single-simulator /volumes/pipettes-volume/pipettes-simulator
-cp /ot3-firmware/build-host/head/simulator/head-simulator /volumes/head-volume/head-simulator
-cp /ot3-firmware/build-host/gantry/simulator/gantry-x-simulator /volumes/gantry-x-volume/gantry-x-simulator
-cp /ot3-firmware/build-host/gantry/simulator/gantry-y-simulator /volumes/gantry-y-volume/gantry-y-simulator
-cp /ot3-firmware/build-host/bootloader/simulator/bootloader-simulator /volumes/bootloader-volume/bootloader-simulator
-cp /ot3-firmware/build-host/gripper/simulator/gripper-simulator /volumes/gripper-volume/gripper-simulator
 cp -r /ot3-firmware/build-host/.venv/* /volumes/state-manager-venv/
+cp -r /ot3-firmware/build-host/pipettes/simulator/*-simulator /volumes/left-pipette-executable/
+cp -r /ot3-firmware/build-host/pipettes/simulator/*-simulator /volumes/right-pipette-executable/
 cp -r /ot3-firmware/state_manager/dist/* /volumes/state-manager-dist/
+cp /ot3-firmware/build-host/bootloader/simulator/bootloader-simulator /volumes/bootloader-executable/bootloader-simulator
+cp /ot3-firmware/build-host/gantry/simulator/gantry-x-simulator /volumes/gantry-x-executable/gantry-x-simulator
+cp /ot3-firmware/build-host/gantry/simulator/gantry-y-simulator /volumes/gantry-y-executable/gantry-y-simulator
+cp /ot3-firmware/build-host/gripper/simulator/gripper-simulator /volumes/gripper-executable/gripper-simulator
+cp /ot3-firmware/build-host/head/simulator/head-simulator /volumes/head-executable/head-simulator
 
-cp /ot3-firmware/build-host/pipettes/simulator/pipettes-single-simulator /volumes/pipettes-volume/pipettes-simulator
-cp /ot3-firmware/build-host/head/simulator/head-simulator /volumes/head-volume/head-simulator
-cp /ot3-firmware/build-host/gantry/simulator/gantry-x-simulator /volumes/gantry-x-volume/gantry-x-simulator
-cp /ot3-firmware/build-host/gantry/simulator/gantry-y-simulator /volumes/gantry-y-volume/gantry-y-simulator
-cp /ot3-firmware/build-host/bootloader/simulator/bootloader-simulator /volumes/bootloader-volume/bootloader-simulator
-cp /ot3-firmware/build-host/gripper/simulator/gripper-simulator /volumes/gripper-volume/gripper-simulator
-cp -r /ot3-firmware/build-host/.venv/* /volumes/state-manager-venv/
-cp -r /ot3-firmware/state_manager/dist/* /volumes/state-manager-dist/
+# Add serial generation here

--- a/emulation_system/emulation_system/compose_file_creator/config_file_settings.py
+++ b/emulation_system/emulation_system/compose_file_creator/config_file_settings.py
@@ -111,13 +111,6 @@ class RPMModelSettings(OpentronsBaseModel):
     starting: float = 0.0
 
 
-class PipetteSettings(OpentronsBaseModel):
-    """Pipette defintions for OT-2 and OT-3."""
-
-    model: str = "p20_single_v2.0"
-    id: str = "P20SV202020070101"
-
-
 class OpentronsRepository(str, Enum):
     """Possible repos to download from."""
 

--- a/emulation_system/emulation_system/compose_file_creator/config_file_settings.py
+++ b/emulation_system/emulation_system/compose_file_creator/config_file_settings.py
@@ -48,7 +48,8 @@ class Hardware(str, Enum):
 class OT3Hardware(str, Enum):
     """Names of OT3 hardware."""
 
-    PIPETTES = "ot3-pipettes"
+    LEFT_PIPETTE = "ot3-left-pipette"
+    RIGHT_PIPETTE = "ot3-right-pipette"
     HEAD = "ot3-head"
     GANTRY_X = "ot3-gantry-x"
     GANTRY_Y = "ot3-gantry-y"

--- a/emulation_system/emulation_system/compose_file_creator/config_file_settings.py
+++ b/emulation_system/emulation_system/compose_file_creator/config_file_settings.py
@@ -30,14 +30,14 @@ class Hardware(str, Enum):
         return self.value.replace("-module", "")
 
     @property
-    def named_volume_name(self) -> str:
+    def executable_volume_name(self) -> str:
         """Get name of volume that will be shared between services."""
         return f"{self.hw_name}-executable"
 
     @property
-    def container_volume_storage_path(self) -> str:
+    def builder_executable_volume_path(self) -> str:
         """Where the builder container stores it's volumes."""
-        return f"/volumes/{self.hw_name}-volume/"
+        return f"/volumes/{self.hw_name}-executable/"
 
     @property
     def simulator_name(self) -> str:
@@ -62,19 +62,36 @@ class OT3Hardware(str, Enum):
         return self.value.replace("ot3-", "")
 
     @property
-    def named_volume_name(self) -> str:
-        """Get name of volume that will be shared between services."""
+    def builder_executable_volume_path(self) -> str:
+        """Where the builder container stores its volumes."""
+        return f"/volumes/{self.hw_name}-executable"
+
+    @property
+    def executable_volume_name(self) -> str:
+        """Get name of volume that will share the built executable to the emulator."""
         return f"{self.hw_name}-executable"
 
     @property
-    def container_volume_storage_path(self) -> str:
-        """Where the builder container stores its volumes."""
-        return f"/volumes/{self.hw_name}-volume/"
+    def eeprom_file_volume_name(self) -> str:
+        """Get name of volume that will be share the generate eeprom.bin file into the emulator."""
+        if self not in self.eeprom_required_hardware():
+            raise ValueError(f"{self.value} does not require an eeprom file.")
+        return f"{self.hw_name}-eeprom"
+
+    @property
+    def eeprom_file_volume_storage_path(self) -> str:
+        """Path to eeprom file"""
+        return f"/volumes/{self.hw_name}-eeprom"
 
     @property
     def simulator_name(self) -> str:
         """Generates simulator name."""
         return f'{self.value.replace("ot3-", "")}-simulator'
+
+    @classmethod
+    def eeprom_required_hardware(cls) -> List["OT3Hardware"]:
+        """Get list of hardware that require eeprom file."""
+        return [cls.LEFT_PIPETTE, cls.RIGHT_PIPETTE, cls.GRIPPER]
 
 
 class EmulationLevels(str, Enum):

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/input_services.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/input_services.py
@@ -146,7 +146,7 @@ class InputServices(AbstractService):
             volumes.extend(self._monorepo_source.generate_emulator_mount_strings())
         elif source.repo == OpentronsRepository.OPENTRONS_MODULES:
             volumes.extend(
-                self._opentrons_modules_source.generate_emulator_mount_strings_from_hw(
+                self._opentrons_modules_source.generate_emulator_executable_mount_strings_from_hw(
                     self._container.hardware
                 )
             )

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/ot3_firmware_builder_service.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/ot3_firmware_builder_service.py
@@ -80,7 +80,10 @@ class OT3FirmwareBuilderService(AbstractService):
 
     def generate_volumes(self) -> Optional[IntermediateVolumes]:
         """Generates value for volumes parameter."""
-        return self._ot3_source.generate_builder_mount_strings()
+        vols = self._ot3_source.generate_builder_mount_strings()
+        if self._monorepo_source.is_local():
+            vols.extend(self._monorepo_source.generate_source_code_bind_mounts())
+        return vols
 
     def generate_ports(self) -> Optional[IntermediatePorts]:
         """Generates value for ports parameter."""

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/ot3_firmware_builder_service.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/ot3_firmware_builder_service.py
@@ -2,6 +2,9 @@
 from typing import Optional
 
 from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
+from emulation_system.compose_file_creator.pipette_utils import (
+    get_robot_pipettes,
+)
 from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediateBuildArgs,
     IntermediateEnvironmentVariables,
@@ -91,4 +94,12 @@ class OT3FirmwareBuilderService(AbstractService):
 
     def generate_env_vars(self) -> Optional[IntermediateEnvironmentVariables]:
         """Generates value for environment parameter."""
-        return None
+        robot = self._ot3
+        env_vars: IntermediateEnvironmentVariables = {}
+        pipettes = get_robot_pipettes(
+            robot.hardware, robot.left_pipette, robot.right_pipette
+        )
+
+        env_vars.update(pipettes.get_left_pipette_env_var())
+        env_vars.update(pipettes.get_right_pipette_env_var())
+        return env_vars

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/ot3_services.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/ot3_services.py
@@ -10,18 +10,10 @@ from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediatePorts,
     IntermediateVolumes,
 )
-from emulation_system.consts import OT3_STATE_MANAGER_BOUND_PORT
+from emulation_system.compose_file_creator.utilities.hardware_utils import is_ot3
+from emulation_system.consts import EEPROM_FILE_NAME, OT3_STATE_MANAGER_BOUND_PORT
 
-from ...images import (
-    OT3BootloaderImage,
-    OT3GantryXImage,
-    OT3GantryYImage,
-    OT3GripperImage,
-    OT3HeadImage,
-    OT3PipettesImage,
-    SingleImage,
-)
-from ...input.hardware_models import OT3InputModel
+from ...images import SingleImage
 from ...logging import OT3LoggingClient
 from .abstract_service import AbstractService
 from .service_info import ServiceInfo
@@ -29,6 +21,8 @@ from .service_info import ServiceInfo
 
 class OT3Services(AbstractService):
     """Concrete implementation of AbstractService for building OT-3 firmware services."""
+
+    DEFAULT_ENV_VARS = {"CAN_SERVER_HOST": "can-server"}
 
     def __init__(
         self,
@@ -60,22 +54,22 @@ class OT3Services(AbstractService):
         return self._service_info.image.image_name
 
     def __get_custom_env_vars(self) -> Optional[IntermediateEnvironmentVariables]:
-        image = self._service_info.image
+        service_info = self._service_info
+        robot = self._config_model.robot
         env_vars: IntermediateEnvironmentVariables | None = None
-        assert isinstance(self._config_model.robot, OT3InputModel)
-        match image:
-            case OT3PipettesImage():
-                env_vars = self._config_model.robot.pipettes_env_vars
-            case OT3GripperImage():
-                env_vars = self._config_model.robot.gripper_env_vars
-            case OT3HeadImage():
-                env_vars = self._config_model.robot.head_env_vars
-            case OT3GantryXImage():
-                env_vars = self._config_model.robot.gantry_x_env_vars
-            case OT3GantryYImage():
-                env_vars = self._config_model.robot.gantry_y_env_vars
-            case OT3BootloaderImage():
-                env_vars = self._config_model.robot.bootloader_env_vars
+        assert is_ot3(robot)
+        if service_info.is_pipette():
+            env_vars = robot.pipettes_env_vars
+        elif service_info.is_gripper():
+            env_vars = robot.gripper_env_vars
+        elif service_info.is_head():
+            env_vars = robot.head_env_vars
+        elif service_info.is_gantry_x():
+            env_vars = robot.gantry_x_env_vars
+        elif service_info.is_gantry_y():
+            env_vars = robot.gantry_y_env_vars
+        elif service_info.is_bootloader():
+            env_vars = robot.bootloader_env_vars
         return env_vars
 
     def generate_container_name(self) -> str:
@@ -134,15 +128,26 @@ class OT3Services(AbstractService):
 
     def generate_env_vars(self) -> Optional[IntermediateEnvironmentVariables]:
         """Generates value for environment parameter."""
-        env_vars: IntermediateEnvironmentVariables = {
-            "CAN_SERVER_HOST": self._can_server_service_name,
-        }
-        if not isinstance(self._service_info.image, OT3BootloaderImage):
-            env_vars["STATE_MANAGER_HOST"] = self._state_manager_name
-            env_vars["STATE_MANAGER_PORT"] = OT3_STATE_MANAGER_BOUND_PORT
+        service_info = self._service_info
+        env_vars: IntermediateEnvironmentVariables = {}
+        env_vars.update(self.DEFAULT_ENV_VARS)
 
-        if isinstance(self._service_info.image, (OT3PipettesImage, OT3GripperImage)):
-            env_vars["EEPROM_FILENAME"] = "eeprom.bin"
+        if not service_info.is_bootloader():
+            env_vars.update(
+                {
+                    "STATE_MANAGER_HOST": self._state_manager_name,
+                    "STATE_MANAGER_PORT": OT3_STATE_MANAGER_BOUND_PORT,
+                }
+            )
+
+        if service_info.is_pipette() or service_info.is_gripper():
+            env_vars["EEPROM_FILENAME"] = EEPROM_FILE_NAME
+
+        if service_info.is_left_pipette():
+            env_vars["MOUNT"] = "left"
+
+        if service_info.is_right_pipette():
+            env_vars["MOUNT"] = "right"
 
         custom_env_vars = self.__get_custom_env_vars()
         if custom_env_vars is not None:

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/ot3_services.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/ot3_services.py
@@ -113,9 +113,16 @@ class OT3Services(AbstractService):
 
     def generate_volumes(self) -> Optional[IntermediateVolumes]:
         """Generates value for volumes parameter."""
-        volumes = self._ot3_source.generate_emulator_mount_strings_from_hw(
+        volumes = self._ot3_source.generate_emulator_executable_mount_strings_from_hw(
             self._service_info.ot3_hardware
         )
+
+        if self._service_info.is_pipette() or self._service_info.is_gripper():
+            volumes.append(
+                self._ot3_source.generate_emulator_eeprom_mount_strings_from_hw(
+                    self._service_info.ot3_hardware
+                )
+            )
 
         self._logging_client.log_volumes(volumes)
         return volumes

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/service_info.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/service_info.py
@@ -5,6 +5,12 @@ from dataclasses import dataclass
 from emulation_system.compose_file_creator.config_file_settings import OT3Hardware
 from emulation_system.compose_file_creator.images import (
     FirmwareAndHardwareImages,
+    OT3BootloaderImage,
+    OT3GantryXImage,
+    OT3GantryYImage,
+    OT3GripperImage,
+    OT3HeadImage,
+    OT3PipettesImage,
     SingleImage,
 )
 
@@ -15,3 +21,35 @@ class ServiceInfo:
 
     image: FirmwareAndHardwareImages | SingleImage
     ot3_hardware: OT3Hardware
+
+    def is_head(self) -> bool:
+        """Whether the service is a head service."""
+        return isinstance(self.image, OT3HeadImage)
+
+    def is_gantry_x(self) -> bool:
+        """Whether the service is a gantry x service."""
+        return isinstance(self.image, OT3GantryXImage)
+
+    def is_gantry_y(self) -> bool:
+        """Whether the service is a gantry y service."""
+        return isinstance(self.image, OT3GantryYImage)
+
+    def is_pipette(self) -> bool:
+        """Whether the service is a pipette service."""
+        return isinstance(self.image, OT3PipettesImage)
+
+    def is_gripper(self) -> bool:
+        """Whether the service is a gripper service."""
+        return isinstance(self.image, OT3GripperImage)
+
+    def is_bootloader(self) -> bool:
+        """Whether the service is a bootloader service."""
+        return isinstance(self.image, OT3BootloaderImage)
+
+    def is_left_pipette(self) -> bool:
+        """Whether the service is a left pipette service."""
+        return self.ot3_hardware == OT3Hardware.LEFT_PIPETTE and self.is_pipette()
+
+    def is_right_pipette(self) -> bool:
+        """Whether the service is a left pipette service."""
+        return self.ot3_hardware == OT3Hardware.RIGHT_PIPETTE and self.is_pipette()

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/service_orchestrator.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/service_orchestrator.py
@@ -33,7 +33,8 @@ class ServiceOrchestrator:
 
     OT3_SERVICES_TO_CREATE = [
         ServiceInfo(OT3HeadImage(), OT3Hardware.HEAD),
-        ServiceInfo(OT3PipettesImage(), OT3Hardware.PIPETTES),
+        ServiceInfo(OT3PipettesImage(), OT3Hardware.LEFT_PIPETTE),
+        ServiceInfo(OT3PipettesImage(), OT3Hardware.RIGHT_PIPETTE),
         ServiceInfo(OT3GantryXImage(), OT3Hardware.GANTRY_X),
         ServiceInfo(OT3GantryYImage(), OT3Hardware.GANTRY_Y),
         ServiceInfo(OT3BootloaderImage(), OT3Hardware.BOOTLOADER),

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot2_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot2_model.py
@@ -6,24 +6,27 @@ from emulation_system.compose_file_creator.config_file_settings import (
     EmulationLevels,
     Hardware,
     OpentronsRepository,
-    PipetteSettings,
     SourceRepositories,
 )
+from emulation_system.compose_file_creator.pipette_utils import get_valid_ot2_pipettes
 from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediateEnvironmentVariables,
 )
 
-from ..hardware_specific_attributes import HardwareSpecificAttributes
-
 # cannot import from . because of circular import issue
-from .robot_model import RobotInputModel
+from .robot_model import RobotAttributes, RobotInputModel
 
 
-class OT2Attributes(HardwareSpecificAttributes):
-    """Attributes specific to OT2."""
+class OT2Attributes(RobotAttributes):
+    """Attributes specific to Robots."""
 
-    left_pipette: PipetteSettings = Field(default=PipetteSettings())
-    right_pipette: PipetteSettings = Field(default=PipetteSettings())
+    ####################################################
+    # NOTE: Calling a method to define types is WERID. #
+    #   Refer to pipette_utils.py for an explanation   #
+    ####################################################
+
+    left_pipette: get_valid_ot2_pipettes() | None = None  # type: ignore[valid-type]
+    right_pipette: get_valid_ot2_pipettes() | None = None  # type: ignore[valid-type]
 
 
 class OT2SourceRepositories(SourceRepositories):

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot3_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/ot3_model.py
@@ -8,26 +8,24 @@ from emulation_system.compose_file_creator.config_file_settings import (
     EmulationLevels,
     Hardware,
     OpentronsRepository,
-    PipetteSettings,
     SourceRepositories,
 )
+from emulation_system.compose_file_creator.pipette_utils import get_valid_ot3_pipettes
 from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediateEnvironmentVariables,
     IntermediatePorts,
 )
 from emulation_system.consts import OT3_STATE_MANAGER_BOUND_PORT
 
-from ..hardware_specific_attributes import HardwareSpecificAttributes
-
 # cannot import from . because of circular import issue
-from .robot_model import RobotInputModel
+from .robot_model import RobotAttributes, RobotInputModel
 
 
-class OT3Attributes(HardwareSpecificAttributes):
-    """Attributes specific to OT3."""
+class OT3Attributes(RobotAttributes):
+    """Attributes specific to Robots."""
 
-    left: PipetteSettings = Field(default=PipetteSettings())
-    right: PipetteSettings = Field(default=PipetteSettings())
+    left_pipette: get_valid_ot3_pipettes() | None = None  # type: ignore[valid-type]
+    right_pipette: get_valid_ot3_pipettes() | None = None  # type: ignore[valid-type]
 
 
 class OT3SourceRepositories(SourceRepositories):

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/robot_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/robots/robot_model.py
@@ -3,14 +3,27 @@
 Used to group all robots together and distinguish them from modules.
 """
 
+import abc
+from typing import TypeGuard
+
 from pydantic import Field
 
 from emulation_system.compose_file_creator.images import get_image_name
+from emulation_system.compose_file_creator.input.hardware_models.hardware_specific_attributes import (
+    HardwareSpecificAttributes,
+)
 from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediateEnvironmentVariables,
 )
 
 from ..hardware_model import HardwareModel
+
+
+class RobotAttributes(HardwareSpecificAttributes, abc.ABC):
+    """Attributes specific to Robots."""
+
+    left_pipette: str | None
+    right_pipette: str | None
 
 
 class RobotInputModel(HardwareModel):
@@ -24,6 +37,7 @@ class RobotInputModel(HardwareModel):
 
     robot_server_env_vars: IntermediateEnvironmentVariables | None
     emulator_proxy_env_vars: IntermediateEnvironmentVariables | None
+    hardware_specific_attributes: RobotAttributes
 
     def get_port_binding_string(self) -> str:
         """Get port binding string for Docker Compose file."""
@@ -32,3 +46,25 @@ class RobotInputModel(HardwareModel):
     def get_image_name(self) -> str:
         """Get image name to run based off of passed parameters."""
         return get_image_name(self.hardware, self.emulation_level)
+
+    @staticmethod
+    def _has_pipette(pipette: str | None) -> TypeGuard[str]:
+        return pipette is not None
+
+    def has_left_pipette(self) -> bool:
+        """Return True if left pipette is not None."""
+        return self._has_pipette(self.hardware_specific_attributes.left_pipette)
+
+    def has_right_pipette(self) -> bool:
+        """Return True if right pipette is not None."""
+        return self.hardware_specific_attributes.right_pipette is not None
+
+    @property
+    def right_pipette(self) -> str | None:
+        """Return right pipette."""
+        return self.hardware_specific_attributes.right_pipette
+
+    @property
+    def left_pipette(self) -> str | None:
+        """Return left pipette."""
+        return self.hardware_specific_attributes.left_pipette

--- a/emulation_system/emulation_system/compose_file_creator/output/runtime_compose_file_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/output/runtime_compose_file_model.py
@@ -56,12 +56,12 @@ class RuntimeComposeFileModel(ComposeSpecification):
         return service_list[0] if len(service_list) > 0 else None
 
     @property
-    def ot3_pipette_emulator(self) -> Optional[Service]:
+    def ot3_pipette_emulators(self) -> Optional[List[Service]]:
         """Returns OT3 Pipette service if one exists."""
         service_list = self.load_containers_by_filter(
             ContainerFilters.OT3_PIPETTES.container_filter_name
         )
-        return service_list[0] if len(service_list) > 0 else None
+        return service_list if len(service_list) > 0 else None
 
     @property
     def ot3_gripper_emulator(self) -> Optional[Service]:
@@ -159,7 +159,6 @@ class RuntimeComposeFileModel(ComposeSpecification):
             for prop in
             [
                 self.ot3_head_emulator,
-                self.ot3_pipette_emulator,
                 self.ot3_gantry_x_emulator,
                 self.ot3_gantry_y_emulator,
                 self.ot3_gripper_emulator,
@@ -167,6 +166,10 @@ class RuntimeComposeFileModel(ComposeSpecification):
             ]
             if prop is not None
         ]
+
+        if self.ot3_pipette_emulators is not None: 
+            emulator_list.extend(self.ot3_pipette_emulators)
+
         return emulator_list if len(emulator_list) > 0 else None
 
     @property

--- a/emulation_system/emulation_system/compose_file_creator/pipette_utils/__init__.py
+++ b/emulation_system/emulation_system/compose_file_creator/pipette_utils/__init__.py
@@ -1,11 +1,17 @@
 """Module for pipette utilities."""
 
 
+from enum import Enum
+
 from emulation_system.compose_file_creator.pipette_utils.data_models import (
     PipetteInfo,
     RobotPipettes,
 )
-from emulation_system.compose_file_creator.pipette_utils.lookups import lookup_pipette
+from emulation_system.compose_file_creator.pipette_utils.lookups import (
+    OT2PipetteLookup,
+    OT3PipetteLookup,
+    lookup_pipette,
+)
 
 
 def get_robot_pipettes(
@@ -24,3 +30,13 @@ def get_robot_pipettes(
     )
 
     return RobotPipettes(left=left_pipette_info, right=right_pipette_info)
+
+
+def get_valid_ot2_pipettes() -> Enum:
+    """Gets valid OT-2 pipettes."""
+    return OT2PipetteLookup.get_valid_pipette_names()
+
+
+def get_valid_ot3_pipettes() -> Enum:
+    """Gets valid OT-3 pipettes."""
+    return OT3PipetteLookup.get_valid_pipette_names()

--- a/emulation_system/emulation_system/source.py
+++ b/emulation_system/emulation_system/source.py
@@ -155,7 +155,7 @@ class EmulatorSourceMixin:
     """Mixin providing functionality to classes that require evaluation of hardware type."""
 
     @staticmethod
-    def generate_emulator_mount_strings_from_hw(
+    def generate_emulator_executable_mount_strings_from_hw(
         emulator_hw: OT3Hardware | Hardware,
     ) -> List[str]:
         """Method to generate mount strings based off of hardware."""
@@ -216,8 +216,22 @@ class OT3FirmwareSource(OpentronsBaseModel, Source, EmulatorSourceMixin):
     @staticmethod
     def _generate_emulator_executable_volumes() -> List[str]:
         return [
-            f"{member.named_volume_name}:{member.container_volume_storage_path}"
+            f"{member.executable_volume_name}:{member.builder_executable_volume_path}"
             for member in OT3Hardware.__members__.values()
+        ]
+
+    @staticmethod
+    def generate_emulator_eeprom_mount_strings_from_hw(
+        emulator_hw: OT3Hardware,
+    ) -> str:
+        """Method to generate mount strings based off of OT3Hardware."""
+        return f"{emulator_hw.eeprom_file_volume_name}:/eeprom"
+
+    @staticmethod
+    def _generate_builder_eeprom_mount_strings() -> List[str]:
+        return [
+            f"{member.eeprom_file_volume_name}:{member.eeprom_file_volume_storage_path}"
+            for member in OT3Hardware.eeprom_required_hardware()
         ]
 
     @classmethod
@@ -240,6 +254,7 @@ class OT3FirmwareSource(OpentronsBaseModel, Source, EmulatorSourceMixin):
             self.DEFAULT_BUILDER_VOLUMES
             + self._generate_emulator_executable_volumes()
             + self.generate_source_code_bind_mounts()
+            + self._generate_builder_eeprom_mount_strings()
         )
 
     @staticmethod
@@ -267,7 +282,7 @@ class OpentronsModulesSource(OpentronsBaseModel, Source, EmulatorSourceMixin):
     @staticmethod
     def _generate_emulator_executable_volumes() -> List[str]:
         return [
-            f"{hardware.named_volume_name}:{hardware.container_volume_storage_path}"
+            f"{hardware.executable_volume_name}:{hardware.builder_executable_volume_path}"
             for hardware in Hardware.opentrons_modules_hardware()
         ]
 

--- a/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_local_ot3_firmware_builder_builder.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_local_ot3_firmware_builder_builder.py
@@ -1,6 +1,6 @@
 """Tests to confirm that local-ot3-firmware-builder container is created correctly."""
 
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 import pytest
 from pydantic import parse_obj_as
@@ -48,7 +48,13 @@ def test_simple_values(
     assert "can-network" in service.networks
     assert service.command is None
     assert service.ports is None
-    assert service.environment is None
+
+    assert service.environment is not None
+    env_root = cast(Dict[str, Any], service.environment.__root__)
+    assert env_root is not None
+    assert len(env_root.values()) == 2
+    assert "LEFT_OT3_PIPETTE_DEFINITION" in env_root
+    assert "RIGHT_OT3_PIPETTE_DEFINITION" in env_root
 
 
 def test_local_ot3_firmware_remote_monorepo(

--- a/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_ot3_service_builder.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_ot3_service_builder.py
@@ -1,5 +1,5 @@
 """Tests to confirm that OT3Services builds the CAN Server Service correctly."""
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Tuple, cast
 
 import pytest
 from pydantic import parse_obj_as
@@ -24,6 +24,19 @@ def get_ot3_service(service_list: List[Service], hardware: OT3Hardware) -> Servi
             return service
 
     raise Exception(f"Service with hardware {hardware} not found.")
+
+
+def get_pipettes(service_list: List[Service]) -> Tuple[Service, Service]:
+    """Get Pipettes from passed service_list."""
+    pipette_list = []
+    for service in service_list:
+        assert service.image is not None
+        if "pipettes" in service.image:
+            pipette_list.append(service)
+
+    if len(pipette_list) != 2:
+        raise ValueError("Expected two pipettes, got {len(pipette_list)}")
+    return (pipette_list[0], pipette_list[1])
 
 
 @pytest.mark.parametrize(
@@ -54,14 +67,16 @@ def test_simple_ot3_values(
         can_server_service_name="can-server", state_manager_name="state-manager"
     )
     head = get_ot3_service(services, OT3Hardware.HEAD)
-    pipettes = get_ot3_service(services, OT3Hardware.PIPETTES)
+    pipette_1, pipette_2 = get_pipettes(services)
     gantry_x = get_ot3_service(services, OT3Hardware.GANTRY_X)
     gantry_y = get_ot3_service(services, OT3Hardware.GANTRY_Y)
     bootloader = get_ot3_service(services, OT3Hardware.BOOTLOADER)
     gripper = get_ot3_service(services, OT3Hardware.GRIPPER)
 
+    eeprom_services = [pipette_1, pipette_2, gripper]
+
     expected_dockerfile_name = DEV_DOCKERFILE_NAME if dev else DOCKERFILE_NAME
-    assert len(services) == 6
+    assert len(services) == 7
 
     for service in services:
         # Build
@@ -80,7 +95,10 @@ def test_simple_ot3_values(
         # Volumes
         volumes = service.volumes
         assert volumes is not None
-        assert len(volumes) == 2
+        if service in eeprom_services:
+            assert len(volumes) == 3
+        else:
+            assert len(volumes) == 2
         assert partial_string_in_mount("entrypoint.sh:/entrypoint.sh", service)
 
         assert service.container_name is not None
@@ -94,7 +112,10 @@ def test_simple_ot3_values(
 
     # Container Names
     assert head.container_name == OT3Hardware.HEAD
-    assert pipettes.container_name == OT3Hardware.PIPETTES
+    assert {pipette_1.container_name, pipette_2.container_name} == {
+        OT3Hardware.LEFT_PIPETTE,
+        OT3Hardware.RIGHT_PIPETTE,
+    }
     assert gantry_x.container_name == OT3Hardware.GANTRY_X
     assert gantry_y.container_name == OT3Hardware.GANTRY_Y
     assert bootloader.container_name == OT3Hardware.BOOTLOADER
@@ -123,13 +144,13 @@ def test_ot3_service_environment_variables(
         can_server_service_name="can-server", state_manager_name="state-manager"
     )
     # The number of items in ServiceOrchestrator.OT3_SERVICES_TO_CREATE
-    assert len(services) == 6
+    assert len(services) == 7
     head = get_ot3_service(services, OT3Hardware.HEAD)
     gantry_x = get_ot3_service(services, OT3Hardware.GANTRY_X)
     gantry_y = get_ot3_service(services, OT3Hardware.GANTRY_Y)
     bootloader = get_ot3_service(services, OT3Hardware.BOOTLOADER)
     gripper = get_ot3_service(services, OT3Hardware.GRIPPER)
-    pipettes = get_ot3_service(services, OT3Hardware.PIPETTES)
+    pipette_1, pipette_2 = get_pipettes(services)
 
     not_pipette_or_gripper_services = [head, gantry_x, gantry_y]
 
@@ -144,8 +165,8 @@ def test_ot3_service_environment_variables(
         assert "STATE_MANAGER_HOST" in env_root
         assert "STATE_MANAGER_PORT" in env_root
 
-    # Env vars 2/3
-    for service in [pipettes, gripper]:
+    # Env vars 2/4
+    for service in [gripper]:
         service_env = service.environment
         assert service_env is not None
         env_root = cast(Dict[str, Any], service_env.__root__)
@@ -156,7 +177,20 @@ def test_ot3_service_environment_variables(
         assert "STATE_MANAGER_HOST" in env_root
         assert "STATE_MANAGER_PORT" in env_root
 
-    # Env vars 3/3
+    # Env vars 3/4
+    for service in [pipette_1, pipette_2]:
+        service_env = service.environment
+        assert service_env is not None
+        env_root = cast(Dict[str, Any], service_env.__root__)
+        assert env_root is not None
+        assert len(env_root.values()) == 5
+        assert "MOUNT" in env_root
+        assert "CAN_SERVER_HOST" in env_root
+        assert "EEPROM_FILENAME" in env_root
+        assert "STATE_MANAGER_HOST" in env_root
+        assert "STATE_MANAGER_PORT" in env_root
+
+    # Env vars 4/4
     bootloader_service_env = bootloader.environment
     assert bootloader_service_env is not None
     bootloader_env_root = cast(Dict[str, Any], bootloader_service_env.__root__)

--- a/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_smoothie_service_builder.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_smoothie_service_builder.py
@@ -8,7 +8,6 @@ from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 
 from emulation_system import OpentronsEmulationConfiguration, SystemConfigurationModel
 from emulation_system.compose_file_creator import BuildItem
-from emulation_system.compose_file_creator.config_file_settings import PipetteSettings
 from emulation_system.compose_file_creator.conversion import SmoothieService
 from emulation_system.compose_file_creator.output.compose_file_model import ListOrDict
 from emulation_system.consts import DEV_DOCKERFILE_NAME, DOCKERFILE_NAME
@@ -61,10 +60,7 @@ def test_simple_smoothie_values(
     ).build_service()
 
     expected_dockerfile_name = DEV_DOCKERFILE_NAME if dev else DOCKERFILE_NAME
-    default_pipette_definition = {
-        "model": PipetteSettings().model,
-        "id": PipetteSettings().id,
-    }
+    default_pipette_definition = None
 
     assert service.container_name == "smoothie"
     assert service.image == "smoothie"

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_custom_env_vars.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_custom_env_vars.py
@@ -341,7 +341,8 @@ def test_ot3_env_vars(
     emulator_proxy = services[EMULATOR_PROXY_ID]
     can_server = services["can-server"]
     head = services["ot3-head"]
-    pipettes = services["ot3-pipettes"]
+    left_pipette = services["ot3-left-pipette"]
+    right_pipette = services["ot3-right-pipette"]
     gantry_x = services["ot3-gantry-x"]
     gantry_y = services["ot3-gantry-y"]
     bootloader = services["ot3-bootloader"]
@@ -351,7 +352,8 @@ def test_ot3_env_vars(
     assert emulator_proxy is not None
     assert can_server is not None
     assert head is not None
-    assert pipettes is not None
+    assert left_pipette is not None
+    assert right_pipette is not None
     assert gantry_x is not None
     assert gantry_y is not None
     assert bootloader is not None
@@ -361,7 +363,8 @@ def test_ot3_env_vars(
     assert emulator_proxy.environment is not None
     assert can_server.environment is not None
     assert head.environment is not None
-    assert pipettes.environment is not None
+    assert left_pipette.environment is not None
+    assert right_pipette.environment is not None
     assert gantry_x.environment is not None
     assert gantry_y.environment is not None
     assert bootloader.environment is not None
@@ -373,7 +376,8 @@ def test_ot3_env_vars(
     emulator_proxy_env = cast(Dict, emulator_proxy.environment.__root__)
     can_server_env = cast(Dict, can_server.environment.__root__)
     head_env = cast(Dict, head.environment.__root__)
-    pipettes_env = cast(Dict, pipettes.environment.__root__)
+    left_pipette_env = cast(Dict, left_pipette.environment.__root__)
+    right_pipette_env = cast(Dict, right_pipette.environment.__root__)
     gantry_x_env = cast(Dict, gantry_x.environment.__root__)
     gantry_y_env = cast(Dict, gantry_y.environment.__root__)
     bootloader_env = cast(Dict, bootloader.environment.__root__)
@@ -383,7 +387,8 @@ def test_ot3_env_vars(
     assert emulator_proxy_env is not None
     assert can_server_env is not None
     assert head_env is not None
-    assert pipettes_env is not None
+    assert left_pipette_env is not None
+    assert right_pipette_env is not None
     assert gantry_x_env is not None
     assert gantry_y_env is not None
     assert bootloader_env is not None
@@ -410,12 +415,19 @@ def test_ot3_env_vars(
     assert can_server_env["can-server-2"] == str(OT3_CAN_SERVER_VAL_2)
     assert can_server_env["can-server-3"] == str(OT3_CAN_SERVER_VAL_3)
 
-    assert "pipettes-1" in pipettes_env.keys()
-    assert "pipettes-2" in pipettes_env.keys()
-    assert "pipettes-3" in pipettes_env.keys()
-    assert pipettes_env["pipettes-1"] == str(OT3_PIPETTES_VAL_1)
-    assert pipettes_env["pipettes-2"] == str(OT3_PIPETTES_VAL_2)
-    assert pipettes_env["pipettes-3"] == str(OT3_PIPETTES_VAL_3)
+    assert "pipettes-1" in left_pipette_env.keys()
+    assert "pipettes-2" in left_pipette_env.keys()
+    assert "pipettes-3" in left_pipette_env.keys()
+    assert left_pipette_env["pipettes-1"] == str(OT3_PIPETTES_VAL_1)
+    assert left_pipette_env["pipettes-2"] == str(OT3_PIPETTES_VAL_2)
+    assert left_pipette_env["pipettes-3"] == str(OT3_PIPETTES_VAL_3)
+
+    assert "pipettes-1" in right_pipette_env.keys()
+    assert "pipettes-2" in right_pipette_env.keys()
+    assert "pipettes-3" in right_pipette_env.keys()
+    assert right_pipette_env["pipettes-1"] == str(OT3_PIPETTES_VAL_1)
+    assert right_pipette_env["pipettes-2"] == str(OT3_PIPETTES_VAL_2)
+    assert right_pipette_env["pipettes-3"] == str(OT3_PIPETTES_VAL_3)
 
     assert "gripper-1" in gripper_env.keys()
     assert "gripper-2" in gripper_env.keys()

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_extra_service_creation.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_extra_service_creation.py
@@ -124,7 +124,8 @@ def test_smoothie_not_created(
 @pytest.mark.parametrize(
     "container_name, expected_image_name",
     [
-        [OT3Hardware.PIPETTES.value, OT3PipettesImage().image_name],
+        [OT3Hardware.LEFT_PIPETTE.value, OT3PipettesImage().image_name],
+        [OT3Hardware.RIGHT_PIPETTE.value, OT3PipettesImage().image_name],
         [OT3Hardware.HEAD.value, OT3HeadImage().image_name],
         [OT3Hardware.GANTRY_X.value, OT3GantryXImage().image_name],
         [OT3Hardware.GANTRY_Y.value, OT3GantryYImage().image_name],

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_healthcheck.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_healthcheck.py
@@ -44,7 +44,7 @@ def test_ot3_services_heathcheck(
         and "ot3-firmware-builder" not in service.image
         and ("ot3" in service.image or "can-server" in service.image)
     ]
-    assert len(services_to_check) == 7
+    assert len(services_to_check) == 8
     for service in services_to_check:
         healthcheck = service.healthcheck
         assert healthcheck is None

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_source_code_insertion.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_source_code_insertion.py
@@ -245,16 +245,28 @@ def test_ot3_mounts(
 
     check_correct_number_of_volumes(monorepo_builder, 2 if monorepo_is_local else 1)
 
-    # Firmware builder should have the following volumes:
-    # 1 volume per emulator for copying the binaries over
-    # State Manager Venv
-    # State Manager Wheel
-    # build-host cache override
-    # stm32-tools cache override
-    # eeprom volume for left-pipette, right-pipette, and gripper
+    binary_volumes = len(emulators)
+    state_manager_volumes = 2
+    build_host_cache_override_volume = 1
+    stm32_tools_cache_override_volume = 1
+    eeprom_volumes = 3
+    ot3_firmware_bind_mount = 1 if ot3_firmware_is_local else 0
+    monorepo_bind_mount = 1 if monorepo_is_local else 0
+
+    ot3_firmware_builder_expected_vols = sum(
+        [
+            binary_volumes,
+            state_manager_volumes,
+            build_host_cache_override_volume,
+            stm32_tools_cache_override_volume,
+            eeprom_volumes,
+            ot3_firmware_bind_mount,
+            monorepo_bind_mount,
+        ]
+    )
 
     check_correct_number_of_volumes(
-        ot3_firmware_builder, len(emulators) + (5 if ot3_firmware_is_local else 4) + 3
+        ot3_firmware_builder, ot3_firmware_builder_expected_vols
     )
 
     assert partial_string_in_mount("entrypoint.sh:/entrypoint.sh", robot_server)

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_source_code_insertion.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_source_code_insertion.py
@@ -251,9 +251,10 @@ def test_ot3_mounts(
     # State Manager Wheel
     # build-host cache override
     # stm32-tools cache override
+    # eeprom volume for left-pipette, right-pipette, and gripper
 
     check_correct_number_of_volumes(
-        ot3_firmware_builder, len(emulators) + (5 if ot3_firmware_is_local else 4)
+        ot3_firmware_builder, len(emulators) + (5 if ot3_firmware_is_local else 4) + 3
     )
 
     assert partial_string_in_mount("entrypoint.sh:/entrypoint.sh", robot_server)
@@ -271,10 +272,19 @@ def test_ot3_mounts(
         )
 
     for emulator in emulators:
-        check_correct_number_of_volumes(emulator, 2)
+
         assert partial_string_in_mount("entrypoint.sh:/entrypoint.sh", emulator)
         assert emulator.image is not None
         hardware_name = emulator.image.replace("ot3-", "").replace("-hardware", "")
+        is_eeprom_service = "pipette" in hardware_name or "gripper" in hardware_name
+        if is_eeprom_service:
+            # left-pipette, right-pipette, and gripper all have eeprom volumes
+            check_correct_number_of_volumes(emulator, 3)
+        else:
+            check_correct_number_of_volumes(emulator, 2)
+
+        if "pipettes" in hardware_name:
+            hardware_name = hardware_name.replace("pipettes", "pipette")
 
         assert partial_string_in_mount(
             f"{hardware_name}-executable:/executable", emulator
@@ -282,7 +292,7 @@ def test_ot3_mounts(
 
         # Note checking volumes on ot3_firmware_builder here
         assert partial_string_in_mount(
-            f"{hardware_name}-executable:/volumes/{hardware_name}-volume",
+            f"{hardware_name}-executable:/volumes/",
             ot3_firmware_builder,
         )
 

--- a/emulation_system/tests/compose_file_creator/input/hardware_models/robots/test_ot2.py
+++ b/emulation_system/tests/compose_file_creator/input/hardware_models/robots/test_ot2.py
@@ -31,13 +31,8 @@ def ot2_bad_emulation_level(ot2_model: Dict[str, Any]) -> Dict[str, Any]:
 def ot2_with_pipettes(ot2_model: Dict[str, Any]) -> Dict[str, Any]:
     """OT-2 using user-specified pipettes."""
     hardware_specific_attributes = ot2_model["hardware-specific-attributes"]
-    hardware_specific_attributes["left-pipette"] = {}
-    hardware_specific_attributes["left-pipette"]["model"] = "test_1"
-    hardware_specific_attributes["left-pipette"]["id"] = "test_1_id"
-
-    hardware_specific_attributes["right-pipette"] = {}
-    hardware_specific_attributes["right-pipette"]["model"] = "test_2"
-    hardware_specific_attributes["right-pipette"]["id"] = "test_2_id"
+    hardware_specific_attributes["left-pipette"] = "P20 Single"
+    hardware_specific_attributes["right-pipette"] = "P300 Multi"
     return ot2_model
 
 
@@ -49,10 +44,8 @@ def test_default_ot2(ot2_model: Dict[str, Any]) -> None:
     assert ot2.emulation_level == EmulationLevels.FIRMWARE.value
     assert ot2.exposed_port == 5000
     assert ot2.bound_port == 31950
-    assert ot2.hardware_specific_attributes.left_pipette.model == "p20_single_v2.0"
-    assert ot2.hardware_specific_attributes.left_pipette.id == "P20SV202020070101"
-    assert ot2.hardware_specific_attributes.right_pipette.model == "p20_single_v2.0"
-    assert ot2.hardware_specific_attributes.right_pipette.id == "P20SV202020070101"
+    assert ot2.hardware_specific_attributes.left_pipette is None
+    assert ot2.hardware_specific_attributes.right_pipette is None
     assert ot2.source_repos.firmware_repo_name == OpentronsRepository.OPENTRONS
     assert ot2.source_repos.hardware_repo_name is None
 
@@ -67,10 +60,8 @@ def test_ot2_with_overridden_bound_port(
     assert ot2.emulation_level == EmulationLevels.FIRMWARE.value
     assert ot2.exposed_port == 5000
     assert ot2.bound_port == 2500
-    assert ot2.hardware_specific_attributes.left_pipette.model == "p20_single_v2.0"
-    assert ot2.hardware_specific_attributes.left_pipette.id == "P20SV202020070101"
-    assert ot2.hardware_specific_attributes.right_pipette.model == "p20_single_v2.0"
-    assert ot2.hardware_specific_attributes.right_pipette.id == "P20SV202020070101"
+    assert ot2.hardware_specific_attributes.left_pipette is None
+    assert ot2.hardware_specific_attributes.right_pipette is None
 
 
 def test_ot2_with_custom_pipettes(ot2_with_pipettes: Dict[str, Any]) -> None:
@@ -81,10 +72,8 @@ def test_ot2_with_custom_pipettes(ot2_with_pipettes: Dict[str, Any]) -> None:
     assert ot2.emulation_level == EmulationLevels.FIRMWARE.value
     assert ot2.exposed_port == 5000
     assert ot2.bound_port == 31950
-    assert ot2.hardware_specific_attributes.left_pipette.model == "test_1"
-    assert ot2.hardware_specific_attributes.left_pipette.id == "test_1_id"
-    assert ot2.hardware_specific_attributes.right_pipette.model == "test_2"
-    assert ot2.hardware_specific_attributes.right_pipette.id == "test_2_id"
+    assert ot2.hardware_specific_attributes.left_pipette == "P20 Single"
+    assert ot2.hardware_specific_attributes.right_pipette == "P300 Multi"
 
 
 def test_ot2_with_bad_emulation_level(ot2_bad_emulation_level: Dict[str, Any]) -> None:

--- a/emulation_system/tests/e2e/consts.py
+++ b/emulation_system/tests/e2e/consts.py
@@ -48,31 +48,35 @@ STATE_MANAGER_WHEEL_VOLUME = NamedVolumeInfo.from_string(
 ENTRYPOINT_MOUNT = BindMountInfo(ENTRYPOINT_FILE_LOCATION, "/entrypoint.sh")
 MONOREPO_WHEEL_VOLUME = NamedVolumeInfo.from_string(MONOREPO_NAMED_VOLUME_STRING)
 OT3_FIRMWARE_BUILDER_NAMED_VOLUMES = {
-    NamedVolumeInfo("gantry-x-executable", "/volumes/gantry-x-volume"),
-    NamedVolumeInfo("gantry-y-executable", "/volumes/gantry-y-volume"),
-    NamedVolumeInfo("head-executable", "/volumes/head-volume"),
-    NamedVolumeInfo("gripper-executable", "/volumes/gripper-volume"),
-    NamedVolumeInfo("pipettes-executable", "/volumes/pipettes-volume"),
-    NamedVolumeInfo("bootloader-executable", "/volumes/bootloader-volume"),
+    NamedVolumeInfo.from_string(OT3_FIRMWARE_BUILDER_BUILD_HOST_CACHE_OVERRIDE_VOLUME),
     NamedVolumeInfo.from_string(
         OT3_FIRMWARE_BUILDER_STATE_MANAGER_VENV_NAMED_VOLUME_STRING
     ),
     NamedVolumeInfo.from_string(
         OT3_FIRMWARE_BUILDER_STATE_MANAGER_WHEEL_NAMED_VOLUME_STRING
     ),
-    NamedVolumeInfo.from_string(OT3_FIRMWARE_BUILDER_BUILD_HOST_CACHE_OVERRIDE_VOLUME),
     NamedVolumeInfo.from_string(OT3_FIRMWARE_BUILDER_STM32_TOOLS_CACHE_OVERRIDE_VOLUME),
+    NamedVolumeInfo("bootloader-executable", "/volumes/bootloader-executable"),
+    NamedVolumeInfo("gantry-x-executable", "/volumes/gantry-x-executable"),
+    NamedVolumeInfo("gantry-y-executable", "/volumes/gantry-y-executable"),
+    NamedVolumeInfo("gripper-eeprom", "/volumes/gripper-eeprom"),
+    NamedVolumeInfo("gripper-executable", "/volumes/gripper-executable"),
+    NamedVolumeInfo("head-executable", "/volumes/head-executable"),
+    NamedVolumeInfo("left-pipette-eeprom", "/volumes/left-pipette-eeprom"),
+    NamedVolumeInfo("left-pipette-executable", "/volumes/left-pipette-executable"),
+    NamedVolumeInfo("right-pipette-eeprom", "/volumes/right-pipette-eeprom"),
+    NamedVolumeInfo("right-pipette-executable", "/volumes/right-pipette-executable"),
 }
 
 OPENTRONS_MODULES_BUILDER_NAMED_VOLUMES = {
-    NamedVolumeInfo("heater-shaker-executable", "/volumes/heater-shaker-volume"),
-    NamedVolumeInfo("thermocycler-executable", "/volumes/thermocycler-volume"),
     NamedVolumeInfo.from_string(
         OPENTRONS_MODULES_BUILDER_BUILD_HOST_CACHE_OVERRIDE_VOLUME
     ),
     NamedVolumeInfo.from_string(
         OPENTRONS_MODULES_BUILDER_STM32_TOOLS_CACHE_OVERRIDE_VOLUME
     ),
+    NamedVolumeInfo("heater-shaker-executable", "/volumes/heater-shaker-executable"),
+    NamedVolumeInfo("thermocycler-executable", "/volumes/thermocycler-executable"),
 }
 
 
@@ -80,12 +84,22 @@ OPENTRONS_MODULES_BUILDER_NAMED_VOLUMES = {
 class OT3FirmwareEmulatorNamedVolumesMap:
     """Class representing expected named volume for each OT-3 emulator container."""
 
+    BOOTLOADER = NamedVolumeInfo("bootloader-executable", "/executable")
     GANTRY_X = NamedVolumeInfo("gantry-x-executable", "/executable")
     GANTRY_Y = NamedVolumeInfo("gantry-y-executable", "/executable")
+    GRIPPER = {
+        NamedVolumeInfo("gripper-executable", "/executable"),
+        NamedVolumeInfo("gripper-eeprom", "/eeprom"),
+    }
     HEAD = NamedVolumeInfo("head-executable", "/executable")
-    GRIPPER = NamedVolumeInfo("gripper-executable", "/executable")
-    PIPETTES = NamedVolumeInfo("pipettes-executable", "/executable")
-    BOOTLOADER = NamedVolumeInfo("bootloader-executable", "/executable")
+    LEFT_PIPETTE = {
+        NamedVolumeInfo("left-pipette-executable", "/executable"),
+        NamedVolumeInfo("left-pipette-eeprom", "/eeprom"),
+    }
+    RIGHT_PIPETTE = {
+        NamedVolumeInfo("right-pipette-executable", "/executable"),
+        NamedVolumeInfo("right-pipette-eeprom", "/eeprom"),
+    }
 
 
 @dataclass(frozen=True)
@@ -100,17 +114,26 @@ class OpentronsModulesEmulatorNamedVolumes:
 class OT3FirmwareExpectedBinaryNames:
     """Exepected names of OT-3 Firmware binary executables."""
 
+    BOOTLOADER = "bootloader-simulator"
     GANTRY_X = "gantry-x-simulator"
     GANTRY_Y = "gantry-y-simulator"
-    HEAD = "head-simulator"
     GRIPPER = "gripper-simulator"
-    PIPETTES = "pipettes-simulator"
-    BOOTLOADER = "bootloader-simulator"
+    HEAD = "head-simulator"
+    LEFT_PIPETTE = {
+        "pipettes-96-simulator",
+        "pipettes-multi-simulator",
+        "pipettes-single-simulator",
+    }
+    RIGHT_PIPETTE = {
+        "pipettes-96-simulator",
+        "pipettes-multi-simulator",
+        "pipettes-single-simulator",
+    }
 
 
 @dataclass(frozen=True)
 class ModulesExpectedBinaryNames:
     """Expecte names of opentrons-modules binary executableds."""
 
-    THERMOCYCLER = "thermocycler-simulator"
     HEATER_SHAKER = "heater-shaker-simulator"
+    THERMOCYCLER = "thermocycler-simulator"

--- a/emulation_system/tests/e2e/dataclass_helpers.py
+++ b/emulation_system/tests/e2e/dataclass_helpers.py
@@ -27,10 +27,14 @@ def __inner_convert_to_dict(obj):  # noqa: ANN001, ANN202
         return type(obj)(__inner_convert_to_dict(v) for v in obj)
     elif isinstance(obj, set):
         if len(obj) > 1:
-            return {
-                frozenset((k, v) for k, v in __inner_convert_to_dict(instance).items())
-                for instance in obj
-            }
+            a_set = set()
+            for instance in obj:
+                converted = __inner_convert_to_dict(instance)
+                if isinstance(converted, dict):
+                    a_set.add(frozenset((k, v) for k, v in converted.items()))
+                else:
+                    a_set.add(converted)
+            return a_set
         else:
             return obj
 

--- a/emulation_system/tests/e2e/docker_interface/ot3_containers.py
+++ b/emulation_system/tests/e2e/docker_interface/ot3_containers.py
@@ -20,7 +20,8 @@ class OT3SystemUnderTest:
     gantry_y: Container
     head: Container
     gripper: Container
-    pipettes: Container
+    left_pipette: Container
+    right_pipette: Container
     bootloader: Container
     state_manager: Container
     can_server: Container

--- a/emulation_system/tests/e2e/helper_functions.py
+++ b/emulation_system/tests/e2e/helper_functions.py
@@ -1,6 +1,6 @@
 """Module containing pure functions to retrieve general information from Docker containers."""
 
-from typing import Iterable, List, Optional, Set
+from typing import Dict, Iterable, List, Optional, Set
 
 import docker  # type: ignore[import]
 from docker.errors import NotFound as ContainerNotFoundError  # type: ignore[import]
@@ -40,6 +40,20 @@ def get_mounts(container: Optional[Container]) -> Set[BindMountInfo]:
             if mount["Type"] == "bind"
         }
     )
+
+
+def get_environment_variables(container: Optional[Container]) -> Dict[str, str]:
+    """Gets a list of environment variables for a docker container.
+
+    Returns None if no environment variables exist
+    """
+    if container is None:
+        return {}
+    else:
+        env_var_list = container.attrs["Config"]["Env"]
+        return {
+            env_var.split("=")[0]: env_var.split("=")[1] for env_var in env_var_list
+        }
 
 
 def get_container_names(containers: Iterable[Container]) -> Set[str]:

--- a/emulation_system/tests/e2e/results/ot3_results.py
+++ b/emulation_system/tests/e2e/results/ot3_results.py
@@ -29,7 +29,8 @@ class OT3EmulatorContainers(ResultABC):
     gantry_x_exists: bool
     gantry_y_exists: bool
     gripper_exists: bool
-    pipettes_exists: bool
+    left_pipette_exists: bool
+    right_pipette_exists: bool
     bootloader_exists: bool
     can_server_exists: bool
 
@@ -48,7 +49,8 @@ class OT3EmulatorContainers(ResultABC):
                 gantry_x_exists=True,
                 gantry_y_exists=True,
                 gripper_exists=True,
-                pipettes_exists=True,
+                left_pipette_exists=True,
+                right_pipette_exists=True,
                 bootloader_exists=True,
                 can_server_exists=True,
             )
@@ -59,7 +61,8 @@ class OT3EmulatorContainers(ResultABC):
                 gantry_x_exists=False,
                 gantry_y_exists=False,
                 gripper_exists=False,
-                pipettes_exists=False,
+                left_pipette_exists=False,
+                right_pipette_exists=False,
                 bootloader_exists=False,
                 can_server_exists=False,
             )
@@ -77,7 +80,10 @@ class OT3EmulatorContainers(ResultABC):
             gantry_x_exists=system_under_test.ot3_containers.gantry_x is not None,
             gantry_y_exists=system_under_test.ot3_containers.gantry_y is not None,
             gripper_exists=system_under_test.ot3_containers.gripper is not None,
-            pipettes_exists=system_under_test.ot3_containers.pipettes is not None,
+            left_pipette_exists=system_under_test.ot3_containers.left_pipette
+            is not None,
+            right_pipette_exists=system_under_test.ot3_containers.right_pipette
+            is not None,
             bootloader_exists=system_under_test.ot3_containers.bootloader is not None,
             can_server_exists=system_under_test.ot3_containers.can_server is not None,
         )
@@ -91,7 +97,8 @@ class OT3EmulatorNamedVolumes(ResultABC):
     gantry_x_volumes: Set[NamedVolumeInfo]
     gantry_y_volumes: Set[NamedVolumeInfo]
     gripper_volumes: Set[NamedVolumeInfo]
-    pipettes_volumes: Set[NamedVolumeInfo]
+    left_pipette_volumes: Set[NamedVolumeInfo]
+    right_pipette_volumes: Set[NamedVolumeInfo]
     bootloader_volumes: Set[NamedVolumeInfo]
 
     @classmethod
@@ -103,8 +110,9 @@ class OT3EmulatorNamedVolumes(ResultABC):
             head_volumes={OT3FirmwareEmulatorNamedVolumesMap.HEAD},
             gantry_x_volumes={OT3FirmwareEmulatorNamedVolumesMap.GANTRY_X},
             gantry_y_volumes={OT3FirmwareEmulatorNamedVolumesMap.GANTRY_Y},
-            gripper_volumes={OT3FirmwareEmulatorNamedVolumesMap.GRIPPER},
-            pipettes_volumes={OT3FirmwareEmulatorNamedVolumesMap.PIPETTES},
+            gripper_volumes=OT3FirmwareEmulatorNamedVolumesMap.GRIPPER,
+            left_pipette_volumes=OT3FirmwareEmulatorNamedVolumesMap.LEFT_PIPETTE,
+            right_pipette_volumes=OT3FirmwareEmulatorNamedVolumesMap.RIGHT_PIPETTE,
             bootloader_volumes={OT3FirmwareEmulatorNamedVolumesMap.BOOTLOADER},
         )
 
@@ -118,7 +126,12 @@ class OT3EmulatorNamedVolumes(ResultABC):
             gantry_x_volumes=get_volumes(system_under_test.ot3_containers.gantry_x),
             gantry_y_volumes=get_volumes(system_under_test.ot3_containers.gantry_y),
             gripper_volumes=get_volumes(system_under_test.ot3_containers.gripper),
-            pipettes_volumes=get_volumes(system_under_test.ot3_containers.pipettes),
+            left_pipette_volumes=get_volumes(
+                system_under_test.ot3_containers.left_pipette
+            ),
+            right_pipette_volumes=get_volumes(
+                system_under_test.ot3_containers.right_pipette
+            ),
             bootloader_volumes=get_volumes(system_under_test.ot3_containers.bootloader),
         )
 
@@ -158,7 +171,8 @@ class OT3EmulatorMounts(ResultABC):
     gantry_x_mounts: Set[BindMountInfo]
     gantry_y_mounts: Set[BindMountInfo]
     gripper_mounts: Set[BindMountInfo]
-    pipettes_mounts: Set[BindMountInfo]
+    left_pipette_mounts: Set[BindMountInfo]
+    right_pipette_mounts: Set[BindMountInfo]
     bootloader_mounts: Set[BindMountInfo]
 
     @classmethod
@@ -171,7 +185,12 @@ class OT3EmulatorMounts(ResultABC):
             gantry_x_mounts=get_mounts(system_under_test.ot3_containers.gantry_x),
             gantry_y_mounts=get_mounts(system_under_test.ot3_containers.gantry_y),
             gripper_mounts=get_mounts(system_under_test.ot3_containers.gripper),
-            pipettes_mounts=get_mounts(system_under_test.ot3_containers.pipettes),
+            left_pipette_mounts=get_mounts(
+                system_under_test.ot3_containers.left_pipette
+            ),
+            right_pipette_mounts=get_mounts(
+                system_under_test.ot3_containers.right_pipette
+            ),
             bootloader_mounts=get_mounts(system_under_test.ot3_containers.bootloader),
         )
 
@@ -185,7 +204,8 @@ class OT3EmulatorMounts(ResultABC):
             gantry_x_mounts={ENTRYPOINT_MOUNT},
             gantry_y_mounts={ENTRYPOINT_MOUNT},
             gripper_mounts={ENTRYPOINT_MOUNT},
-            pipettes_mounts={ENTRYPOINT_MOUNT},
+            left_pipette_mounts={ENTRYPOINT_MOUNT},
+            right_pipette_mounts={ENTRYPOINT_MOUNT},
             bootloader_mounts={ENTRYPOINT_MOUNT},
         )
 
@@ -228,7 +248,8 @@ class OT3Binaries(ResultABC):
     gantry_x_binary_name: str
     gantry_y_binary_name: str
     gripper_binary_name: str
-    pipettes_binary_name: str
+    left_pipette_binary_names: Set[str]
+    right_pipette_binary_names: Set[str]
     bootloader_binary_name: str
 
     @classmethod
@@ -241,7 +262,8 @@ class OT3Binaries(ResultABC):
             gantry_x_binary_name=OT3FirmwareExpectedBinaryNames.GANTRY_X,
             gantry_y_binary_name=OT3FirmwareExpectedBinaryNames.GANTRY_Y,
             gripper_binary_name=OT3FirmwareExpectedBinaryNames.GRIPPER,
-            pipettes_binary_name=OT3FirmwareExpectedBinaryNames.PIPETTES,
+            left_pipette_binary_names=OT3FirmwareExpectedBinaryNames.LEFT_PIPETTE,
+            right_pipette_binary_names=OT3FirmwareExpectedBinaryNames.RIGHT_PIPETTE,
             bootloader_binary_name=OT3FirmwareExpectedBinaryNames.BOOTLOADER,
         )
 
@@ -263,8 +285,15 @@ class OT3Binaries(ResultABC):
             gripper_binary_name=exec_in_container(
                 system_under_test.ot3_containers.gripper, "ls /executable"
             ),
-            pipettes_binary_name=exec_in_container(
-                system_under_test.ot3_containers.pipettes, "ls /executable"
+            left_pipette_binary_names=set(
+                exec_in_container(
+                    system_under_test.ot3_containers.left_pipette, "ls /executable"
+                ).split("\n")
+            ),
+            right_pipette_binary_names=set(
+                exec_in_container(
+                    system_under_test.ot3_containers.right_pipette, "ls /executable"
+                ).split("\n")
             ),
             bootloader_binary_name=exec_in_container(
                 system_under_test.ot3_containers.bootloader, "ls /executable"


### PR DESCRIPTION
> NOTE: Probably easiest to view each commit individually!!


# Overview

Rework pipettes to allow for specification of pipettes on emulated Flex

- Integrate `pipette_utils` package into the repo's `compose-file-creator` framework
- Separate singular Flex pipette container into `left` and `right` pipette containers
- Add Flex "Pipette Configuration" environment variable to ot3-firmware-builder in prep for eeprom file generation script
- Add eeprom volumes to facillitate ot3-firmware-builder pushing eeprom.bin files into pipette and gripper containers

# Changelog

Change notes are captured inside of each commit to this PR.
View them [here](https://github.com/Opentrons/opentrons-emulation/pull/261/commits)

# Review requests

- [x] Please help me evaluate if Pytest & e2e test coverage adequately mitigates risks 

# Risk assessment

**High Risk** for the following reasons:

- [Volume naming changes](https://github.com/Opentrons/opentrons-emulation/pull/261/commits/20b512dbcced7d63a8d0a1dcb4337ed5c91336f0) / [Addition of eeprom volumes](https://github.com/Opentrons/opentrons-emulation/pull/261/commits/20b512dbcced7d63a8d0a1dcb4337ed5c91336f0) - If naming doesn't match up everything will explode
- [Separating pipette container](https://github.com/Opentrons/opentrons-emulation/pull/261/commits/7ddb1bee8e5c0a1ba19ca65bb7b6c5c30de1638e) - Been a single container for so long. Need to make sure any edge cases of this new paradigm are handled correctly

Good news is I added test coverage for all these things. But who knows, I could have screwed that up.