### PR TITLE
fix: Fix emulation failing to build

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -7,6 +7,7 @@ on:
       - 'release-*'
   pull_request:
     paths:
+      - 'docker/**'
       - 'emulation_system/**'
       - '.github/workflows/e2e-tests.yaml'
       - '.github/actions/**'

--- a/.github/workflows/emulation-system-lint-test.yaml
+++ b/.github/workflows/emulation-system-lint-test.yaml
@@ -10,6 +10,7 @@ on:
       - 'release-*'
   pull_request:
     paths:
+      - 'docker/**'
       - 'emulation_system/**'
       - '.github/workflows/emulation-system-lint-test.yaml'
       - '.github/actions/**'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -119,24 +119,14 @@ ENV OPENTRONS_HARDWARE "can-server"
 #######################
 
 FROM ghcr.io/opentrons/cpp-base-${TARGETARCH}:latest as ot3-firmware-source
-ARG FIRMWARE_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/ot3-firmware/archive/refs/heads/main.zip"
-ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons/archive/refs/heads/edge.zip"
+ARG FIRMWARE_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/ot3-firmware.git#main"
+ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons.git#edge"
 
 ENV FIRMWARE_SOURCE_DOWNLOAD_LOCATION=$FIRMWARE_SOURCE_DOWNLOAD_LOCATION
 ENV OPENTRONS_SOURCE_DOWNLOAD_LOCATION=$OPENTRONS_SOURCE_DOWNLOAD_LOCATION
 
-ADD --keep-git-dir=true $FIRMWARE_SOURCE_DOWNLOAD_LOCATION /ot3-firmware.zip
-ADD --keep-git-dir=true $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons.zip
-
-RUN (cd / &&  \
-    unzip -q ot3-firmware.zip && \
-    rm -f ot3-firmware.zip && \
-    mv ot3-firmware* ot3-firmware)
-
-RUN (cd / &&  \
-    unzip -q opentrons.zip && \
-    rm -f opentrons.zip && \
-    mv opentrons* opentrons)
+ADD --keep-git-dir=true $FIRMWARE_SOURCE_DOWNLOAD_LOCATION /ot3-firmware
+ADD --keep-git-dir=true $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons
 
 FROM ot3-firmware-source as ot3-firmware-builder
 COPY entrypoints/ot3_firmware_builder.sh /build.sh
@@ -147,7 +137,7 @@ COPY scripts/selective_monorepo_builder.sh /selective_monorepo_builder.sh
 ##################
 
 FROM ghcr.io/opentrons/cpp-base-${TARGETARCH}:latest as opentrons-modules-source
-ARG MODULE_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons-modules/archive/refs/heads/edge.zip"
+ARG MODULE_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons-modules.git#edge"
 
 ENV MODULE_SOURCE_DOWNLOAD_LOCATION=$MODULE_SOURCE_DOWNLOAD_LOCATION
 
@@ -163,16 +153,11 @@ COPY entrypoints/opentrons_modules_builder.sh /build.sh
 
 FROM ghcr.io/opentrons/python-base:latest as opentrons-source
 
-ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons/archive/refs/heads/edge.zip"
+ARG OPENTRONS_SOURCE_DOWNLOAD_LOCATION="https://github.com/Opentrons/opentrons.git#edge"
 
 ENV OPENTRONS_SOURCE_DOWNLOAD_LOCATION=$OPENTRONS_SOURCE_DOWNLOAD_LOCATION
 
-ADD  --keep-git-dir=true $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons.zip
-
-RUN (cd / &&  \
-    unzip -q opentrons.zip && \
-    rm -f opentrons.zip && \
-    mv opentrons* opentrons)
+ADD  --keep-git-dir=true $OPENTRONS_SOURCE_DOWNLOAD_LOCATION /opentrons
 
 FROM opentrons-source as monorepo-builder
 COPY entrypoints/monorepo_builder.sh /build.sh


### PR DESCRIPTION
# Overview

Emulation was failing during the docker build stage (not the source code build stage). 

I had an old version of docker-compose on my laptop and the `ADD` command worked different on my laptop compared to CI or my server. 

# Changelog

- Not getting zipfile anymore. 
- Based on docker documentation, https://docs.docker.com/engine/reference/builder/#adding-a-git-repository-add-git-ref-dir , I should be adding the .git version of the repo. 
- Now it just downloads that whole repo as a folder. Way nicer
- So no need for unzip and mv command

# Review requests

None

# Risk assessment

Low, I mean I could break it MORE. But it's currently unusable so the only one that would suffer would be me.
