### PR TITLE
feat: Add ability to add custom files and folders to emulation

### DIFF
--- a/emulation_system/emulation_system/compose_file_creator/config_file_settings.py
+++ b/emulation_system/emulation_system/compose_file_creator/config_file_settings.py
@@ -195,7 +195,7 @@ class MountTypes(str, Enum):
 
 
 class Mount(OpentronsBaseModel):
-    """Contains infomation about a single extra bind mount."""
+    """Contains information about a single extra bind mount."""
 
     type: str
     mount_path: str
@@ -231,3 +231,11 @@ class FileMount(Mount):
 
     type: Literal[MountTypes.FILE]
     source_path: FilePath
+
+
+class ExtraMount(OpentronsBaseModel):
+    """Extra bind mount for one or more containers."""
+
+    container_names: List[str]
+    host_path: DirectoryPath | FilePath
+    container_path: str

--- a/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/configuration_file.py
@@ -11,7 +11,11 @@ from emulation_system.consts import DEFAULT_NETWORK_NAME
 from opentrons_pydantic_base_model import OpentronsBaseModel
 
 from ...source import MonorepoSource, OpentronsModulesSource, OT3FirmwareSource
-from ..config_file_settings import EmulationLevels, Hardware
+from ..config_file_settings import (
+    EmulationLevels,
+    ExtraMount,
+    Hardware,
+)
 from ..errors import DuplicateHardwareNameError
 from ..types.input_types import Containers, Modules, Robots
 from ..types.intermediate_types import IntermediateNetworks
@@ -43,6 +47,7 @@ class SystemConfigurationModel(OpentronsBaseModel):
     opentrons_modules_source: OpentronsModulesSource = Field(
         default=OpentronsModulesSource(source_location="latest")
     )
+    extra_mounts: List[ExtraMount] = Field(default=[])
 
     @root_validator(pre=True)
     def validate_names(cls, values) -> Dict[str, Dict[str, Containers]]:  # noqa: ANN001
@@ -254,7 +259,7 @@ class SystemConfigurationModel(OpentronsBaseModel):
     # parent method. So just type ignoring it.
 
     def dict(self, *args, **kwargs) -> Dict[str, Any]:  # noqa: ANN002, ANN003
-        """Override default dict logic and add custom logic for source feilds."""
+        """Override default dict logic and add custom logic for source fields."""
         default_dict = super().dict(*args, **kwargs)
         default_dict["monorepo-source"] = self.monorepo_source.source_location
         default_dict["ot3-firmware-source"] = self.ot3_firmware_source.source_location

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/hardware_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/hardware_model.py
@@ -1,17 +1,12 @@
 """Parent class for all hardware."""
 from __future__ import annotations
 
-from itertools import combinations
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional
 
-from pydantic import Field, validator
+from pydantic import Field
 
-from emulation_system.compose_file_creator import BuildItem, Service
 from emulation_system.compose_file_creator.config_file_settings import (
-    DirectoryMount,
     EmulationLevels,
-    FileMount,
-    Mount,
     SourceRepositories,
 )
 from emulation_system.compose_file_creator.images import get_image_name

--- a/emulation_system/emulation_system/compose_file_creator/input/hardware_models/hardware_model.py
+++ b/emulation_system/emulation_system/compose_file_creator/input/hardware_models/hardware_model.py
@@ -25,10 +25,6 @@ class HardwareModel(OpentronsBaseModel):
 
     id: str = Field(..., regex=r"^[a-zA-Z0-9-_]+$")
     hardware: str
-    # This is being called mounts because all mounts will be stored in it.
-    # Just going to start by adding the extra-mounts to it and adding any
-    # generated mounts during _post_init().
-    mounts: List[Union[FileMount, DirectoryMount]] = Field(default=[])
     source_repos: SourceRepositories = NotImplemented
     emulation_level: EmulationLevels = NotImplemented
     hardware_specific_attributes: HardwareSpecificAttributes = NotImplemented
@@ -36,34 +32,9 @@ class HardwareModel(OpentronsBaseModel):
     def __init__(self, **data: Any) -> None:  # noqa: ANN401
         super().__init__(**data)
 
-    @validator("mounts")
-    def check_for_duplicate_mounts(
-        cls, v: List[Mount], values: Dict[str, Any]
-    ) -> List[Mount]:
-        """Confirms that there are not duplicate mounts."""
-        assert all(
-            [not mount_1 == mount_2 for mount_1, mount_2 in combinations(v, 2)]
-        ), "Cannot have duplicate mounts"
-        return v
-
     def get_image_name(self) -> str:
         """Get image name to run based off of passed parameters."""
         return get_image_name(self.hardware, self.emulation_level)
-
-    def get_mount_strings(self) -> List[str]:
-        """Get list of all mount strings for hardware."""
-        mounts = [mount.get_bind_mount_string() for mount in self.mounts]
-        return mounts
-
-    def to_service(self) -> Service:
-        """Converts HardwareModel object to Service object."""
-        build = BuildItem(context=".", target=f"{self.get_image_name()}:latest")
-        return Service(
-            container_name=self.id,
-            build=build,
-            volumes=self.get_mount_strings(),  # type: ignore[arg-type]
-            tty=True,
-        )
 
     def get_hardware_level_command(
         self, emulator_proxy_name: str

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_extra_mounts.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_extra_mounts.py
@@ -1,7 +1,8 @@
 """Tests related to extra-mounts on services"""
-
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
+
+import pytest
 
 from emulation_system.compose_file_creator.conversion.conversion_functions import (
     convert_from_obj,
@@ -9,16 +10,34 @@ from emulation_system.compose_file_creator.conversion.conversion_functions impor
 from tests.validation_helper_functions import mount_string_is
 
 
-def test_extra_mounts(tmp_path: Path, ot3_only: Dict[str, Any]) -> None:
-    """Test extra mounts added correctly"""
+@pytest.fixture
+def extra_file_mount(
+    tmp_path: Path,
+) -> Path:
+    """Create a file to mount."""
     extra_file_mount = tmp_path / "envs/extra.env"
     extra_file_mount.parent.mkdir()
     extra_file_mount.touch()
+    return extra_file_mount
 
+
+@pytest.fixture
+def extra_dir_mount(
+    tmp_path: Path,
+) -> Path:
+    """Create a directory to mount."""
     extra_dir_mount = tmp_path / "extra_dir"
     extra_dir_mount.mkdir()
+    return extra_dir_mount
 
-    ot3_only["extra-mounts"] = [
+
+@pytest.fixture
+def extra_mounts(
+    extra_file_mount: Path,
+    extra_dir_mount: Path,
+) -> List[Dict[str, Any]]:
+    """Create a list of extra mounts."""
+    return [
         {
             "container-names": ["edgar-allen-poebot", "ot3-state-manager"],
             "host-path": str(extra_file_mount),
@@ -31,6 +50,35 @@ def test_extra_mounts(tmp_path: Path, ot3_only: Dict[str, Any]) -> None:
         },
     ]
 
+
+@pytest.fixture
+def extra_mounts_with_bad_container_names(
+    extra_file_mount: Path,
+    extra_dir_mount: Path,
+) -> List[Dict[str, Any]]:
+    """Create a list of extra mounts with bad container names."""
+    return [
+        {
+            "container-names": ["no-bot", "ot3-state-imploder"],
+            "host-path": str(extra_file_mount),
+            "container-path": "/extra.env",
+        },
+        {
+            "container-names": ["ot3-foot", "emulator-pixie"],
+            "host-path": str(extra_dir_mount),
+            "container-path": "/extra_dir",
+        },
+    ]
+
+
+def test_extra_mounts(
+    extra_file_mount: Path,
+    extra_dir_mount: Path,
+    extra_mounts: List[Dict[str, Any]],
+    ot3_only: Dict[str, Any],
+) -> None:
+    """Test extra mounts added correctly"""
+    ot3_only["extra-mounts"] = extra_mounts
     converted_object = convert_from_obj(ot3_only, dev=False)
     robot_server = converted_object.robot_server
     state_manager = converted_object.ot3_state_manager
@@ -47,3 +95,18 @@ def test_extra_mounts(tmp_path: Path, ot3_only: Dict[str, Any]) -> None:
         assert container is not None
         assert not mount_string_is(f"{str(extra_file_mount)}:/extra.env", container)
         assert mount_string_is(f"{str(extra_dir_mount)}:/extra_dir", container)
+
+
+def test_exception_thrown_on_invalid_container_names(
+    extra_mounts_with_bad_container_names: List[Dict[str, Any]],
+    ot3_only: Dict[str, Any],
+) -> None:
+    """Test that exception is thrown if extra mounts have invalid container names."""
+    ot3_only["extra-mounts"] = extra_mounts_with_bad_container_names
+    with pytest.raises(ValueError) as error_info:
+        convert_from_obj(ot3_only, dev=False)
+
+    assert (
+        'The following "container_names" specified in "extra-mounts" do not exist in the emulated system:'
+        in str(error_info.value)
+    )

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_extra_mounts.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_extra_mounts.py
@@ -14,7 +14,7 @@ def test_extra_mounts(tmp_path: Path, ot3_only: Dict[str, Any]) -> None:
     extra_file_mount = tmp_path / "envs/extra.env"
     extra_file_mount.parent.mkdir()
     extra_file_mount.touch()
-    
+
     extra_dir_mount = tmp_path / "extra_dir"
     extra_dir_mount.mkdir()
 
@@ -28,7 +28,7 @@ def test_extra_mounts(tmp_path: Path, ot3_only: Dict[str, Any]) -> None:
             "container-names": ["ot3-head", "emulator-proxy"],
             "host-path": str(extra_dir_mount),
             "container-path": "/extra_dir",
-        }
+        },
     ]
 
     converted_object = convert_from_obj(ot3_only, dev=False)
@@ -37,7 +37,7 @@ def test_extra_mounts(tmp_path: Path, ot3_only: Dict[str, Any]) -> None:
     for container in [robot_server, state_manager]:
         assert container is not None
         assert mount_string_is(f"{str(extra_file_mount)}:/extra.env", container)
-        
+
         assert not mount_string_is(f"{str(extra_dir_mount)}:/extra_dir", container)
 
     emulator_proxy = converted_object.emulator_proxy

--- a/emulation_system/tests/compose_file_creator/conversion_logic/test_extra_mounts.py
+++ b/emulation_system/tests/compose_file_creator/conversion_logic/test_extra_mounts.py
@@ -1,0 +1,49 @@
+"""Tests related to extra-mounts on services"""
+
+from pathlib import Path
+from typing import Any, Dict
+
+from emulation_system.compose_file_creator.conversion.conversion_functions import (
+    convert_from_obj,
+)
+from tests.validation_helper_functions import mount_string_is
+
+
+def test_extra_mounts(tmp_path: Path, ot3_only: Dict[str, Any]) -> None:
+    """Test extra mounts added correctly"""
+    extra_file_mount = tmp_path / "envs/extra.env"
+    extra_file_mount.parent.mkdir()
+    extra_file_mount.touch()
+    
+    extra_dir_mount = tmp_path / "extra_dir"
+    extra_dir_mount.mkdir()
+
+    ot3_only["extra-mounts"] = [
+        {
+            "container-names": ["edgar-allen-poebot", "ot3-state-manager"],
+            "host-path": str(extra_file_mount),
+            "container-path": "/extra.env",
+        },
+        {
+            "container-names": ["ot3-head", "emulator-proxy"],
+            "host-path": str(extra_dir_mount),
+            "container-path": "/extra_dir",
+        }
+    ]
+
+    converted_object = convert_from_obj(ot3_only, dev=False)
+    robot_server = converted_object.robot_server
+    state_manager = converted_object.ot3_state_manager
+    for container in [robot_server, state_manager]:
+        assert container is not None
+        assert mount_string_is(f"{str(extra_file_mount)}:/extra.env", container)
+        
+        assert not mount_string_is(f"{str(extra_dir_mount)}:/extra_dir", container)
+
+    emulator_proxy = converted_object.emulator_proxy
+    ot3_head = converted_object.ot3_head_emulator
+
+    for container in [emulator_proxy, ot3_head]:
+        assert container is not None
+        assert not mount_string_is(f"{str(extra_file_mount)}:/extra.env", container)
+        assert mount_string_is(f"{str(extra_dir_mount)}:/extra_dir", container)

--- a/emulation_system/tests/compose_file_creator/input/hardware_models/test_hardware_model.py
+++ b/emulation_system/tests/compose_file_creator/input/hardware_models/test_hardware_model.py
@@ -211,19 +211,6 @@ def test_get_bind_mount_string(mount: Mount, expected_value: str) -> None:
     assert parse_obj_as(Mount, mount).get_bind_mount_string().endswith(expected_value)
 
 
-def test_duplicate_mounts(file_mount: Dict[str, str]) -> None:
-    """Confirm that duplicate mounts are not allowed."""
-    with pytest.raises(ValidationError, match=".*Cannot have duplicate mounts"):
-        HeaterShakerModuleInputModel.parse_obj(
-            {
-                "id": "my-heater-shaker",
-                "hardware": Hardware.HEATER_SHAKER_MODULE,
-                "emulation-level": EmulationLevels.HARDWARE,
-                "mounts": [file_mount, file_mount],
-            }
-        )
-
-
 def test_exception_thrown_when_local_source_code_does_not_exist() -> None:
     """Confirm LocalSourceDoesNotExistError is thrown when local path does not exist."""
     bad_path = "/this/surely/must/be/a/bad/path"

--- a/samples/ot3/ot3_local_with_custom_mounts.yaml
+++ b/samples/ot3/ot3_local_with_custom_mounts.yaml
@@ -16,18 +16,18 @@ robot:
   hardware: ot3
   emulation-level: hardware
   
-monorepo-source: /home/derek-maggio/Documents/repos/opentrons
-ot3-firmware-source: /home/derek-maggio/Documents/repos/ot3-firmware
+monorepo-source: /make/this/a/path/that/exists/opentrons
+ot3-firmware-source: /make/this/a/path/that/exists/ot3-firmware
 
 extra-mounts:
   - container_names: [otie, ot3-state-manager]
     # Have to make sure this file exists on your local machine before running
-    host_path: /home/derek-maggio/Documents/extra.env
+    host_path: /make/this/a/path/that/exists/extra.env
     container_path: /extra.env
 
   - container_names: [ot3-left-pipette]
     # Have to make sure this dir exists on your local machine before running
-    host_path: /home/derek-maggio/Documents/test_dir
+    host_path: /make/this/a/path/that/exists/test_dir
     container_path: /test_dir
 
 

--- a/samples/ot3/ot3_local_with_custom_mounts.yaml
+++ b/samples/ot3/ot3_local_with_custom_mounts.yaml
@@ -3,6 +3,7 @@
 ######################
 
 # This system builds a single OT3
+# It demonstrates how to mount a local directory/file into containers
 
 ########################
 # Required Source Code #

--- a/samples/ot3/ot3_local_with_custom_mounts.yaml
+++ b/samples/ot3/ot3_local_with_custom_mounts.yaml
@@ -1,0 +1,32 @@
+######################
+# System Description #
+######################
+
+# This system builds a single OT3
+
+########################
+# Required Source Code #
+########################
+
+# Change the paths below to point to your local copies of the source code.
+
+robot:
+  id: otie
+  hardware: ot3
+  emulation-level: hardware
+  
+monorepo-source: /home/derek-maggio/Documents/repos/opentrons
+ot3-firmware-source: /home/derek-maggio/Documents/repos/ot3-firmware
+
+extra-mounts:
+  - container_names: [otie, ot3-state-manager]
+    # Have to make sure this file exists on your local machine before running
+    host_path: /home/derek-maggio/Documents/extra.env
+    container_path: /extra.env
+
+  - container_names: [ot3-left-pipette]
+    # Have to make sure this dir exists on your local machine before running
+    host_path: /home/derek-maggio/Documents/test_dir
+    container_path: /test_dir
+
+


### PR DESCRIPTION
# Overview

Allow users to specify arbitrary files and folders to bind in/out of emulation

Remaining Tasks: 

- [x] Add logic to throw exception if container name specified in mount does not exist
- [x] Update wiki with extra mounts syntax

# Changelog

- Remove old and non-functional extra-mounts logic and tests
- Add `ExtraMount` setting to config_file_settings.py
- Add logic to AbstractService.build_service to add any extra mounts to specified containers at runtime
- Add `extra-mounts` field to configuration file
- Add tests for extra mounts

# Review requests

How does the syntax in the configuration file feel?
