### PR TITLE
test: Add validation that pipette eeproms are created correctly

### DIFF
--- a/emulation_system/tests/e2e/system_mappings.py
+++ b/emulation_system/tests/e2e/system_mappings.py
@@ -25,6 +25,8 @@ OT3_REMOTE = SystemTestDefinition(
     ot3_firmware_build_args=BuildArgConfigurations.LATEST_BUILD_ARGS,
     opentrons_modules_build_args=BuildArgConfigurations.NO_BUILD_ARGS,
     module_configuration=ModuleConfiguration.NO_MODULES(),
+    left_pipette_expected=True,
+    right_pipette_expected=False,
 )
 
 OT3_FIRMWARE_DEV = SystemTestDefinition(
@@ -42,6 +44,8 @@ OT3_FIRMWARE_DEV = SystemTestDefinition(
     ot3_firmware_build_args=BuildArgConfigurations.LATEST_BUILD_ARGS,
     opentrons_modules_build_args=BuildArgConfigurations.NO_BUILD_ARGS,
     module_configuration=ModuleConfiguration.NO_MODULES(),
+    left_pipette_expected=False,
+    right_pipette_expected=True,
 )
 
 OT3_AND_MODULES = SystemTestDefinition(
@@ -64,6 +68,8 @@ OT3_AND_MODULES = SystemTestDefinition(
         fw_magnetic_module_names={"ot3-and-modules-magdeck"},
         fw_temperature_module_names={"ot3-and-modules-tempdeck"},
     ),
+    left_pipette_expected=True,
+    right_pipette_expected=True,
 )
 
 _TEST_DEFS: Dict[str, SystemTestDefinition] = {

--- a/emulation_system/tests/e2e/test_definition/system_test_definition.py
+++ b/emulation_system/tests/e2e/test_definition/system_test_definition.py
@@ -67,3 +67,5 @@ class SystemTestDefinition:
     opentrons_modules_build_args: BuildArgConfigurations
 
     module_configuration: ModuleConfiguration
+    left_pipette_expected: bool
+    right_pipette_expected: bool

--- a/samples/ci/ot3/ot3_remote.yaml
+++ b/samples/ci/ot3/ot3_remote.yaml
@@ -20,7 +20,6 @@ robot:
   emulation-level: hardware
   hardware-specific-attributes:
     left-pipette: P1000 Multi
-    right-pipette: P50 Multi
 
 monorepo-source: latest
 ot3-firmware-source: latest

--- a/samples/ci/team_specific_setups/ot3_firmware_development.yaml
+++ b/samples/ci/team_specific_setups/ot3_firmware_development.yaml
@@ -19,7 +19,6 @@ robot:
   hardware: ot3
   emulation-level: hardware
   hardware-specific-attributes:
-    left-pipette: P1000 Multi
     right-pipette: P50 Multi
 
 monorepo-source: /home/runner/work/opentrons-emulation/opentrons-emulation/opentrons


### PR DESCRIPTION
# Overview

Add validation that size of eeprom.bin file is greater than 0 if a pipette is mounted

# Changelog

- Add `left_pipette_expected` and `right_pipette_expected` fields to SystemTestDefinition
- Modify the 3 sample files under test to have different pipette configurations
- Add logic to get size of eeprom.bin files

# Review requests

None

# Risk assessment

Low
