### PR TITLE
chore: Add shared-data as a dependency for hardware project

### DIFF
--- a/docker/entrypoints/ot3_firmware_builder.sh
+++ b/docker/entrypoints/ot3_firmware_builder.sh
@@ -65,6 +65,6 @@ cp /ot3-firmware/build-host/gripper/simulator/gripper-simulator /volumes/gripper
 cp /ot3-firmware/build-host/head/simulator/head-simulator /volumes/head-executable/head-simulator
 
 mkdir -p /opentrons_hardware_dist
-/selective_monorepo_builder.sh "/opentrons_hardware_dist" "hardware"
+/selective_monorepo_builder.sh "/opentrons_hardware_dist" "shared-data/python" "hardware"
 monorepo_python -m pip install --force-reinstall /opentrons_hardware_dist/*
 monorepo_python -m opentrons_hardware.scripts.emulation_pipette_provision

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/monorepo_builder_service.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/monorepo_builder_service.py
@@ -10,6 +10,7 @@ from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediatePorts,
     IntermediateVolumes,
 )
+from emulation_system.compose_file_creator.utilities.hardware_utils import is_ot3
 
 from ...images import MonorepoBuilderImage
 from .abstract_service import AbstractService
@@ -76,4 +77,10 @@ class MonorepoBuilderService(AbstractService):
 
     def generate_env_vars(self) -> Optional[IntermediateEnvironmentVariables]:
         """Generates value for environment parameter."""
-        return None
+        env_vars: IntermediateEnvironmentVariables = {}
+        if is_ot3(self._config_model.robot):
+            env_vars = {
+                "OPENTRONS_PROJECT": "ot3",
+            }
+
+        return env_vars

--- a/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/ot3_firmware_builder_service.py
+++ b/emulation_system/emulation_system/compose_file_creator/conversion/service_builders/ot3_firmware_builder_service.py
@@ -13,6 +13,7 @@ from emulation_system.compose_file_creator.types.intermediate_types import (
     IntermediatePorts,
     IntermediateVolumes,
 )
+from emulation_system.compose_file_creator.utilities.hardware_utils import is_ot3
 
 from ...images import OT3FirmwareBuilderImage
 from .abstract_service import AbstractService
@@ -94,6 +95,11 @@ class OT3FirmwareBuilderService(AbstractService):
         pipettes = get_robot_pipettes(
             robot.hardware, robot.left_pipette, robot.right_pipette
         )
+
+        if is_ot3(robot):
+            env_vars = {
+                "OPENTRONS_PROJECT": "ot3",
+            }
 
         env_vars.update(pipettes.get_left_pipette_env_var())
         env_vars.update(pipettes.get_right_pipette_env_var())

--- a/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_local_ot3_firmware_builder_builder.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/service_builders/test_concrete_local_ot3_firmware_builder_builder.py
@@ -49,9 +49,10 @@ def test_simple_values(
     assert service.environment is not None
     env_root = cast(Dict[str, Any], service.environment.__root__)
     assert env_root is not None
-    assert len(env_root.values()) == 2
+    assert len(env_root.values()) == 3
     assert "LEFT_OT3_PIPETTE_DEFINITION" in env_root
     assert "RIGHT_OT3_PIPETTE_DEFINITION" in env_root
+    assert "OPENTRONS_PROJECT" in env_root
 
 
 def test_local_ot3_firmware_remote_monorepo(


### PR DESCRIPTION
# Overview

The `shared-data` project in the monorepo became a dependency of the `hardware` project in the monorepo. 

This PR accounts for that 

# Changelog

- Add `OPENTRONS_PROJECT: ot3` env var to ot3-firmware-builder and monorepo-builder if robot is flex
- Add shared-data project whenever hardware project is installed

# Review requests

None

# Risk assessment

Low
