### PR TITLE
feat: Add support for empty pipette mounts

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/pipette_utils/__init__.py
+++ b/emulation_system/emulation_system/compose_file_creator/pipette_utils/__init__.py
@@ -21,12 +21,12 @@ def get_robot_pipettes(
     left_pipette_info = (
         None
         if left_pipette is None
-        else PipetteInfo(lookup_pipette(left_pipette, robot_type))
+        else PipetteInfo.from_pipette_lookup(lookup_pipette(left_pipette, robot_type))
     )
     right_pipette_info = (
         None
         if not right_pipette is not None
-        else PipetteInfo(lookup_pipette(right_pipette, robot_type))
+        else PipetteInfo.from_pipette_lookup(lookup_pipette(right_pipette, robot_type))
     )
 
     return RobotPipettes(left=left_pipette_info, right=right_pipette_info)

--- a/emulation_system/emulation_system/compose_file_creator/pipette_utils/data_models.py
+++ b/emulation_system/emulation_system/compose_file_creator/pipette_utils/data_models.py
@@ -38,6 +38,7 @@ def generate_eeprom_file_path(mount: Literal["left", "right"]) -> str:
     """Generates eeprom file path."""
     return f"/volumes/{mount}-pipette-eeprom/{_get_eeprom_file_name()}"
 
+
 @dataclass
 class PipetteInfo:
     """Class for pipette info."""
@@ -50,9 +51,10 @@ class PipetteInfo:
     serial_code: str
     eeprom_file_name: str
 
-
     @classmethod
-    def from_pipette_lookup(cls, pipette_lookup: Union["OT2PipetteLookup", "OT3PipetteLookup"]) -> "PipetteInfo":
+    def from_pipette_lookup(
+        cls, pipette_lookup: Union["OT2PipetteLookup", "OT3PipetteLookup"]
+    ) -> "PipetteInfo":
         """Creates pipette info from pipette lookup."""
         return cls(
             display_name=pipette_lookup.display_name,
@@ -63,7 +65,7 @@ class PipetteInfo:
             serial_code=_get_date_string(),
             eeprom_file_name=_get_eeprom_file_name(),
         )
-    
+
     @classmethod
     def EMPTY(cls) -> "PipetteInfo":
         """Creates empty pipette info."""
@@ -74,7 +76,7 @@ class PipetteInfo:
             pipette_type=PipetteTypes.SINGLE,
             model=-1,
             serial_code="",
-            eeprom_file_name=_get_eeprom_file_name()
+            eeprom_file_name=_get_eeprom_file_name(),
         )
 
     @property

--- a/samples/ot3/ot3_local.yaml
+++ b/samples/ot3/ot3_local.yaml
@@ -14,7 +14,6 @@ robot:
   id: otie
   hardware: ot3
   emulation-level: hardware
-  hardware-specific-attributes:
-    left-pipette: P1000 Multi
   
-monorepo-source: /home/server-user/opentrons
+monorepo-source: /absolute/path/to/opentrons
+ot3-firmware-source: /absolute/path/to/ot3-firmware

--- a/samples/ot3/ot3_local.yaml
+++ b/samples/ot3/ot3_local.yaml
@@ -14,6 +14,7 @@ robot:
   id: otie
   hardware: ot3
   emulation-level: hardware
+  hardware-specific-attributes:
+    left-pipette: P1000 Multi
   
-monorepo-source: /absolute/path/to/opentrons
-ot3-firmware-source: /absolute/path/to/ot3-firmware
+monorepo-source: /home/server-user/opentrons


### PR DESCRIPTION
# Overview

Add special case when a mount does not have pipette

# Changelog

- Added EMPTY classmethod om PipetteInfo to generate what an empty pipette is mounted.
- When pipette is not specifed automatically use EMPTY pipette type

# Review requests

None

# Risk assessment

Low
